### PR TITLE
hud module causes error on cs:s

### DIFF
--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -100,7 +100,7 @@ public void OnConfigsExecuted()
 {
 	if(gSG_Type == Game_CSS)
 	{
-		FindConVar("sv_hudhint_sound").SetBool(false);
+		ServerCommand("sv_hudhint_sound 0");
 	}
 }
 


### PR DESCRIPTION
L 10/15/2015 - 13:39:16: [SM] Native "ConVar.SetBool" reported: Invalid convar handle 0 (error 4)
L 10/15/2015 - 13:39:16: [SM] Displaying call stack trace for plugin "shavit-hud.smx":
L 10/15/2015 - 13:39:16: [SM]   [0]  Line 103, shavit-hud.sp::OnConfigsExecuted()