### PR TITLE
Fix Noclip Abuse

### DIFF
--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -277,7 +277,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 			float fSpeed[3];
 			GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);
 
-			float fSpeed_New = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
+			float fSpeed_New = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0) + Pow(fSpeed[2], 2.0));		//edited
 			float fScale = gCV_PrespeedLimit.FloatValue / fSpeed_New;
 
 			if(fScale < 1.0)


### PR DESCRIPTION
This is significant:
If player uses noclip and flies 45 - 90 degrees up in the air in the start zone and disables noclip before he leaves the start zone, he can start the timer and fly/shortcut right into another stage or even to the end zone. (Bug found randomly by CRNO)
This line of code fixes it and is working fine on my server :)

Could be also fixed differently e.g: Setting the Y-speed of the player to 0 when he disables noclip in the start zone :+1: 