### PR TITLE
Allow keys on ground & block prejump in start zone

### DIFF
--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -815,7 +815,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	bool bEdit = false;
 
 	// key blocking
-	if(!Shavit_InsideZone(client, Zone_Freestyle) && !bOnLadder)
+	if(!Shavit_InsideZone(client, Zone_Freestyle) && !bOnLadder && !bOnGround)
 	{
 		if(gI_StyleProperties[gBS_Style[client]] & STYLE_BLOCK_W && (vel[0] > 0 || buttons & IN_FORWARD))
 		{
@@ -861,6 +861,15 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 
 	bool bOnGround = GetEntityFlags(client) & FL_ONGROUND || bOnLadder;
+	
+	if(Shavit_InsideZone(client, Zone_Start))
+	{
+		if(vel[2] > 0 || buttons & IN_JUMP)
+		{
+			vel[2] = 0.0;
+			buttons &= ~IN_JUMP;	//block jump
+		}
+	}		
 
 	// autobhop
 	if(gI_StyleProperties[gBS_Style[client]] & STYLE_AUTOBHOP && gCV_Autobhop.BoolValue && gB_Auto[client] && buttons & IN_JUMP && !bOnGround && GetEntProp(client, Prop_Send, "m_nWaterLevel") <= 1)

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -76,6 +76,7 @@ ConVar gCV_Pause = null;
 ConVar gCV_MySQLPrefix = null;
 ConVar gCV_NoStaminaReset = null;
 ConVar gCV_AllowTimerWithoutZone = null;
+ConVar gCV_BlockPreJump = null;
 
 // table prefix
 char gS_MySQLPrefix[32];
@@ -206,6 +207,7 @@ public void OnPluginStart()
 	gCV_Pause = CreateConVar("shavit_core_pause", "1", "Allow pausing?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	gCV_NoStaminaReset = CreateConVar("shavit_core_nostaminareset", "1", "Disables the built-in stamina reset.\nAlso known as 'easybhop'.\nWill be forced to not work if STYLE_EASYBHOP is not defined for a style!", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 	gCV_AllowTimerWithoutZone = CreateConVar("shavit_core_timernozone", "0", "Allow the timer to start if there's no start zone?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
+	gCV_BlockPreJump = CreateConVar("shavit_core_blockprejump", "1", "Prevents jumping in the start zone.", FCVAR_PLUGIN, true, 0.0, true, 1.0);
 
 	gCV_MySQLPrefix = CreateConVar("shavit_core_sqlprefix", "", "MySQL table prefix.\nDO NOT TOUCH OR MODIFY UNLESS YOU KNOW WHAT YOU ARE DOING!!!\nLeave empty unless you have your own prefix for tables.\nRestarting your server is highly recommended after changing this cvar!", FCVAR_PLUGIN);
 	gCV_MySQLPrefix.AddChangeHook(OnPrefixChange);
@@ -862,7 +864,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 	bool bOnGround = GetEntityFlags(client) & FL_ONGROUND || bOnLadder;
 	
-	if(Shavit_InsideZone(client, Zone_Start))
+	if(Shavit_InsideZone(client, Zone_Start) && gCV_BlockPreJump.BoolValue)
 	{
 		if(vel[2] > 0 || buttons & IN_JUMP)
 		{


### PR DESCRIPTION
It's better if the player can use all keys on ground if he selects a style like w-only. Makes walking on ground easier!

Also it would be better to block prejump on start zone because every prejump is different and the player doesn't start with the same speed every time. With this fix, times can be compared much better. :) You could also do a cvar for this.