### PR TITLE
Additions and optimizations

### DIFF
--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -262,77 +262,77 @@ Action ShowHUDMenu(int client, int item)
 		return Plugin_Handled;
 	}
 
-	Menu m = new Menu(MenuHandler_HUD, MENU_ACTIONS_DEFAULT|MenuAction_DisplayItem);
-	m.SetTitle("%T", "HUDMenuTitle", client);
+	Menu menu = new Menu(MenuHandler_HUD, MENU_ACTIONS_DEFAULT|MenuAction_DisplayItem);
+	menu.SetTitle("%T", "HUDMenuTitle", client);
 
 	char[] sInfo = new char[16];
 	char[] sHudItem = new char[64];
 	IntToString(HUD_MASTER, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudMaster", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_CENTER, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudCenter", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_ZONEHUD, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudZoneHud", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_OBSERVE, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudObserve", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_SPECTATORS, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudSpectators", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_KEYOVERLAY, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudKeyOverlay", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_HIDEWEAPON, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudHideWeapon", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	IntToString(HUD_TOPLEFT, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "HudTopLeft", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	if(gEV_Type == Engine_CSS)
 	{
 		IntToString(HUD_SYNC, sInfo, 16);
 		FormatEx(sHudItem, 64, "%T", "HudSync", client);
-		m.AddItem(sInfo, sHudItem);
+		menu.AddItem(sInfo, sHudItem);
 
 		IntToString(HUD_TIMELEFT, sInfo, 16);
 		FormatEx(sHudItem, 64, "%T", "HudTimeLeft", client);
-		m.AddItem(sInfo, sHudItem);
+		menu.AddItem(sInfo, sHudItem);
 	}
 
 	IntToString(HUD_2DVEL, sInfo, 16);
 	FormatEx(sHudItem, 64, "%T", "Hud2dVel", client);
-	m.AddItem(sInfo, sHudItem);
+	menu.AddItem(sInfo, sHudItem);
 
 	if(gB_Sounds)
 	{
 		IntToString(HUD_NOSOUNDS, sInfo, 16);
 		FormatEx(sHudItem, 64, "%T", "HudNoRecordSounds", client);
-		m.AddItem(sInfo, sHudItem);
+		menu.AddItem(sInfo, sHudItem);
 	}
 
-	m.ExitButton = true;
-	m.DisplayAt(client, item, 60);
+	menu.ExitButton = true;
+	menu.DisplayAt(client, item, 60);
 
 	return Plugin_Handled;
 }
 
-public int MenuHandler_HUD(Menu m, MenuAction action, int param1, int param2)
+public int MenuHandler_HUD(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_Select)
 	{
 		char[] sCookie = new char[16];
-		m.GetItem(param2, sCookie, 16);
+		menu.GetItem(param2, sCookie, 16);
 		int iSelection = StringToInt(sCookie);
 
 		gI_HUDSettings[param1] ^= iSelection;
@@ -348,7 +348,7 @@ public int MenuHandler_HUD(Menu m, MenuAction action, int param1, int param2)
 		char[] sInfo = new char[16];
 		char[] sDisplay = new char[64];
 		int style = 0;
-		m.GetItem(param2, sInfo, 16, style, sDisplay, 64);
+		menu.GetItem(param2, sInfo, 16, style, sDisplay, 64);
 
 		Format(sDisplay, 64, "[%s] %s", ((gI_HUDSettings[param1] & StringToInt(sInfo)) > 0)? "x":" ", sDisplay);
 
@@ -357,7 +357,7 @@ public int MenuHandler_HUD(Menu m, MenuAction action, int param1, int param2)
 
 	else if(action == MenuAction_End)
 	{
-		delete m;
+		delete menu;
 	}
 
 	return 0;

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -61,7 +61,7 @@ ConVar gCV_Hostname = null;
 ConVar gCV_Hostport = null;
 BhopStyle gBS_Style[MAXPLAYERS+1];
 float gF_Checkpoints[MAXPLAYERS+1][2][3][3]; // 3 - position, angles, velocity
-int gI_CheckpointsSettings[MAXPLAYERS+1]; // 3 - position, angles, velocity
+int gI_CheckpointsSettings[MAXPLAYERS+1];
 
 // cookies
 Handle gH_HideCookie = null;
@@ -407,12 +407,12 @@ public void OnMapStart()
 		int iEntity = -1;
 		float fOrigin[3];
 
-		if((iEntity = FindEntityByClassname(-1, "info_player_terrorist")) != -1)
+		if((iEntity = FindEntityByClassname(iEntity, "info_player_terrorist")) != INVALID_ENT_REFERENCE)
 		{
 			GetEntPropVector(iEntity, Prop_Send, "m_vecOrigin", fOrigin);
 		}
 
-		else if((iEntity = FindEntityByClassname(-1, "info_player_counterterrorist")) != -1)
+		else if((iEntity = FindEntityByClassname(iEntity, "info_player_counterterrorist")) != INVALID_ENT_REFERENCE)
 		{
 			GetEntPropVector(iEntity, Prop_Send, "m_vecOrigin", fOrigin);
 		}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -179,8 +179,8 @@ public void OnPluginStart()
 	// checkpoints
 	RegConsoleCmd("sm_cpmenu", Command_Checkpoints, "Opens the checkpoints menu.");
 	RegConsoleCmd("sm_cp", Command_Checkpoints, "Opens the checkpoints menu. Alias for sm_cpmenu.");
-	// RegConsoleCmd("sm_save", Command_Save, "Saves checkpoint 1.");
-	// RegConsoleCmd("sm_tele", Command_Tele, "Teleports to checkpoint 1.");
+	RegConsoleCmd("sm_save", Command_Save, "Saves checkpoint 1.");
+	RegConsoleCmd("sm_tele", Command_Tele, "Teleports to checkpoint 1.");
 	gH_CheckpointsCookie = RegClientCookie("shavit_checkpoints", "Checkpoints settings", CookieAccess_Protected);
 
 	gI_Ammo = FindSendPropInfo("CCSPlayer", "m_iAmmo");
@@ -1105,6 +1105,52 @@ public Action Command_Checkpoints(int client, int args)
 	}
 
 	return OpenCheckpointsMenu(client, 0);
+}
+
+public Action Command_Save(int client, int args)
+{
+	if(client == 0)
+	{
+		ReplyToCommand(client, "This command may be only performed in-game.");
+
+		return Plugin_Handled;
+	}
+
+	if(!gB_Checkpoints)
+	{
+		Shavit_PrintToChat(client, "%T", "FeatureDisabled", client, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
+
+		return Plugin_Handled;
+	}
+
+	SaveCheckpoint(client, 0);
+
+	Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+
+	return Plugin_Handled;
+}
+
+public Action Command_Tele(int client, int args)
+{
+	if(client == 0)
+	{
+		ReplyToCommand(client, "This command may be only performed in-game.");
+
+		return Plugin_Handled;
+	}
+
+	if(!gB_Checkpoints)
+	{
+		Shavit_PrintToChat(client, "%T", "FeatureDisabled", client, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
+
+		return Plugin_Handled;
+	}
+
+	TeleportToCheckpoint(client, 0);
+
+	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+
+	return Plugin_Handled;
 }
 
 public Action OpenCheckpointsMenu(int client, int item)

--- a/translations/shavit-misc.phrases.txt
+++ b/translations/shavit-misc.phrases.txt
@@ -63,6 +63,11 @@
 	{
 		"en"		"Invalid target."
 	}
+	"MiscCheckpointsStopped"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"Your timer has been {1}stopped{2} due to teleporting."
+	}
 	// ---------- Menus ---------- //
 	"TeleportMenuTitle"
 	{
@@ -72,6 +77,38 @@
 	{
 		"#format"	"{1:s},{2:s}"
 		"en"		"You need to be {1}alive{2} to spawn weapons."
+	}
+	"MiscCheckpointMenu"
+	{
+		"en"		"Checkpoints"
+	}
+	"MiscCheckpointWarning"
+	{
+		"en"		"WARNING: Teleporting will stop your timer!"
+	}
+	"MiscCheckpointSave1"
+	{
+		"en"		"Save 1st checkpoint"
+	}
+	"MiscCheckpointTele1"
+	{
+		"en"		"Teleport to 1st checkpoint"
+	}
+	"MiscCheckpointSave2"
+	{
+		"en"		"Save 2nd checkpoint"
+	}
+	"MiscCheckpointTele2"
+	{
+		"en"		"Teleport to 2nd checkpoint"
+	}
+	"MiscCheckpointUseAngles"
+	{
+		"en"		"Use angles"
+	}
+	"MiscCheckpointUseVelocity"
+	{
+		"en"		"Use velocity"
 	}
 	// ---------- Misc ---------- //
 	"BHStartZoneDisallowed"

--- a/translations/shavit-misc.phrases.txt
+++ b/translations/shavit-misc.phrases.txt
@@ -68,6 +68,16 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"Your timer has been {1}stopped{2} due to teleporting."
 	}
+	"MiscCheckpointsSaved"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"Checkpoint {1}saved{2}."
+	}
+	"MiscCheckpointsTeleported"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"{1}Teleported{2} to checkpoint."
+	}
 	// ---------- Menus ---------- //
 	"TeleportMenuTitle"
 	{


### PR DESCRIPTION
1. Added a checkpoints menu, including `sm_save` and `sm_tele`. Use `sm_cp` or `sm_cpmenu` to open the menu! See #313.
2. Optimized per-player `sv_airaccelerate` so the server won't make two SourceMod calls but only one. An even better micro-optimization would be to cache the player's status (alive/dead) instead so there's only one call to SourceMod (`SetConVarInt`), and only when it's needed as PreThink gets called A LOT.
3. I'm not sure what went wrong, but I tested the timer in my local server and one replay bot would stay in the spectator team so I added `shavit_replay_defaultteam`. Values are 2 for T and 3 for CT.

I'm also a bit confused about why my branches duplicate some commits.. does anyone know what could be wrong?