### PR TITLE
Fix CS:GO HUD indentation

### DIFF
--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -526,7 +526,7 @@ void UpdateHUD(int client)
 
 				if(fPB > 0.0)
 				{
-					Format(sHintText, 512, "%s%s%T: %s (#%d)", sHintText, (status >= Timer_Running)? "\t":"", "HudBestText", client, sPB, (Shavit_GetRankForTime(gBS_Style[target], fPB) - 1));
+					Format(sHintText, 512, "%s%T: %s (#%d)", sHintText, "HudBestText", client, sPB, (Shavit_GetRankForTime(gBS_Style[target], fPB) - 1));
 				}
 
 				if(status >= Timer_Running)


### PR DESCRIPTION
This was mentioned in #318, whether the timer is running or paused the player's best will be indented 1 tab too far, this seems to happen no matter the player's current running time/position.