### PR TITLE
Fix noclip prespeed abuse

### DIFF
--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -419,6 +419,15 @@ native int Shavit_ZoneExists(MapZones type);
 native int Shavit_InsideZone(int client, MapZones type);
 
 /**
+ * Checks if a player is inside a mapzone
+ *
+ * @param client					Client index.
+ * @param type						Mapzone type. (Check "enum MapZones")
+ * @return							1 if is in the mapzone, 0 if isn't.
+ */
+native int Shavit_IsInsideZone(int client, MapZones type);
+
+/**
  * Pauses a player's timer.
  *
  * @param client					Client index.

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -261,7 +261,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 	}
 
 	// prespeed
-	if(!(gI_StyleProperties[bsStyle] & STYLE_PRESPEED) && Shavit_InsideZone(client, Zone_Start))
+	if(!(gI_StyleProperties[bsStyle] & STYLE_PRESPEED) && Shavit_InsideZone(client, Zone_Start) || Shavit_IsInsideZone(client, Zone_Start) && !(gI_StyleProperties[bsStyle] & STYLE_PRESPEED))	//edited
 	{
 		if((gCV_PreSpeed.IntValue == 2 || gCV_PreSpeed.IntValue == 3) && !(gF_LastFlags[client] & FL_ONGROUND) && (GetEntityFlags(client) & FL_ONGROUND) && buttons & IN_JUMP)
 		{


### PR DESCRIPTION
So I found out a way to fix the noclip prespeed abuse.
I looked into the code of the InsideZone function and saw that you move the y-origin 5 units up. This means if the player touches the upper corner of the start zone with his feet, his timer will start AND his speed will remain. So i copied this function and just called it IsInsideZone and removed the playerPos[2] += 5.0; and added another condition of the prespeed part.
Well it works and fixes it but looks like it can be made easier and shorter. Maybe you know how.
Also i tested to just remove the playersPos line in the InsideZone function but this will result in starting the timer even if the player stands in the start zone because the y-origin is below the start zone.

I hope this helps :P