### PR TITLE
Fixes

### DIFF
--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -970,13 +970,15 @@ public void OnClientCookiesCached(int client)
 	}
 
 	gB_Auto[client] = (strlen(sCookie) > 0)? view_as<bool>(StringToInt(sCookie)):true;
+	int style = 0;
 
 	if(gH_StyleCookie != null)
 	{
 		GetClientCookie(client, gH_StyleCookie, sCookie, 4);
+		style = StringToInt(sCookie);
 	}
 
-	gBS_Style[client] = view_as<BhopStyle>((strlen(sCookie) > 0)? StringToInt(sCookie):0);
+	gBS_Style[client] = view_as<BhopStyle>((style >= 0 && style < gI_Styles)? style:0);
 
 	UpdateAutoBhop(client);
 }

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -1482,7 +1482,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 	// velocity limit
 	if(iGroundEntity != -1 && view_as<float>(gA_StyleSettings[gBS_Style[client]][fVelocityLimit] > 0.0) &&
-	(!gB_Zones || !Shavit_InsideZone(client, Zone_NoVelLimit)))
+		(!gB_Zones || !Shavit_InsideZone(client, Zone_NoVelLimit)))
 	{
 		float fSpeed[3];
 		GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -963,11 +963,21 @@ public void OnClientCookiesCached(int client)
 	}
 
 	char[] sCookie = new char[4];
-	GetClientCookie(client, gH_AutoBhopCookie, sCookie, 4);
+
+	if(gH_AutoBhopCookie != null)
+	{
+		GetClientCookie(client, gH_AutoBhopCookie, sCookie, 4);
+	}
+
 	gB_Auto[client] = (strlen(sCookie) > 0)? view_as<bool>(StringToInt(sCookie)):true;
 
-	GetClientCookie(client, gH_StyleCookie, sCookie, 4);
-	gBS_Style[client] = view_as<BhopStyle>(StringToInt(sCookie));
+	if(gH_StyleCookie != null)
+	{
+		GetClientCookie(client, gH_StyleCookie, sCookie, 4);
+	}
+
+	gBS_Style[client] = view_as<BhopStyle>((strlen(sCookie) > 0)? StringToInt(sCookie):0);
+
 	UpdateAutoBhop(client);
 }
 

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -333,6 +333,11 @@ public void Shavit_OnChatConfigLoaded()
 	}
 }
 
+public void Shavit_OnStyleChanged(int client, BhopStyle oldstyle, BhopStyle newstyle)
+{
+	gBS_Style[client] = newstyle;
+}
+
 public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	gI_GodMode = gCV_GodMode.IntValue;

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -218,7 +218,7 @@ public void OnPluginStart()
 	gCV_WeaponCommands = CreateConVar("shavit_misc_weaponcommands", "2", "Enable sm_usp, sm_glock and sm_knife?\n0 - Disabled\n1 - Enabled\n2 - Also give infinite reserved ammo.", 0, true, 0.0, true, 2.0);
 	gCV_PlayerOpacity = CreateConVar("shavit_misc_playeropacity", "-1", "Player opacity (alpha) to set on spawn.\n-1 - Disabled\nValue can go up to 255. 0 for invisibility.", 0, true, -1.0, true, 255.0);
 	gCV_StaticPrestrafe = CreateConVar("shavit_misc_staticprestrafe", "1", "Force prestrafe for every pistol.\n250 is the default value and some styles will have 260.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_NoclipMe = CreateConVar("shavit_misc_noclipme", "1", "Allow +noclip, sm_p and all the noclip commands?\n0 - Disabled\n1 - Enabled\n2 - requires 'noclipme' override or ADMFLAG_CHEATS flag.", 0, true, 0.0, true, 1.0);
+	gCV_NoclipMe = CreateConVar("shavit_misc_noclipme", "1", "Allow +noclip, sm_p and all the noclip commands?\n0 - Disabled\n1 - Enabled\n2 - requires 'admin_noclipme' override or ADMFLAG_CHEATS flag.", 0, true, 0.0, true, 2.0);
 	gCV_AdvertisementInterval = CreateConVar("shavit_misc_advertisementinterval", "600.0", "Interval between each chat advertisement.\nConfiguration file for those is configs/shavit-advertisements.cfg.\nSet to 0.0 to disable.\nRequires server restart for changes to take effect.", 0, true, 0.0);
 
 	gCV_GodMode.AddChangeHook(OnConVarChanged);

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -53,6 +53,7 @@ int gI_AdvertisementsCycle = 0;
 char gS_CurrentMap[192];
 ConVar gCV_Hostname = null;
 ConVar gCV_Hostport = null;
+BhopStyle gBS_Style[MAXPLAYERS+1];
 
 // cookies
 Handle gH_HideCookie = null;
@@ -200,7 +201,7 @@ public void OnPluginStart()
 
 	// cvars and stuff
 	gCV_GodMode = CreateConVar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.", 0, true, 0.0, true, 3.0);
-	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "3", "Stop prespeed in startzone?\n0 - Disabled\n1 - Limit 280 speed.\n2 - Block bhopping in startzone\n3 - Limit 280 speed and block bhopping in startzone.", 0, true, 0.0, true, 3.0);
+	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "3", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit to shavit_misc_prespeedlimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to shavit_misc_prespeedlimit and block bunnyhopping.", 0, true, 0.0, true, 3.0);
 	gCV_HideTeamChanges = CreateConVar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = CreateConVar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnRestart = CreateConVar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if he uses the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -301,6 +302,8 @@ public void OnClientCookiesCached(int client)
 	{
 		gB_Hide[client] = view_as<bool>(StringToInt(sHideSetting));
 	}
+
+	gBS_Style[client] = Shavit_GetBhopStyle(client);
 }
 
 public void Shavit_OnStyleConfigLoaded(int styles)
@@ -538,7 +541,7 @@ public MRESReturn DHook_GetMaxPlayerSpeed(int pThis, Handle hReturn)
 		return MRES_Ignored;
 	}
 
-	DHookSetReturn(hReturn, view_as<float>(gA_StyleSettings[Shavit_GetBhopStyle(pThis)][fRunspeed]));
+	DHookSetReturn(hReturn, view_as<float>(gA_StyleSettings[gBS_Style[pThis]][fRunspeed]));
 
 	return MRES_Override;
 }
@@ -654,7 +657,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 	}
 
 	// prespeed
-	if(!gA_StyleSettings[Shavit_GetBhopStyle(client)][bPrespeed] && bInStart)
+	if(!gA_StyleSettings[gBS_Style[client]][bPrespeed] && bInStart)
 	{
 		if((gI_PreSpeed == 2 || gI_PreSpeed == 3) && (gI_LastFlags[client] & FL_ONGROUND) == 0 && (GetEntityFlags(client) & FL_ONGROUND) > 0 && (buttons & IN_JUMP) > 0)
 		{
@@ -669,9 +672,9 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 		if(gI_PreSpeed == 1 || gI_PreSpeed == 3)
 		{
 			float fSpeed[3];
-			GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);
+			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
-			float fSpeed_New = SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0));
+			float fSpeed_New = GetVectorLength(fSpeed);
 			float fScale = (gF_PrespeedLimit / fSpeed_New);
 
 			if(bNoclipping)
@@ -695,6 +698,8 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 
 public void OnClientPutInServer(int client)
 {
+	gBS_Style[client] = Shavit_GetBhopStyle(client);
+
 	if(!AreClientCookiesCached(client))
 	{
 		gB_Hide[client] = false;

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -817,7 +817,17 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 			MakeVectorFromPoints(vecCurrentPosition, vecPosition, vecVelocity);
 			ScaleVector(vecVelocity, gF_Tickrate);
 
-			TeleportEntity(client, NULL_VECTOR, vecAngles, vecVelocity);
+			float fDistance = GetVectorDistance(vecCurrentPosition, vecPosition);
+
+			if((gI_ReplayTick[iReplayBotStyle] % RoundToFloor(gF_Tickrate * 1.5)) == 0 && GetVectorLength(vecVelocity) < 2.0 * fDistance)
+			{
+				TeleportEntity(client, vecPosition, vecAngles, vecVelocity);
+			}
+
+			else
+			{
+				TeleportEntity(client, NULL_VECTOR, vecAngles, vecVelocity);
+			}
 
 			return Plugin_Changed;
 		}

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1194,11 +1194,35 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 		{
 			float vTeleport[3];
 			GetClientAbsOrigin(param1, vTeleport);
+			vTeleport[2] += 2.0;
 
-			// if()
-			gV_Teleport[param1] = vTeleport;
-			//GetClientAbsOrigin(param1, gV_Teleport[param1]);
-			Shavit_PrintToChat(param1, "%T", "ZoneTeleportUpdated", param1);
+			float vPoints[8][3];
+			vPoints[0] = gV_Point1[param1];
+			vPoints[7] = gV_Point2[param1];
+
+			CreateZonePoints(vPoints, gF_RotateAngle[param1], gV_Fix1[param1], gV_Fix2[param1], PLACEHOLDER, false, true);
+
+			bool bInside = true;
+
+			for(int i = 0; i < 3; i++)
+			{
+				if(vPoints[0][i] >= vTeleport[i] == vPoints[7][i] >= vTeleport[i])
+				{
+					bInside = false;
+				}
+			}
+
+			if(bInside)
+			{
+				Shavit_PrintToChat(param1, "%T", "ZoneTeleportInsideZone", param1);
+			}
+
+			else
+			{
+				gV_Teleport[param1] = vTeleport;
+
+				Shavit_PrintToChat(param1, "%T", "ZoneTeleportUpdated", param1);
+			}
 
 			CreateEditMenu(param1);
 		}
@@ -1232,6 +1256,7 @@ void CreateEditMenu(int client)
 			FormatEx(sMenuItem, 64, "%T", "ZoneSetYes", client);
 			menu.AddItem("yes", sMenuItem);
 		}
+
 		FormatEx(sMenuItem, 64, "%T", "ZoneSetTPZone", client);
 		menu.AddItem("tpzone", sMenuItem);
 	}

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1192,7 +1192,12 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 
 		else if(StrEqual(info, "tpzone"))
 		{
-			GetClientAbsOrigin(param1, gV_Teleport[param1]);
+			float vTeleport[3];
+			GetClientAbsOrigin(param1, vTeleport);
+
+			// if()
+			gV_Teleport[param1] = vTeleport;
+			//GetClientAbsOrigin(param1, gV_Teleport[param1]);
 			Shavit_PrintToChat(param1, "%T", "ZoneTeleportUpdated", param1);
 
 			CreateEditMenu(param1);

--- a/translations/shavit-core.phrases.txt
+++ b/translations/shavit-core.phrases.txt
@@ -3,22 +3,22 @@
 	// ---------- Commands ---------- //
 	"AutobhopEnabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"Autobhop {1}enabled{2}."
 	}
 	"AutobhopDisabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"Autobhop {1}disabled{2}."
 	}
 	"CheatTimerStop"
 	{
-		"#format"	"{1:c},{2:c},{3:s}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"{1}Timer stopped! {2}{3}"
 	}
     "CommandDisabled"
     {
-        "#format" 	"{1:c},{2:s},{3:c}"
+        "#format" 	"{1:s},{2:s},{3:s}"
 		"en"		"The command ({1}{2}{3}) is disabled."
     }
 	// ---------- Errors ---------- //
@@ -33,7 +33,7 @@
 	}
 	"StyleSelection"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"You have selected to play {1}{2}{3}."
 	}
 	"StyleUnranked"
@@ -51,49 +51,49 @@
 	}
 	"UnrankedWarning"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"{1}WARNING: {2}This style is unranked. Your times WILL NOT be saved and will be only displayed to you!"
 	}
 	// ---------- Pauses ---------- //
 	"MessagePause"
 	{
-		"#format"	"{1:c},{2:c},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"{1}Timer has been {2}paused{3}."
 	}
 	"MessageUnpause"
 	{
-		"#format"	"{1:c},{2:c},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"{1}Timer has been {2}resumed{3}."
 	}
 	"PauseNotOnGround"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You {1}are not{2} allowed to pause when not on ground."
 	}
 	"PauseStartZone"
 	{
-		"#format"	"{1:c},{2:c},{3:c},{4:c},{5:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s}"
 		"en"		"{1}You {2}cannot{3} pause in the {4}start zone{5}."
 	}
 	"TimerUnpaused"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"Timer has been {1}unpaused{2}."
 	}
 	"TimerPaused"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"Timer has been {1}paused{2}."
 	}
 	// ---------- Zones ---------- //
 	"StartZoneUndefined"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"Your timer {1}will not{2} start as a start zone for the map is not defined."
 	}
 	"EndZoneUndefined"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You {1}can't{2} teleport as an end zone for the map is not defined."
 	}
 }

--- a/translations/shavit-misc.phrases.txt
+++ b/translations/shavit-misc.phrases.txt
@@ -3,47 +3,47 @@
 	// ---------- Commands ---------- //
 	"CommandAlive"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You have to be {1}alive{2} to use this command."
 	}
 	"CommandDisabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"This command is {1}disabled{2}."
 	}
 	"FeatureDisabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"This feature is {1}disabled{2}."
 	}
 	"HideEnabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You are now {1}hiding{2} players."
 	}
 	"HideDisabled"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You are now {1}not hiding{2} players."
 	}
 	"LackingAccess"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You're {1}lacking access{2} to this command."
 	}
 	"SpectateDead"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You {1}cannot{2} target a dead player."
 	}
 	"SpectatorCount"
 	{
-		"#format"	"{1:c},{2:N},{3:c},{4:c},{5:i},{6:c},{7:s}"
+		"#format"	"{1:s},{2:N},{3:s},{4:s},{5:i},{6:s},{7:s}"
 		"en"		"{1}{2}{3} has {4}{5}{6} spectators: {7}"
 	}
 	"SpectatorCountZero"
 	{
-		"#format"	"{1:c},{2:N},{3:c}"
+		"#format"	"{1:s},{2:N},{3:s}"
 		"en"		"No one is spectating {1}{2}{3}."
 	}
 	"SpectatorInvalid"
@@ -56,7 +56,7 @@
 	}
 	"TeleportInZone"
 	{
-		"#format"	"{1:c},{2:c},{3:c},{4:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s}"
 		"en"		"You {1}cannot teleport{2} inside the {3}start/end zones{4}."
 	}
 	"TeleportInvalidTarget"
@@ -70,18 +70,18 @@
 	}
 	"WeaponAlive"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You need to be {1}alive{2} to spawn weapons."
 	}
 	// ---------- Misc ---------- //
 	"BHStartZoneDisallowed"
 	{
-		"#format"	"{1:c},{2:c},{3:c},{4:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s}"
 		"en"		"Bunnyhopping in the {1}start zone{2} is {3}not allowed{4}."
 	}
 	"WRNotice"
 	{
-		"#format"	"{1:c},{2:s}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"{1}NEW {2} WR!!!"
 	}
 }

--- a/translations/shavit-rankings.phrases.txt
+++ b/translations/shavit-rankings.phrases.txt
@@ -39,33 +39,33 @@
 	// ---------- Points ---------- //
 	"ApproximatePoints"
 	{
-		"#format"	"{1:c},{2:s},{3:c},{4:c},{5:.01f},{6:c},{7:c},{8:i},{9:s}"
+		"#format"	"{1s},{2:s},{3s},{4s},{5:.01f},{6s},{7s},{8:i},{9:s}"
 		"en"		"{1}{2}{3}: Around {4}{5}{6} points for a time of {7}{8}{9}."
 	}
 	"Rank"
 	{
-		"#format"	"{1:c},{2:N},{3:c},{4:c},{5:i},{6:c},{7:c},{8:i},{9:c},{10:c},{11:.02f},{12:s}"
+		"#format"	"{1s},{2:N},{3s},{4s},{5:i},{6s},{7s},{8:i},{9s},{10s},{11:.02f},{12:s}"
 		"en"		"{1}{2}{3} is ranked {4}{5}{6} out of {7}{8}{9} with {10}{11} points {12}."
 	}
 	"UnknownPoints"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1s},{2:s},{3s}"
 		"en"		"{1}{2}{3}: Unknown points, no records on map."
 	}
 	"Unranked"
 	{
-		"#format"	"{1:c},{2:N},{3:c},{4:c},{5:c}"
+		"#format"	"{1s},{2:N},{3s},{4s},{5s}"
 		"en"		"{1}{2}{3} is {4}unranked{5}."
 	}
 	// ---------- Tiers ---------- //
 	"Tier"
 	{
-		"#format"	"{1:c},{2:s},{3:c},{4:c},{5:.01f},{6:c}"
+		"#format"	"{1s},{2:s},{3s},{4s},{5:.01f},{6s}"
 		"en"		"{1}{2}{3} is rated as {4}Tier {5}{6}."
 	}
 	"TierUnset"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1s},{2:s},{3s}"
 		"en"		"{1}{2}{3} is not rated."
 	}
 }

--- a/translations/shavit-replay.phrases.txt
+++ b/translations/shavit-replay.phrases.txt
@@ -25,12 +25,12 @@
 	// ---------- Replay Deletion ---------- //
 	"ReplayDeleted"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Deleted replay for {1}{2}{3}."
 	}
 	"ReplayDeleteFailure"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Could not delete replay for {1}{2}{3}."
 	}
 }

--- a/translations/shavit-stats.phrases.txt
+++ b/translations/shavit-stats.phrases.txt
@@ -3,7 +3,7 @@
 	// ---------- Errors ---------- //
 	"StatsMenuFailure"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"{1}ERROR: {2}Could not open the stats menu."
 	}
 	// ---------- Map Completions ---------- //

--- a/translations/shavit-wr.phrases.txt
+++ b/translations/shavit-wr.phrases.txt
@@ -11,7 +11,7 @@
 	}
 	"DeletedRecordsMap"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Deleted ALL records for {1}{2}{3}."
 	}
 	// ---------- Client Menus ---------- //
@@ -27,22 +27,22 @@
 	// ---------- Completion Messages ---------- //
 	"FirstCompletion"
 	{
-		"#format"	"{1:c},{2:N},{3:c},{4:c},{5:s},{6:c},{7:c},{8:s},{9:c},{10:c},{11:d},{12:c},{13:d},{14:d},{15:s},{16:c}"
+		"#format"	"{1:s},{2:N},{3:s},{4:s},{5:s},{6:s},{7:s},{8:s},{9:s},{10:s},{11:d},{12:s},{13:d},{14:d},{15:s},{16:s}"
 		"en"		"{1}{2}{3} finished ({4}{5}{6}) in {7}{8}{9} ({10}#{11}{12}) with {13} jumps, {14} strafes{15}{16}."
 	}
 	"NotFirstCompletion"
 	{
-		"#format"	"{1:c},{2:N},{3:c},{4:c},{5:s},{6:c},{7:c},{8:s},{9:c},{10:c},{11:d},{12:c},{13:d},{14:d},{15:s},{16:c},{17:c},{18:s}"
+		"#format"	"{1:s},{2:N},{3:s},{4:s},{5:s},{6:s},{7:s},{8:s},{9:s},{10:s},{11:d},{12:s},{13:d},{14:d},{15:s},{16:s},{17:s},{18:s}"
 		"en"		"{1}{2}{3} finished ({4}{5}{6}) in {7}{8}{9} ({10}#{11}{12}) with {13} jumps, {14} strafes{15}{16}. {17}(-{18})"
 	}
 	"WorseTime"
 	{
-		"#format"	"{1:c},{2:s},{3:c},{4:c},{5:s},{6:c},{7:d},{8:d},{9:s},{10:c},{11:s}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s},{7:d},{8:d},{9:s},{10:s},{11:s}"
 		"en"		"You have finished ({1}{2}{3}) in {4}{5}{6} with {7} jumps, {8} strafes{9}{10}. (+{11})"
 	}
 	"UnrankedTime"
 	{
-		"#format"	"{1:c},{2:s},{3:c},{4:c},{5:s},{6:c},{7:d},{8:d},{9:s},{10:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:s},{7:d},{8:d},{9:s},{10:s}"
 		"en"		"You have finished ({1}{2}{3}) in {4}{5}{6} with {7} jumps, {8} strafes{9}{10}."
 	}
 	// ---------- Deletion Menus ---------- //
@@ -90,7 +90,7 @@
 	}
 	"NoStyles"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"{1}FATAL ERROR: {2}No styles are available. Contact the server owner immediately!"
 	}
 	// ---------- WR Menu ---------- //

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -32,7 +32,7 @@
 	}
 	"ZonesCommand"
 	{
-		"#format"	"{1:c},{2:c}"
+		"#format"	"{1:s},{2:s}"
 		"en"		"You {1}cannot{2} setup mapzones when you're dead."
 	}
 	"ZoneCustomSpawnExists"
@@ -100,7 +100,7 @@
 	}
 	"ZoneDeleteSuccessful"
 	{
-		"#format"	"{1:c},{2:s},{3:c}"
+		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Deleted {1}{2}{3} successfully."
 	}
 	"ZoneDeleteAllSuccessful"
@@ -117,7 +117,7 @@
 	}
 	"ZoneEdgeChange"
 	{
-		"#format"	"{1:s},{2:c},{3:s},{4:c},{5:c},{6:.01f},{7:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:.01f},{7:s}"
 		"en"		"{1} edge {2}{3}{4} by {5}{6} degrees{7}."
 	}
 	"ZoneMenuDeleteTitle"
@@ -151,7 +151,7 @@
 	}
 	"ZonePoint"
 	{
-		"#format"	"{1:d},{2:c}"
+		"#format"	"{1:d},{2:s}"
 		"en"		"Point {1} | {2} axis"
 	}
 	"ZoneRotate"
@@ -170,7 +170,7 @@
 	}
 	"ZoneRotateSuccessful"
 	{
-		"#format"	"{1:c},{2:.01f},{3:c}"
+		"#format"	"{1:s},{2:.01f},{3:s}"
 		"en"		"Zone rotated by {1}{2}{3} degrees."
 	}
 	"ZoneSecond"
@@ -207,12 +207,12 @@
 	}
 	"ZoneSizeIncrease"
 	{
-		"#format"	"{1:c},{2:c},{3:c},{4:d},{5:c},{6:.01f},{7:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:d},{5:s},{6:.01f},{7:s}"
 		"en"		"{1}{2} axis{3} (point {4}) increased by {5}{6}{7}"
 	}
 	"ZoneSizeDecrease"
 	{
-		"#format"	"{1:c},{2:c},{3:c},{4:d},{5:c},{6:.01f},{7:c}"
+		"#format"	"{1:s},{2:s},{3:s},{4:d},{5:s},{6:.01f},{7:s}"
 		"en"		"{1}{2} axis{3} (point {4}) decreased by {5}{6}{7}"
 	}
 	"ZoneTeleportUpdated"

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -219,4 +219,8 @@
 	{
 		"en"		"Teleport zone destination updated."
 	}
+	"ZoneTeleportInsideZone"
+	{
+		"en"		"You may not place a destination inside the teleport zone."
+	}
 }


### PR DESCRIPTION
1. Fixed some cookie handle errors in `shavit-core`.
2. Fixed translations breaking for CS:S. Note to @Technoblazed, @Nickelony or any other translator: use `:s` and not `:c` for colors, as CS:S uses the RRGGBB format and not just a single character like CS:GO does.
3. Optimized `shavit-misc` by caching the players' styles.
4. Fixed an infinite loop by not allowed teleport zone destinations to placed inside the zones themselves.
5. Fix `+noclip` and such commands not respecting `2` as a value of `shavit_misc_noclipme`.
6. Implemented @zipcore's solution for #336 but with SourceMod's own functions.