### PR TITLE
Zones plugin rewrite

### DIFF
--- a/configs/shavit-zones.cfg
+++ b/configs/shavit-zones.cfg
@@ -1,7 +1,7 @@
 // Absolutely DON'T delete subkeys from this file.
 //
 // visible defaults to 1
-// other values default to 255
+// other values default to 255, except for width which is 2.0
 "Zones"
 {
 	// zone sprites
@@ -26,6 +26,7 @@
 			"red"		"67"
 			"green"		"210"
 			"blue"		"230"
+			"width"		"2.0"
 		}
 
 		"End"
@@ -82,6 +83,7 @@
 			"visible"	"0"
 			"green"		"200"
 			"blue"		"0"
+			"width"		"4.0"
 		}
 	}
 }

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -411,6 +411,30 @@ forward void Shavit_OnDatabaseLoaded(Database db);
 forward void Shavit_OnChatConfigLoaded();
 
 /**
+ * Called when a player enters a zone.
+ *
+ * @param client					Client index.
+ * @param type						Zone type.
+ * @param track						Zone track.
+ * @param id						Zone ID.
+ * @param entity					Zone entity iD.
+ * @noreturn
+ */
+forward void Shavit_OnEnterZone(int client, int type, int track, int id, int entity);
+
+/**
+ * Called when a player leaves a zone.
+ *
+ * @param client					Client index.
+ * @param type						Zone type.
+ * @param track						Zone track.
+ * @param id						Zone ID.
+ * @param entity					Zone entity iD.
+ * @noreturn
+ */
+forward void Shavit_OnLeaveZone(int client, int type, int track, int id, int entity);
+
+/**
  * Returns the game type the server is running.
  *
  * @return							Game type. (See "enum ServerGame")

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -222,6 +222,13 @@ enum
 	ZONECACHE_SIZE
 };
 
+enum
+{
+	Track_Main,
+	Track_Bonus,
+	TRACKS_SIZE
+};
+
 // let's not throw errors k?
 stock bool IsValidClient(int client, bool bAlive = false) // when bAlive is false = technical checks, when it's true = gameplay checks
 {
@@ -608,18 +615,20 @@ native int Shavit_GetRankForTime(BhopStyle style, float time);
  * Checks if a mapzone exists.
  *
  * @param type						Mapzone type.
+ * @param track						Mapzone track, -1 to ignore track.
  * @return							Boolean value.
  */
-native bool Shavit_ZoneExists(int type);
+native bool Shavit_ZoneExists(int type, int track);
 
 /**
  * Checks if a player is inside a mapzone
  *
  * @param client					Client index.
  * @param type						Mapzone type.
+ * @param track						Mapzone track, -1 to ignore track.
  * @return							Boolean value.
  */
-native bool Shavit_InsideZone(int client, int type);
+native bool Shavit_InsideZone(int client, int type, int track);
 
 /**
  * Checks if a player is in the process of creating a mapzone.

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -31,7 +31,7 @@
 
 #define SHAVIT_VERSION "1.5b"
 #define STYLE_LIMIT 256
-#define MAX_ZONES 8
+#define MAX_ZONES 64
 
 // HUD
 #define HUD_NONE				(0)
@@ -199,10 +199,7 @@ char gS_CSGOColors[][] =
 };
 #endif
 
-// map zones
-#define MULTIPLEZONES_LIMIT 32
-
-enum MapZones(+=1)
+enum(+=1)
 {
 	Zone_Start = 0,
 	Zone_End,
@@ -212,7 +209,17 @@ enum MapZones(+=1)
 	Zone_Freestyle,
 	Zone_NoVelLimit,
 	Zone_Teleport,
-	Zone_CustomSpawn
+	Zone_CustomSpawn,
+	ZONETYPES_SIZE
+};
+
+enum
+{
+	bZoneInitialized,
+	iZoneType,
+	iZoneTrack, // 0 - main, 1 - bonus
+	iEntityID,
+	ZONECACHE_SIZE
 };
 
 // let's not throw errors k?
@@ -576,19 +583,19 @@ native int Shavit_GetRankForTime(BhopStyle style, float time);
 /**
  * Checks if a mapzone exists.
  *
- * @param type						Mapzone type. (Check "enum MapZones")
+ * @param type						Mapzone type.
  * @return							Boolean value.
  */
-native bool Shavit_ZoneExists(MapZones type);
+native bool Shavit_ZoneExists(int type);
 
 /**
  * Checks if a player is inside a mapzone
  *
  * @param client					Client index.
- * @param type						Mapzone type. (Check "enum MapZones")
+ * @param type						Mapzone type.
  * @return							Boolean value.
  */
-native bool Shavit_InsideZone(int client, MapZones type);
+native bool Shavit_InsideZone(int client, int type);
 
 /**
  * Checks if a player is in the process of creating a mapzone.

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -428,7 +428,7 @@ public Action Command_StartTimer(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(gB_AllowTimerWithoutZone || (gB_Zones && Shavit_ZoneExists(Zone_Start)))
+	if(gB_AllowTimerWithoutZone || (gB_Zones && Shavit_ZoneExists(Zone_Start, Track_Main)))
 	{
 		Call_StartForward(gH_Forwards_OnRestart);
 		Call_PushCell(client);
@@ -452,7 +452,7 @@ public Action Command_TeleportEnd(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(gB_Zones && Shavit_ZoneExists(Zone_End))
+	if(gB_Zones && Shavit_ZoneExists(Zone_End, Track_Main))
 	{
 		Shavit_StopTimer(client);
 		
@@ -488,7 +488,7 @@ public Action Command_TogglePause(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(Shavit_InsideZone(client, Zone_Start))
+	if(Shavit_InsideZone(client, Zone_Start, -1))
 	{
 		Shavit_PrintToChat(client, "%T", "PauseStartZone", client, gS_ChatStrings[sMessageText], gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 
@@ -669,7 +669,7 @@ void ChangeClientStyle(int client, BhopStyle style)
 
 	StopTimer(client);
 
-	if(gB_AllowTimerWithoutZone || (gB_Zones && Shavit_ZoneExists(Zone_Start)))
+	if(gB_AllowTimerWithoutZone || (gB_Zones && Shavit_ZoneExists(Zone_Start, Track_Main)))
 	{
 		Call_StartForward(gH_Forwards_OnRestart);
 		Call_PushCell(client);
@@ -1479,7 +1479,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 
 	int iGroundEntity = GetEntPropEnt(client, Prop_Send, "m_hGroundEntity");
-	bool bInStart = Shavit_InsideZone(client, Zone_Start);
+	bool bInStart = Shavit_InsideZone(client, Zone_Start, Track_Main);
 
 	if(gB_TimerEnabled[client] && !gB_ClientPaused[client])
 	{
@@ -1511,7 +1511,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 
 	// key blocking
-	if(!Shavit_InsideZone(client, Zone_Freestyle))
+	if(!Shavit_InsideZone(client, Zone_Freestyle, -1))
 	{
 		// block E
 		if(gA_StyleSettings[gBS_Style[client]][bBlockUse] && (buttons & IN_USE) > 0)
@@ -1628,7 +1628,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 	// velocity limit
 	if(iGroundEntity != -1 && view_as<float>(gA_StyleSettings[gBS_Style[client]][fVelocityLimit] > 0.0) &&
-		(!gB_Zones || !Shavit_InsideZone(client, Zone_NoVelLimit)))
+		(!gB_Zones || !Shavit_InsideZone(client, Zone_NoVelLimit, -1)))
 	{
 		float fSpeed[3];
 		GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);

--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -433,7 +433,7 @@ void UpdateHUD(int client)
 
 	if((gI_HUDSettings[client] & HUD_ZONEHUD) > 0)
 	{
-		if(Shavit_InsideZone(target, Zone_Start))
+		if(Shavit_InsideZone(target, Zone_Start, -1))
 		{
 			if(gEV_Type == Engine_CSGO)
 			{
@@ -446,7 +446,7 @@ void UpdateHUD(int client)
 			}
 		}
 
-		else if(Shavit_InsideZone(target, Zone_End))
+		else if(Shavit_InsideZone(target, Zone_End, -1))
 		{
 			if(gEV_Type == Engine_CSGO)
 			{
@@ -571,7 +571,7 @@ void UpdateHUD(int client)
 							Format(sFirstLine, 64, "%s %T", sFirstLine, "HudPracticeMode", client);
 						}
 
-						FormatEx(sHintText, 512, "%s\n%T: %s (%d)\n%T: %d\n%T: %d\n%T: %d%s", sFirstLine, "HudTimeText", client, sTime, rank, "HudJumpsText", client, jumps, "HudStrafeText", client, strafes, "HudSpeedText", client, iSpeed, (gA_StyleSettings[gBS_Style[target]][fVelocityLimit] > 0.0 && Shavit_InsideZone(target, Zone_NoVelLimit))? "\nNo Speed Limit":"");
+						FormatEx(sHintText, 512, "%s\n%T: %s (%d)\n%T: %d\n%T: %d\n%T: %d%s", sFirstLine, "HudTimeText", client, sTime, rank, "HudJumpsText", client, jumps, "HudStrafeText", client, strafes, "HudSpeedText", client, iSpeed, (gA_StyleSettings[gBS_Style[target]][fVelocityLimit] > 0.0 && Shavit_InsideZone(target, Zone_NoVelLimit, -1))? "\nNo Speed Limit":"");
 					}
 
 					else
@@ -854,7 +854,7 @@ void UpdateKeyHint(int client)
 
 		if(IsValidClient(target) && (target == client || (gI_HUDSettings[client] & HUD_OBSERVE) > 0))
 		{
-			if((gI_HUDSettings[client] & HUD_SYNC) > 0 && Shavit_GetTimerStatus(target) == Timer_Running && gA_StyleSettings[gBS_Style[target]][bSync] && !IsFakeClient(target) && (!gB_Zones || !Shavit_InsideZone(target, Zone_Start)))
+			if((gI_HUDSettings[client] & HUD_SYNC) > 0 && Shavit_GetTimerStatus(target) == Timer_Running && gA_StyleSettings[gBS_Style[target]][bSync] && !IsFakeClient(target) && (!gB_Zones || !Shavit_InsideZone(target, Zone_Start, -1)))
 			{
 				Format(sMessage, 256, "%s%s%T: %.02f", sMessage, (strlen(sMessage) > 0)? "\n\n":"", "HudSync", client, Shavit_GetSync(target));
 			}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -704,7 +704,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 		return Plugin_Continue;
 	}
 
-	bool bInStart = Shavit_InsideZone(client, Zone_Start);
+	bool bInStart = Shavit_InsideZone(client, Zone_Start, -1);
 	bool bNoclipping = (GetEntityMoveType(client) == MOVETYPE_NOCLIP);
 
 	if(bNoclipping && !bInStart && Shavit_GetTimerStatus(client) == Timer_Running)
@@ -1029,7 +1029,7 @@ bool Teleport(int client, int targetserial)
 
 	int iTarget = GetClientFromSerial(targetserial);
 
-	if(Shavit_InsideZone(client, Zone_Start) || Shavit_InsideZone(client, Zone_End))
+	if(Shavit_InsideZone(client, Zone_Start, -1) || Shavit_InsideZone(client, Zone_End, -1))
 	{
 		Shavit_PrintToChat(client, "%T", "TeleportInZone", client, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 
@@ -1516,7 +1516,7 @@ public Action Respawn(Handle Timer, any data)
 
 void RestartTimer(int client)
 {
-	if(Shavit_ZoneExists(Zone_Start))
+	if(Shavit_ZoneExists(Zone_Start, Track_Main))
 	{
 		Shavit_RestartTimer(client);
 	}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1556,7 +1556,7 @@ public void Player_Spawn(Event event, const char[] name, bool dontBroadcast)
 	}
 }
 
-public void RemoveRadar(any data)
+void RemoveRadar(any data)
 {
 	int client = GetClientFromSerial(data);
 

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -560,7 +560,7 @@ public Action Command_Modifier(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(!args)
+	if(args == 0)
 	{
 		Shavit_PrintToChat(client, "%T", "ModifierCommandNoArgs", client);
 
@@ -708,8 +708,12 @@ public Action Command_DeleteZone(int client, int args)
 		if(gA_ZoneCache[i][bZoneInitialized])
 		{
 			char[] sInfo = new char[8];
-			IntToString(gA_ZoneCache[i][iZoneType], sInfo, 8);
-			menu.AddItem(sInfo, gS_ZoneNames[gA_ZoneCache[i][iZoneType]]);
+			IntToString(i, sInfo, 8);
+
+			char[] sDisplay = new char[64];
+			FormatEx(sDisplay, 64, "#%d %s", (i + 1), gS_ZoneNames[gA_ZoneCache[i][iZoneType]]);
+
+			menu.AddItem(sInfo, sDisplay);
 		}
 	}
 
@@ -1391,6 +1395,8 @@ public Action Timer_Draw(Handle Timer, any data)
 		points[0] = gV_Point1[client];
 		points[7] = vOrigin;
 
+		CreateZonePoints(points);
+
 		DrawZone(points, GetZoneColors(gI_ZoneType[client]), 0.1);
 
 		if(gI_ZoneType[client] == Zone_Teleport && !EmptyVector(gV_Teleport[client]))
@@ -1717,6 +1723,7 @@ public void CreateZoneEntities()
 			continue;
 		}
 
+		DispatchKeyValue(entity, "wait", "0");
 		DispatchKeyValue(entity, "spawnflags", "4097");
 		
 		if(!DispatchSpawn(entity))
@@ -1742,15 +1749,15 @@ public void CreateZoneEntities()
 		float distance_z = abs(gV_MapZones[i][0][2] - gV_MapZones[i][7][2]);
 
 		float min[3];
-		min[0] = -(distance_x / 2);
-		min[1] = -(distance_y / 2);
-		min[2] = -(distance_z / 2);
+		min[0] = -(distance_x / 2) + 16.0;
+		min[1] = -(distance_y / 2) + 16.0;
+		min[2] = -(distance_z / 2) + 16.0;
 		SetEntPropVector(entity, Prop_Send, "m_vecMins", min);
 
 		float max[3];
-		max[0] = distance_x / 2;
-		max[1] = distance_y / 2;
-		max[2] = distance_z / 2;
+		max[0] = (distance_x / 2) - 16.0;
+		max[1] = (distance_y / 2) - 16.0;
+		max[2] = (distance_z / 2) - 16.0;
 		SetEntPropVector(entity, Prop_Send, "m_vecMaxs", max);
 
 		SetEntProp(entity, Prop_Send, "m_nSolidType", 2);

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -116,6 +116,7 @@ ConVar gCV_Interval = null;
 ConVar gCV_TeleportToStart = null;
 ConVar gCV_TeleportToEnd = null;
 ConVar gCV_UseCustomSprite = null;
+ConVar gCV_Height = null;
 
 // cached cvars
 bool gB_FlatZones = false;
@@ -123,6 +124,7 @@ float gF_Interval = 1.5;
 bool gB_TeleportToStart = true;
 bool gB_TeleportToEnd = true;
 bool gB_UseCustomSprite = true;
+float gF_Height = 128.0;
 
 // handles
 Handle gH_DrawEverything = null;
@@ -202,12 +204,14 @@ public void OnPluginStart()
 	gCV_TeleportToStart = CreateConVar("shavit_zones_teleporttostart", "1", "Teleport players to the start zone on timer restart?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_TeleportToEnd = CreateConVar("shavit_zones_teleporttoend", "1", "Teleport players to the end zone on sm_end?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_UseCustomSprite = CreateConVar("shavit_zones_usecustomsprite", "1", "Use custom sprite for zone drawing?\nSee `configs/shavit-zones.cfg`.\nRestart server after change.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_Height = CreateConVar("shavit_zones_height", "128.0", "Height to use for the start zone.", 0, true, 0.0, false);
 
 	gCV_FlatZones.AddChangeHook(OnConVarChanged);
 	gCV_Interval.AddChangeHook(OnConVarChanged);
 	gCV_TeleportToStart.AddChangeHook(OnConVarChanged);
 	gCV_TeleportToEnd.AddChangeHook(OnConVarChanged);
 	gCV_UseCustomSprite.AddChangeHook(OnConVarChanged);
+	gCV_Height.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 
@@ -223,6 +227,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_TeleportToStart = gCV_TeleportToStart.BoolValue;
 	gB_UseCustomSprite = gCV_UseCustomSprite.BoolValue;
 	gB_TeleportToEnd = gCV_TeleportToEnd.BoolValue;
+	gF_Height = gCV_Height.FloatValue;
 
 	if(convar == gCV_Interval)
 	{
@@ -1108,7 +1113,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 
 				else if(gI_MapStep[client] == 2)
 				{
-					origin[2] += 128.0;
+					origin[2] += gF_Height;
 					gV_Point2[client] = origin;
 
 					gI_MapStep[client]++;

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1724,13 +1724,13 @@ public void CreateZoneEntities()
 		float min[3];
 		min[0] = -(distance_x / 2) + 16.0;
 		min[1] = -(distance_y / 2) + 16.0;
-		min[2] = -(distance_z / 2) + 16.0;
+		min[2] = -(distance_z / 2) + 36.0;
 		SetEntPropVector(entity, Prop_Send, "m_vecMins", min);
 
 		float max[3];
 		max[0] = (distance_x / 2) - 16.0;
 		max[1] = (distance_y / 2) - 16.0;
-		max[2] = (distance_z / 2) - 16.0;
+		max[2] = (distance_z / 2) - 36.0;
 		SetEntPropVector(entity, Prop_Send, "m_vecMaxs", max);
 
 		SetEntProp(entity, Prop_Send, "m_nSolidType", 2);

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1148,8 +1148,6 @@ void CreateEditMenu(int client)
 	menu.AddItem("no", sMenuItem);
 	FormatEx(sMenuItem, 64, "%T", "ZoneSetAdjust", client);
 	menu.AddItem("adjust", sMenuItem);
-	FormatEx(sMenuItem, 64, "%T", "ZoneSetRotate", client);
-	menu.AddItem("rotate", sMenuItem);
 	FormatEx(sMenuItem, 64, "%T", "ZoneChangeTrack", client);
 	menu.AddItem("track", sMenuItem);
 

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1075,6 +1075,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 				if(gI_MapStep[client] == 1)
 				{
 					gV_Point1[client] = origin;
+					gV_Point1[client][2] += 1.0;
 
 					ShowPanel(client, 2);
 				}

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -20,6 +20,7 @@
 
 #include <sourcemod>
 #include <sdktools>
+#include <sdkhooks>
 #include <cstrike>
 #include <dynamic>
 
@@ -31,8 +32,6 @@
 #pragma dynamic 131072
 #pragma newdecls required
 
-#define PLACEHOLDER 32767
-
 EngineVersion gEV_Type = Engine_Unknown;
 
 Database gH_SQL = null;
@@ -40,7 +39,7 @@ bool gB_MySQL = false;
 
 char gS_Map[128];
 
-char gS_ZoneNames[MAX_ZONES][] =
+char gS_ZoneNames[][] =
 {
 	"Start Zone", // starts timer
 	"End Zone", // stops timer
@@ -69,9 +68,7 @@ enum
 	ZONESETTINGS_SIZE
 }
 
-any gA_ZoneSettings[MAX_ZONES*8][ZONESETTINGS_SIZE];
-
-MapZones gMZ_Type[MAXPLAYERS+1];
+int gI_ZoneType[MAXPLAYERS+1];
 
 // 0 - nothing
 // 1 - wait for E tap to setup first coord
@@ -82,38 +79,21 @@ int gI_MapStep[MAXPLAYERS+1];
 float gF_Modifier[MAXPLAYERS+1];
 int gI_GridSnap[MAXPLAYERS+1];
 
-// I suck
+// Cache.
 float gV_Point1[MAXPLAYERS+1][3];
 float gV_Point2[MAXPLAYERS+1][3];
 float gV_Teleport[MAXPLAYERS+1][3];
-
 bool gB_Button[MAXPLAYERS+1];
-
-float gV_MapZones[MAX_ZONES][2][3];
-float gV_FreestyleZones[MULTIPLEZONES_LIMIT][2][3];
-MapZones gMZ_FreestyleTypes[MULTIPLEZONES_LIMIT];
-float gV_TeleportZoneDestination[MULTIPLEZONES_LIMIT][3];
-
-// Sorry for adding too many variables: zone rotations
-float gV_MapZonesFixes[MAX_ZONES][2][2];
-float gV_FreeStyleZonesFixes[MULTIPLEZONES_LIMIT][2][2];
-
-// ofir's pull request
-float gF_ConstSin[MAX_ZONES];
-float gF_MinusConstSin[MAX_ZONES];
-float gF_ConstCos[MAX_ZONES];
-float gF_MinusConstCos[MAX_ZONES];
-
-float gF_FreeStyleConstSin[MULTIPLEZONES_LIMIT];
-float gF_FreeStyleMinusConstSin[MULTIPLEZONES_LIMIT];
-float gF_FreeStyleConstCos[MULTIPLEZONES_LIMIT];
-float gF_FreeStyleMinusConstCos[MULTIPLEZONES_LIMIT];
-
+bool gB_BonusZones[MAXPLAYERS+1];
 float gF_CustomSpawn[3];
 
-float gF_RotateAngle[MAXPLAYERS+1];
-float gV_Fix1[MAXPLAYERS+1][2];
-float gV_Fix2[MAXPLAYERS+1][2];
+// Zone cache.
+any gA_ZoneSettings[ZONETYPES_SIZE][ZONESETTINGS_SIZE];
+any gA_ZoneCache[MAX_ZONES][ZONECACHE_SIZE]; // Vectors will not be inside this array.
+int gI_MapZones = 0;
+float gV_MapZones[MAX_ZONES][2][3];
+float gV_Destinations[MAX_ZONES][3];
+int gI_EntityZone[4096];
 
 // beamsprite, used to draw the zone
 char gS_Sprites[ZONESPRITES_SIZE][PLATFORM_MAX_PATH];
@@ -124,17 +104,15 @@ int gI_HaloSprite = -1;
 Handle gH_AdminMenu = INVALID_HANDLE;
 
 // late load?
-bool gB_Late;
+bool gB_Late = false;
 
 // cvars
-ConVar gCV_ZoneStyle = null;
 ConVar gCV_Interval = null;
 ConVar gCV_TeleportToStart = null;
 ConVar gCV_TeleportToEnd = null;
 ConVar gCV_UseCustomSprite = null;
 
 // cached cvars
-int gI_ZoneStyle = 0;
 float gF_Interval = 1.0;
 bool gB_TeleportToStart = true;
 bool gB_TeleportToEnd = true;
@@ -197,14 +175,15 @@ public void OnPluginStart()
 	RegAdminCmd("sm_addspawn", Command_AddSpawn,  ADMFLAG_RCON, "Adds a custom spawn location");
 	RegAdminCmd("sm_delspawn", Command_DelSpawn,  ADMFLAG_RCON, "Deletes a custom spawn location");
 
+	// events
+	HookEvent("round_start", Round_Start);
+
 	// cvars and stuff
-	gCV_ZoneStyle = CreateConVar("shavit_zones_style", "0", "Style for mapzone drawing.\n0 - 3D box\n1 - 2D box", 0, true, 0.0, true, 1.0);
 	gCV_Interval = CreateConVar("shavit_zones_interval", "1.0", "Interval between each time a mapzone is being drawn to the players.", 0, true, 0.5, true, 5.0);
 	gCV_TeleportToStart = CreateConVar("shavit_zones_teleporttostart", "1", "Teleport players to the start zone on timer restart?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_TeleportToEnd = CreateConVar("shavit_zones_teleporttoend", "1", "Teleport players to the end zone on sm_end?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_UseCustomSprite = CreateConVar("shavit_zones_usecustomsprite", "1", "Use custom sprite for zone drawing?\nSee `configs/shavit-zones.cfg`.\nRestart server after change.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 
-	gCV_ZoneStyle.AddChangeHook(OnConVarChanged);
 	gCV_Interval.AddChangeHook(OnConVarChanged);
 	gCV_TeleportToStart.AddChangeHook(OnConVarChanged);
 	gCV_TeleportToEnd.AddChangeHook(OnConVarChanged);
@@ -219,7 +198,6 @@ public void OnPluginStart()
 
 public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	gI_ZoneStyle = gCV_ZoneStyle.IntValue;
 	gF_Interval = gCV_Interval.FloatValue;
 	gB_TeleportToStart = gCV_TeleportToStart.BoolValue;
 	gB_UseCustomSprite = gCV_UseCustomSprite.BoolValue;
@@ -319,28 +297,13 @@ public void AdminMenu_DeleteAllZones(Handle topmenu,  TopMenuAction action, TopM
 
 public int Native_ZoneExists(Handle handler, int numParams)
 {
-	MapZones type = GetNativeCell(1);
-
-	return view_as<int>(!EmptyZone(gV_MapZones[type][0]) && !EmptyZone(gV_MapZones[type][1]));
+	return view_as<int>(GetZoneIndex(GetNativeCell(1)) != -1);
 }
 
 public int Native_InsideZone(Handle handler, int numParams)
 {
-	int client = GetNativeCell(1);
-	MapZones type = GetNativeCell(2);
-
-	if(type >= Zone_Freestyle && type != Zone_Teleport)
-	{
-		for(int i = 0; i < MULTIPLEZONES_LIMIT; i++)
-		{
-			if((i == 0 && InsideZone(client, -PLACEHOLDER)) || InsideZone(client, -i))
-			{
-				return true;
-			}
-		}
-	}
-
-	return view_as<int>(InsideZone(client, view_as<int>(type)));
+	// TODO: implement
+	return false;
 }
 
 public int Native_IsClientCreatingZone(Handle handler, int numParams)
@@ -411,6 +374,7 @@ public void OnMapStart()
 {
 	GetCurrentMap(gS_Map, 128);
 
+	gI_MapZones = 0;
 	UnloadZones(0);
 
 	if(gH_SQL != null)
@@ -444,7 +408,7 @@ public void OnMapStart()
 		}
 	}
 
-	// PrecacheModel("models/props/cs_office/vending_machine.mdl"); // placeholder model
+	PrecacheModel("models/props/cs_office/vending_machine.mdl");
 
 	// draw
 	// start drawing mapzones here
@@ -464,27 +428,44 @@ public void Shavit_OnChatConfigLoaded()
 	}
 }
 
+void ClearZone(int index)
+{
+	for(int i = 0; i < 3; i++)
+	{
+		gV_MapZones[index][0][i] = 0.0;
+		gV_MapZones[index][1][i] = 0.0;
+	}
+
+	gA_ZoneCache[index][bZoneInitialized] = false;
+	gA_ZoneCache[index][iZoneType] = -1;
+	gA_ZoneCache[index][iZoneTrack] = -1;
+	gA_ZoneCache[index][iEntityID] = -1;
+}
+
+void KillZoneEntity(int index)
+{
+	if(gA_ZoneCache[index][iEntityID] != -1 && IsValidEntity(gA_ZoneCache[index][iEntityID]))
+	{
+		AcceptEntityInput(gA_ZoneCache[index][iEntityID], "Kill");
+	}
+}
+
 // 0 - all zones
 void UnloadZones(int zone)
 {
-	if(!zone)
+	if(zone == Zone_CustomSpawn)
+	{
+		ClearCustomSpawn();
+	}
+
+	else
 	{
 		for(int i = 0; i < MAX_ZONES; i++)
 		{
-			for(int j = 0; j < 3; j++)
+			if(gA_ZoneCache[i][bZoneInitialized] && (zone == 0 || gA_ZoneCache[i][iZoneType] == zone))
 			{
-				gV_MapZones[i][0][j] = 0.0;
-				gV_MapZones[i][1][j] = 0.0;
-			}
-		}
-
-		for(int i = 0; i < MULTIPLEZONES_LIMIT; i++)
-		{
-			for(int j = 0; j < 3; j++)
-			{
-				gV_FreestyleZones[i][0][j] = 0.0;
-				gV_FreestyleZones[i][1][j] = 0.0;
-				gMZ_FreestyleTypes[i] = view_as<MapZones>(-1);
+				KillZoneEntity(i);
+				ClearZone(i);
 			}
 		}
 
@@ -492,39 +473,12 @@ void UnloadZones(int zone)
 
 		return;
 	}
-
-	if(zone < view_as<int>(Zone_Freestyle))
-	{
-		for(int i = 0; i < 3; i++)
-		{
-			gV_MapZones[zone][0][i] = 0.0;
-			gV_MapZones[zone][1][i] = 0.0;
-		}
-	}
-
-	else if(zone == view_as<int>(Zone_CustomSpawn))
-	{
-		ClearCustomSpawn();
-	}
-
-	else
-	{
-		for(int i = 0; i < MULTIPLEZONES_LIMIT; i++)
-		{
-			for(int j = 0; j < 3; j++)
-			{
-				gV_FreestyleZones[i][0][j] = 0.0;
-				gV_FreestyleZones[i][1][j] = 0.0;
-				gMZ_FreestyleTypes[i] = view_as<MapZones>(-1);
-			}
-		}
-	}
 }
 
 void RefreshZones()
 {
 	char[] sQuery = new char[512];
-	FormatEx(sQuery, 512, "SELECT type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, rot_ang, fix1_x, fix1_y, fix2_x, fix2_y, destination_x, destination_y, destination_z FROM %smapzones WHERE map = '%s';", gS_MySQLPrefix, gS_Map);
+	FormatEx(sQuery, 512, "SELECT type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, destination_x, destination_y, destination_z, track FROM %smapzones WHERE map = '%s';", gS_MySQLPrefix, gS_Map);
 
 	if(gH_SQL != null)
 	{
@@ -546,85 +500,45 @@ public void SQL_RefreshZones_Callback(Database db, DBResultSet results, const ch
 		return;
 	}
 
-	int iFreestyleRow = 0;
+	gI_MapZones = 0;
 
 	while(results.FetchRow())
 	{
-		MapZones type = view_as<MapZones>(results.FetchInt(0));
+		int type = results.FetchInt(0);
 
 		if(type == Zone_CustomSpawn)
 		{
-			gF_CustomSpawn[0] = results.FetchFloat(12);
-			gF_CustomSpawn[1] = results.FetchFloat(13);
-			gF_CustomSpawn[2] = results.FetchFloat(14);
-		}
-
-		else if(type >= Zone_Freestyle)
-		{
-			gV_FreestyleZones[iFreestyleRow][0][0] = results.FetchFloat(1);
-			gV_FreestyleZones[iFreestyleRow][0][1] = results.FetchFloat(2);
-			gV_FreestyleZones[iFreestyleRow][0][2] = results.FetchFloat(3);
-			gV_FreestyleZones[iFreestyleRow][1][0] = results.FetchFloat(4);
-			gV_FreestyleZones[iFreestyleRow][1][1] = results.FetchFloat(5);
-			gV_FreestyleZones[iFreestyleRow][1][2] = results.FetchFloat(6);
-
-			gMZ_FreestyleTypes[iFreestyleRow] = type;
-
-			float ang = results.FetchFloat(7);
-
-			float radian = DegToRad(ang);
-			gF_FreeStyleConstSin[iFreestyleRow] = Sine(radian);
-			gF_FreeStyleConstCos[iFreestyleRow] = Cosine(radian);
-
-			radian = DegToRad(-ang);
-			gF_FreeStyleMinusConstSin[iFreestyleRow] = Sine(radian);
-			gF_FreeStyleMinusConstCos[iFreestyleRow] = Cosine(radian);
-
-			gV_FreeStyleZonesFixes[iFreestyleRow][0][0] = results.FetchFloat(8);
-			gV_FreeStyleZonesFixes[iFreestyleRow][0][1] = results.FetchFloat(9);
-			gV_FreeStyleZonesFixes[iFreestyleRow][1][0] = results.FetchFloat(10);
-			gV_FreeStyleZonesFixes[iFreestyleRow][1][1] = results.FetchFloat(11);
-
-			if(type == Zone_Teleport)
-			{
-				gV_TeleportZoneDestination[iFreestyleRow][0] = results.FetchFloat(12);
-				gV_TeleportZoneDestination[iFreestyleRow][1] = results.FetchFloat(13);
-				gV_TeleportZoneDestination[iFreestyleRow][2] = results.FetchFloat(14);
-			}
-
-			iFreestyleRow++;
+			gF_CustomSpawn[0] = results.FetchFloat(7);
+			gF_CustomSpawn[1] = results.FetchFloat(8);
+			gF_CustomSpawn[2] = results.FetchFloat(9);
 		}
 
 		else
 		{
-			if(view_as<int>(type) >= MAX_ZONES || view_as<int>(type) < 0)
+			gV_MapZones[gI_MapZones][0][0] = results.FetchFloat(1);
+			gV_MapZones[gI_MapZones][0][1] = results.FetchFloat(2);
+			gV_MapZones[gI_MapZones][0][2] = results.FetchFloat(3);
+			gV_MapZones[gI_MapZones][1][0] = results.FetchFloat(4);
+			gV_MapZones[gI_MapZones][1][1] = results.FetchFloat(5);
+			gV_MapZones[gI_MapZones][1][2] = results.FetchFloat(6);
+
+			if(type == Zone_Teleport)
 			{
-				continue;
+				gV_Destinations[gI_MapZones][0] = results.FetchFloat(7);
+				gV_Destinations[gI_MapZones][1] = results.FetchFloat(8);
+				gV_Destinations[gI_MapZones][2] = results.FetchFloat(9);
 			}
 
-			gV_MapZones[type][0][0] = results.FetchFloat(1);
-			gV_MapZones[type][0][1] = results.FetchFloat(2);
-			gV_MapZones[type][0][2] = results.FetchFloat(3);
-			gV_MapZones[type][1][0] = results.FetchFloat(4);
-			gV_MapZones[type][1][1] = results.FetchFloat(5);
-			gV_MapZones[type][1][2] = results.FetchFloat(6);
+			gA_ZoneCache[gI_MapZones][bZoneInitialized] = true;
+			gA_ZoneCache[gI_MapZones][iZoneType] = type;
+			gA_ZoneCache[gI_MapZones][iZoneTrack] = results.FetchInt(10);
+			gA_ZoneCache[gI_MapZones][iEntityID] = -1;
 
-			float ang = results.FetchFloat(7);
-
-			float radian = DegToRad(ang);
-			gF_ConstSin[type] = Sine(radian);
-			gF_ConstCos[type] = Cosine(radian);
-
-			radian = DegToRad(-ang);
-			gF_MinusConstSin[type] = Sine(radian);
-			gF_MinusConstCos[type] = Cosine(radian);
-
-			gV_MapZonesFixes[type][0][0] = results.FetchFloat(8);
-			gV_MapZonesFixes[type][0][1] = results.FetchFloat(9);
-			gV_MapZonesFixes[type][1][0] = results.FetchFloat(10);
-			gV_MapZonesFixes[type][1][1] = results.FetchFloat(11);
+			gI_MapZones++;
 		}
 	}
+
+	CreateZoneEntities();
 }
 
 public void OnClientPutInServer(int client)
@@ -685,14 +599,14 @@ public Action Command_AddSpawn(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(!EmptyZone(gF_CustomSpawn))
+	if(!EmptyVector(gF_CustomSpawn))
 	{
 		Shavit_PrintToChat(client, "%T", "ZoneCustomSpawnExists", client);
 
 		return Plugin_Handled;
 	}
 
-	gMZ_Type[client] = Zone_CustomSpawn;
+	gI_ZoneType[client] = Zone_CustomSpawn;
 
 	GetClientAbsOrigin(client, gV_Point1[client]);
 	InsertZone(client);
@@ -787,23 +701,13 @@ public Action Command_DeleteZone(int client, int args)
 	Menu menu = new Menu(DeleteZone_MenuHandler);
 	menu.SetTitle("%T", "ZoneMenuDeleteTitle", client);
 
-	for(int i = 0; i < MAX_ZONES; i++)
+	for(int i = 0; i < gI_MapZones; i++)
 	{
-		if(i >= view_as<int>(Zone_Freestyle))
-		{
-			if(!EmptyZone(gV_FreestyleZones[0][0]) && !EmptyZone(gV_FreestyleZones[0][1]))
-			{
-				char[] sInfo = new char[8];
-				IntToString(i, sInfo, 8);
-				menu.AddItem(sInfo, gS_ZoneNames[i]);
-			}
-		}
-
-		if(!EmptyZone(gV_MapZones[i][0]) && !EmptyZone(gV_MapZones[i][1]))
+		if(gA_ZoneCache[i][bZoneInitialized])
 		{
 			char[] sInfo = new char[8];
-			IntToString(i, sInfo, 8);
-			menu.AddItem(sInfo, gS_ZoneNames[i]);
+			IntToString(gA_ZoneCache[i][iZoneType], sInfo, 8);
+			menu.AddItem(sInfo, gS_ZoneNames[gA_ZoneCache[i][iZoneType]]);
 		}
 	}
 
@@ -966,7 +870,7 @@ public int Select_Type_MenuHandler(Menu menu, MenuAction action, int param1, int
 		char[] info = new char[8];
 		menu.GetItem(param2, info, 8);
 
-		gMZ_Type[param1] = view_as<MapZones>(StringToInt(info));
+		gI_ZoneType[param1] = StringToInt(info);
 
 		ShowPanel(param1, 1);
 	}
@@ -981,16 +885,10 @@ public int Select_Type_MenuHandler(Menu menu, MenuAction action, int param1, int
 
 void Reset(int client)
 {
+	gB_BonusZones[client] = false;
 	gF_Modifier[client] = 10.0;
 	gI_MapStep[client] = 0;
 	gI_GridSnap[client] = 16;
-	gF_RotateAngle[client] = 0.0;
-
-	for(int i = 0; i < 2; i++)
-	{
-		gV_Fix1[client][i] = 0.0;
-		gV_Fix2[client][i] = 0.0;
-	}
 
 	for(int i = 0; i < 3; i++)
 	{
@@ -1000,14 +898,12 @@ void Reset(int client)
 	}
 }
 
-// neat idea for this part is by alongub, you have a cool way of thinking. :)
 void ShowPanel(int client, int step)
 {
 	gI_MapStep[client] = step;
 
 	if(step == 1)
 	{
-		// not gonna use gF_Interval here as we need percision when setting up zones
 		CreateTimer(0.1, Timer_Draw, GetClientSerial(client), TIMER_REPEAT);
 	}
 
@@ -1093,8 +989,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 
 				else if(gI_MapStep[client] == 2)
 				{
-					//vOrigin[2] += 72; // was requested to make it higher
-					vOrigin[2] += 144;
+					vOrigin[2] += 128.0;
 					gV_Point2[client] = vOrigin;
 
 					gI_MapStep[client]++;
@@ -1112,22 +1007,23 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 		}
 	}
 
-	if(InsideZone(client, view_as<int>(Zone_Respawn)))
+	if(InsideZone(client, Zone_Respawn))
 	{
 		CS_RespawnPlayer(client);
 
 		return Plugin_Continue;
 	}
 
-	for(int i = 0; i < MULTIPLEZONES_LIMIT; i++)
+	// TODO: fix teleport zones
+	/*for(int i = 0; i < 2; i++)
 	{
 		if(gMZ_FreestyleTypes[i] == Zone_Teleport && !EmptyZone(gV_TeleportZoneDestination[i]) && InsideTeleportZone(client, i))
 		{
 			TeleportEntity(client, gV_TeleportZoneDestination[i], NULL_VECTOR, NULL_VECTOR);
 		}
-	}
+	}*/
 
-	if(InsideZone(client, view_as<int>(Zone_Start)))
+	if(InsideZone(client, Zone_Start))
 	{
 		Shavit_ResumeTimer(client);
 		Shavit_StartTimer(client);
@@ -1135,7 +1031,7 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 		return Plugin_Continue;
 	}
 
-	if(InsideZone(client, view_as<int>(Zone_Slay)))
+	if(InsideZone(client, Zone_Slay))
 	{
 		Shavit_StopTimer(client);
 
@@ -1144,12 +1040,12 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 
 	if(Shavit_GetTimerStatus(client) == Timer_Running)
 	{
-		if(InsideZone(client, view_as<int>(Zone_Stop)))
+		if(InsideZone(client, Zone_Stop))
 		{
 			Shavit_StopTimer(client);
 		}
 
-		if(InsideZone(client, view_as<int>(Zone_End)))
+		if(InsideZone(client, Zone_End))
 		{
 			Shavit_FinishMap(client);
 		}
@@ -1182,16 +1078,6 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 			CreateAdjustMenu(param1, 0);
 		}
 
-		else if(StrEqual(info, "rotate"))
-		{
-			CreateRotateMenu(param1);
-		}
-
-		else if(StrEqual(info, "wl"))
-		{
-			CreateWidthLengthMenu(param1, 0);
-		}
-
 		else if(StrEqual(info, "tpzone"))
 		{
 			float vTeleport[3];
@@ -1202,9 +1088,9 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 			vPoints[0] = gV_Point1[param1];
 			vPoints[7] = gV_Point2[param1];
 
-			CreateZonePoints(vPoints, gF_RotateAngle[param1], gV_Fix1[param1], gV_Fix2[param1], PLACEHOLDER, false, true);
-
-			bool bInside = true;
+			// TODO: reimplement
+			/*
+			CreateZonePoints(vPoints, 0.0, 0.0, 0.0, 0, false, true);
 
 			for(int i = 0; i < 3; i++)
 			{
@@ -1212,7 +1098,9 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 				{
 					bInside = false;
 				}
-			}
+			}*/
+
+			bool bInside = false;
 
 			if(bInside)
 			{
@@ -1228,6 +1116,13 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 
 			CreateEditMenu(param1);
 		}
+
+		else if(StrEqual(info, "track"))
+		{
+			gB_BonusZones[param1] = !gB_BonusZones[param1];
+
+			CreateEditMenu(param1);
+		}
 	}
 
 	else if(action == MenuAction_End)
@@ -1240,14 +1135,26 @@ public int CreateZoneConfirm_Handler(Menu menu, MenuAction action, int param1, i
 
 void CreateEditMenu(int client)
 {
+	char[] sTrack = new char[32];
+	
+	if(!gB_BonusZones[client])
+	{
+		FormatEx(sTrack, 32, "%T", "ZoneEditMain", client);
+	}
+
+	else
+	{
+		FormatEx(sTrack, 32, "%T", "ZoneEditBonus", client);
+	}
+
 	Menu menu = new Menu(CreateZoneConfirm_Handler, MENU_ACTIONS_DEFAULT|MenuAction_DisplayItem);
-	menu.SetTitle("%T", "ZoneEditConfirm", client);
+	menu.SetTitle("%T\n%T\n ", "ZoneEditConfirm", client, "ZoneEditTrack", client, sTrack);
 
 	char[] sMenuItem = new char[64];
 
-	if(gMZ_Type[client] == Zone_Teleport)
+	if(gI_ZoneType[client] == Zone_Teleport)
 	{
-		if(EmptyZone(gV_Teleport[client]))
+		if(EmptyVector(gV_Teleport[client]))
 		{
 			FormatEx(sMenuItem, 64, "%T", "ZoneSetTP", client);
 			menu.AddItem("-1", sMenuItem, ITEMDRAW_DISABLED);
@@ -1268,14 +1175,15 @@ void CreateEditMenu(int client)
 		FormatEx(sMenuItem, 64, "%T", "ZoneSetYes", client);
 		menu.AddItem("yes", sMenuItem);
 	}
+
 	FormatEx(sMenuItem, 64, "%T", "ZoneSetNo", client);
 	menu.AddItem("no", sMenuItem);
 	FormatEx(sMenuItem, 64, "%T", "ZoneSetAdjust", client);
 	menu.AddItem("adjust", sMenuItem);
 	FormatEx(sMenuItem, 64, "%T", "ZoneSetRotate", client);
 	menu.AddItem("rotate", sMenuItem);
-	FormatEx(sMenuItem, 64, "%T", "ZoneSetSize", client);
-	menu.AddItem("wl", sMenuItem);
+	FormatEx(sMenuItem, 64, "%T", "ZoneChangeTrack", client);
+	menu.AddItem("track", sMenuItem);
 
 	menu.ExitButton = true;
 
@@ -1360,166 +1268,9 @@ public int ZoneAdjuster_Handler(Menu menu, MenuAction action, int param1, int pa
 	return 0;
 }
 
-void CreateRotateMenu(int client)
-{
-	Menu hMenu = new Menu(ZoneRotate_Handler);
-	char[] sMenuItem = new char[64];
-
-	hMenu.SetTitle("%T", "ZoneRotate", client);
-
-	FormatEx(sMenuItem, 64, "%T", "ZoneAdjustDone", client);
-	hMenu.AddItem("done", sMenuItem);
-	FormatEx(sMenuItem, 64, "%T", "ZoneAdjustCancel", client);
-	hMenu.AddItem("cancel", sMenuItem);
-
-	char[] sDisplay = new char[64];
-	FormatEx(sDisplay, 64, "%T", "ZoneRotatePlus", client, gF_Modifier[client]);
-	hMenu.AddItem("1", sDisplay);
-
-	FormatEx(sDisplay, 64, "%T", "ZoneRotateNegative", client, gF_Modifier[client]);
-	hMenu.AddItem("2", sDisplay);
-
-	hMenu.Display(client, 40);
-}
-
-public int ZoneRotate_Handler(Menu menu, MenuAction action, int param1, int param2)
-{
-	if(action == MenuAction_Select)
-	{
-		char[] sInfo = new char[16];
-		menu.GetItem(param2, sInfo, 16);
-
-		if(StrEqual(sInfo, "done"))
-		{
-			CreateEditMenu(param1);
-		}
-
-		else if(StrEqual(sInfo, "cancel"))
-		{
-			Reset(param1);
-		}
-
-		else
-		{
-			bool bIncrease = view_as<bool>(StringToInt(sInfo) == 1);
-			gF_RotateAngle[param1] += (bIncrease? gF_Modifier[param1]:-gF_Modifier[param1]);
-
-			Shavit_PrintToChat(param1, "%T", "ZoneRotateSuccessful", param1, gS_ChatStrings[sMessageVariable], ((bIncrease)? gF_Modifier[param1]:-gF_Modifier[param1]), gS_ChatStrings[sMessageText]);
-
-			CreateRotateMenu(param1);
-		}
-	}
-
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
-}
-
-void CreateWidthLengthMenu(int client, int page)
-{
-	Menu hMenu = new Menu(ZoneEdge_Handler);
-	hMenu.SetTitle("%T", "ZoneRotate", client);
-
-	char[] sMenuItem = new char[64];
-	FormatEx(sMenuItem, 64, "%T", "ZoneAdjustDone", client);
-	hMenu.AddItem("done", sMenuItem);
-	FormatEx(sMenuItem, 64, "%T", "ZoneAdjustCancel", client);
-	hMenu.AddItem("cancel", sMenuItem);
-
-	char sEdges[4][64];
-	FormatEx(sEdges[0], 64, "%T", "Edge_Right", client);
-	FormatEx(sEdges[1], 64, "%T", "Edge_Back", client);
-	FormatEx(sEdges[2], 64, "%T", "Edge_Left", client);
-	FormatEx(sEdges[3], 64, "%T", "Edge_Front", client);
-
-	char[] sDisplay = new char[32];
-	char[] sInfo = new char[8];
-
-	for(int iEdge = 0; iEdge < 4; iEdge++)
-	{
-		for(int iState = 1; iState <= 2; iState++)
-		{
-			FormatEx(sDisplay, 32, "%s %T | %c%.01f", sEdges[iEdge], "ZoneEdge", client, (iState == 1)? "+":"-", gF_Modifier[client]);
-			FormatEx(sInfo, 8, "%d;%d", iEdge, iState);
-			hMenu.AddItem(sInfo, sDisplay);
-		}
-	}
-
-	hMenu.DisplayAt(client, page, MENU_TIME_FOREVER);
-}
-
-public int ZoneEdge_Handler(Menu menu, MenuAction action, int param1, int param2)
-{
-	if(action == MenuAction_Select)
-	{
-		char[] sInfo = new char[16];
-		menu.GetItem(param2, sInfo, 16);
-
-		if(StrEqual(sInfo, "done"))
-		{
-			CreateEditMenu(param1);
-		}
-
-		else if(StrEqual(sInfo, "cancel"))
-		{
-			Reset(param1);
-		}
-
-		else
-		{
-			char sEdges[4][64];
-			FormatEx(sEdges[0], 64, "%T", "Edge_Right", param1);
-			FormatEx(sEdges[1], 64, "%T", "Edge_Back", param1);
-			FormatEx(sEdges[2], 64, "%T", "Edge_Left", param1);
-			FormatEx(sEdges[3], 64, "%T", "Edge_Front", param1);
-
-			char[][] sExploded = new char[2][8];
-			ExplodeString(sInfo, ";", sExploded, 2, 8);
-
-			int iEdge = StringToInt(sExploded[0]);
-			bool bIncrease = view_as<bool>(StringToInt(sExploded[1]) == 1);
-
-			if(iEdge >= 2)
-			{
-				iEdge -= 2;
-
-				gV_Fix1[param1][iEdge] += (bIncrease? gF_Modifier[param1]:-gF_Modifier[param1]);
-			}
-
-			else
-			{
-				gV_Fix2[param1][iEdge] += (bIncrease? gF_Modifier[param1]:-gF_Modifier[param1]);
-			}
-
-			char changeText[64];
-			Format(changeText, sizeof(changeText), "%T", (bIncrease)? "ZoneIncreased":"ZoneDecreased", param1);
-
-			Shavit_PrintToChat(param1, "%T", "ZoneEdgeChange", param1, sEdges[iEdge], gS_ChatStrings[sMessageVariable2], changeText, gS_ChatStrings[sMessageText], gS_ChatStrings[sMessageVariable], gF_Modifier[param1], gS_ChatStrings[sMessageText]);
-
-			CreateWidthLengthMenu(param1, GetMenuSelectionPosition());
-		}
-	}
-
-	else if(action == MenuAction_End)
-	{
-		delete menu;
-	}
-}
-
-bool EmptyZone(float vZone[3])
-{
-	if(vZone[0] == 0.0 && vZone[1] == 0.0 && vZone[2] == 0.0)
-	{
-		return true;
-	}
-
-	return false;
-}
-
 void InsertZone(int client)
 {
-	MapZones type = gMZ_Type[client];
+	int type = gI_ZoneType[client];
 
 	char[] sQuery = new char[512];
 
@@ -1528,22 +1279,22 @@ void InsertZone(int client)
 		FormatEx(sQuery, 512, "INSERT INTO %smapzones (map, type, destination_x, destination_y, destination_z) VALUES ('%s', '%d', '%.03f', '%.03f', '%.03f');", gS_MySQLPrefix, gS_Map, type, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2]);
 	}
 
-	else if((EmptyZone(gV_MapZones[type][0]) && EmptyZone(gV_MapZones[type][1])) || type >= Zone_Freestyle) // insert
+	else if((EmptyVector(gV_MapZones[type][0]) && EmptyVector(gV_MapZones[type][1])) || type >= Zone_Respawn) // insert
 	{
 		if(type != Zone_Teleport)
 		{
-			FormatEx(sQuery, 512, "INSERT INTO %smapzones (map, type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, rot_ang, fix1_x, fix1_y, fix2_x, fix2_y) VALUES ('%s', '%d', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f');", gS_MySQLPrefix, gS_Map, type, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], gF_RotateAngle[client], gV_Fix1[client][0], gV_Fix1[client][1], gV_Fix2[client][0], gV_Fix2[client][1]);
+			FormatEx(sQuery, 512, "INSERT INTO %smapzones (map, type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, track) VALUES ('%s', '%d', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%d');", gS_MySQLPrefix, gS_Map, type, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], view_as<int>(gB_BonusZones[client]));
 		}
 
 		else
 		{
-			FormatEx(sQuery, 512, "INSERT INTO %smapzones (map, type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, rot_ang, fix1_x, fix1_y, fix2_x, fix2_y, destination_x, destination_y, destination_z) VALUES ('%s', '%d', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f');", gS_MySQLPrefix, gS_Map, type, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], gF_RotateAngle[client], gV_Fix1[client][0], gV_Fix1[client][1], gV_Fix2[client][0], gV_Fix2[client][1], gV_Teleport[client][0], gV_Teleport[client][1], gV_Teleport[client][2]);
+			FormatEx(sQuery, 512, "INSERT INTO %smapzones (map, type, corner1_x, corner1_y, corner1_z, corner2_x, corner2_y, corner2_z, destination_x, destination_y, destination_z) VALUES ('%s', '%d', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f', '%.03f');", gS_MySQLPrefix, gS_Map, type, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], gV_Teleport[client][0], gV_Teleport[client][1], gV_Teleport[client][2]);
 		}
 	}
 
 	else // update
 	{
-		FormatEx(sQuery, 512, "UPDATE %smapzones SET corner1_x = '%.03f', corner1_y = '%.03f', corner1_z = '%.03f', corner2_x = '%.03f', corner2_y = '%.03f', corner2_z = '%.03f', rot_ang = '%.03f', fix1_x = '%.03f', fix1_y = '%.03f', fix2_x = '%.03f', fix2_y = '%.03f' WHERE map = '%s' AND type = '%d';", gS_MySQLPrefix, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], gF_RotateAngle[client], gV_Fix1[client][0], gV_Fix1[client][1], gV_Fix2[client][0], gV_Fix2[client][1], gS_Map, type);
+		FormatEx(sQuery, 512, "UPDATE %smapzones SET corner1_x = '%.03f', corner1_y = '%.03f', corner1_z = '%.03f', corner2_x = '%.03f', corner2_y = '%.03f', corner2_z = '%.03f' WHERE map = '%s' AND type = '%d' AND track = '%d';", gS_MySQLPrefix, gV_Point1[client][0], gV_Point1[client][1], gV_Point1[client][2], gV_Point2[client][0], gV_Point2[client][1], gV_Point2[client][2], gS_Map, type, view_as<int>(gB_BonusZones[client]));
 	}
 
 	gH_SQL.Query(SQL_InsertZone_Callback, sQuery, GetClientSerial(client));
@@ -1565,40 +1316,35 @@ public void SQL_InsertZone_Callback(Database db, DBResultSet results, const char
 		return;
 	}
 
-	if(gMZ_Type[client] == Zone_CustomSpawn)
+	if(gI_ZoneType[client] == Zone_CustomSpawn)
 	{
 		Shavit_PrintToChat(client, "%T", "ZoneCustomSpawnSuccess", client);
 	}
 
-	UnloadZones((gMZ_Type[client] >= Zone_Freestyle && gMZ_Type[client] != Zone_CustomSpawn)? 0:view_as<int>(gMZ_Type[client]));
+	UnloadZones(0);
 	RefreshZones();
 	Reset(client);
 }
 
 public Action Timer_DrawEverything(Handle Timer)
 {
-	for(int i = 0; i < view_as<int>(Zone_Freestyle); i++)
+	if(gI_MapZones == 0)
 	{
-		if(gA_ZoneSettings[i][bVisible] && !EmptyZone(gV_MapZones[i][0]) || !EmptyZone(gV_MapZones[i][1]))
-		{
-			DrawToAll(gV_MapZones[i][0], gV_MapZones[i][1], gV_MapZonesFixes[i][0], gV_MapZonesFixes[i][1], view_as<MapZones>(i));
-		}
+		return Plugin_Continue;
 	}
 
-	for(int i = 0; i < MULTIPLEZONES_LIMIT; i++)
+	for(int i = 0; i < gI_MapZones; i++)
 	{
-		MapZones type = gMZ_FreestyleTypes[i] + view_as<MapZones>(1);
-
-		if(0 <= view_as<int>(type) <= MAX_ZONES && gA_ZoneSettings[type][bVisible] && (!EmptyZone(gV_FreestyleZones[i][0]) || !EmptyZone(gV_FreestyleZones[i][1])))
+		if(gA_ZoneCache[i][bZoneInitialized] && gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][bVisible])
 		{
-			DrawToAll(gV_FreestyleZones[i][0], gV_FreestyleZones[i][1], gV_FreeStyleZonesFixes[i][0], gV_FreeStyleZonesFixes[i][1], type);
+			DrawZone(gV_MapZones[i][0], gV_MapZones[i][1], GetZoneColors(i), gF_Interval);
 		}
 	}
 
 	return Plugin_Continue;
 }
 
-int[] GetZoneColors(MapZones type)
+int[] GetZoneColors(int type)
 {
 	int colors[4];
 	colors[0] = gA_ZoneSettings[type][iRed];
@@ -1607,27 +1353,6 @@ int[] GetZoneColors(MapZones type)
 	colors[3] = gA_ZoneSettings[type][iAlpha];
 
 	return colors;
-}
-
-void DrawToAll(float point1[3], float point2[3], float fix1[2], float fix2[2], MapZones type)
-{
-	float vPoints[8][3];
-	vPoints[0] = point1;
-	vPoints[7] = point2;
-
-	if(gEV_Type == Engine_CSS)
-	{
-		vPoints[0][2] += 2.0;
-		vPoints[7][2] += 2.0;
-	}
-
-	if(gI_ZoneStyle == 1)
-	{
-		vPoints[7][2] = vPoints[0][2];
-	}
-
-	CreateZonePoints(vPoints, 0.0, fix1, fix2, (type >= Zone_Freestyle)? -PLACEHOLDER:view_as<int>(type), false, true);
-	DrawZone(vPoints, gI_BeamSprite, gI_HaloSprite, GetZoneColors(type), gF_Interval + 0.2);
 }
 
 public Action Timer_Draw(Handle Timer, any data)
@@ -1650,7 +1375,7 @@ public Action Timer_Draw(Handle Timer, any data)
 
 	if(gI_MapStep[client] == 1 || (gV_Point2[client][0] == 0.0))
 	{
-		vOrigin[2] = (vPlayerOrigin[2] + 144.0);
+		vOrigin[2] = (vPlayerOrigin[2] + 128.0);
 	}
 
 	else
@@ -1658,38 +1383,26 @@ public Action Timer_Draw(Handle Timer, any data)
 		vOrigin = gV_Point2[client];
 	}
 
-	if(!EmptyZone(gV_Point1[client]) || !EmptyZone(gV_Point2[client]))
+	if(!EmptyVector(gV_Point1[client]) || !EmptyVector(gV_Point2[client]))
 	{
-		float vPoints[8][3];
-		vPoints[0] = gV_Point1[client];
-		vPoints[7] = vOrigin;
+		float point1[3];
+		point1 = gV_Point1[client];
 
-		if(gEV_Type == Engine_CSS)
-		{
-			vPoints[0][2] += 2.0;
-			vPoints[7][2] += 2.0;
-		}
+		float point2[3];
+		point2 = vOrigin;
 
-		CreateZonePoints(vPoints, gF_RotateAngle[client], gV_Fix1[client], gV_Fix2[client], PLACEHOLDER, false, true);
+		DrawZone(point1, point2, GetZoneColors(gI_ZoneType[client]), 0.1);
 
-		int iColors[4];
-		iColors[0] = gA_ZoneSettings[gMZ_Type[client]][iRed];
-		iColors[1] = gA_ZoneSettings[gMZ_Type[client]][iGreen];
-		iColors[2] = gA_ZoneSettings[gMZ_Type[client]][iBlue];
-		iColors[3] = 255;
-
-		DrawZone(vPoints, gI_BeamSprite, gI_HaloSprite, iColors, 0.1);
-
-		if(gMZ_Type[client] == Zone_Teleport && !EmptyZone(gV_Teleport[client]))
+		if(gI_ZoneType[client] == Zone_Teleport && !EmptyVector(gV_Teleport[client]))
 		{
 			TE_SetupEnergySplash(gV_Teleport[client], NULL_VECTOR, false);
 			TE_SendToAll(0.0);
 		}
 	}
 
-	if(gI_MapStep[client] != 3 && !EmptyZone(vOrigin))
+	if(gI_MapStep[client] != 3 && !EmptyVector(vOrigin))
 	{
-		vOrigin[2] -= 144.0;
+		vOrigin[2] -= 128.0;
 
 		TE_SetupBeamPoints(vPlayerOrigin, vOrigin, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 3.5, 3.5, 0, 0.0, {230, 83, 124, 175}, 0);
 		TE_SendToAll(0.0);
@@ -1698,350 +1411,54 @@ public Action Timer_Draw(Handle Timer, any data)
 	return Plugin_Continue;
 }
 
-bool UsedFixes(float[2][2] fixes)
+void DrawZone(float point1[3], float point2[3], int color[4], float life)
 {
-	for(int a = 0; a < 2; a++)
-	{
-		for(int b = 0; b < 2; b++)
-		{
-			if(fixes[a][b] > 0.0)
-			{
-				return true;
-			}
-		}
-	}
+	float box[8][3];
+	box[0] = point1;
+	box[7] = point2;
 
-	return false;
-}
+	CreateZonePoints(box);
 
-// by blacky https://forums.alliedmods.net/showthread.php?t=222822
-// Some of those functions are by ofir753. Thanks <3
-// I just remade it for SM 1.7, that's it.
-/*
-*
-* @param client - client to check
-* @param zone - zone to check (-PLACEHOLDER for freestyle 0, -zone for freestyle)
-*
-* returns true if a player is inside the given zone
-* returns false if they aren't in it
-*/
-bool InsideZone(int client, int zone)
-{
-	float playerPos[3];
-	GetEntPropVector(client, Prop_Send, "m_vecOrigin", playerPos);
-
-	playerPos[2] += 5.0;
-
-	float vPoints[8][3];
-
-	if(zone >= 0)
-	{
-		vPoints[0] = gV_MapZones[zone][0];
-		vPoints[7] = gV_MapZones[zone][1];
-
-		if(UsedFixes(gV_MapZonesFixes[zone]))
-		{
-			// Getting the original zone points with the fixes
-			CreateZonePoints(vPoints, 0.0, gV_MapZonesFixes[zone][0], gV_MapZonesFixes[zone][1], zone, true, false);
-		}
-
-		if(gF_MinusConstSin[zone] != 0.0 || gF_MinusConstCos[zone] != 0.0)
-		{
-			// Rotating the player so the box and the player will be on the same axis
-			PointConstRotate(gF_MinusConstSin[zone], gF_MinusConstCos[zone], vPoints[0], playerPos);
-		}
-	}
-
-	else
-	{
-		// Explanation above
-		if(zone == -PLACEHOLDER)
-		{
-			vPoints[0] = gV_FreestyleZones[0][0];
-			vPoints[7] = gV_FreestyleZones[0][1];
-
-			if(UsedFixes(gV_FreeStyleZonesFixes[0]))
-			{
-				CreateZonePoints(vPoints, 0.0, gV_FreeStyleZonesFixes[0][0], gV_FreeStyleZonesFixes[0][1], zone, true, false);
-			}
-
-			if(gF_FreeStyleMinusConstSin[0] != 0.0 || gF_FreeStyleMinusConstCos[0] != 0.0)
-			{
-				PointConstRotate(gF_FreeStyleMinusConstSin[0], gF_FreeStyleMinusConstCos[0], vPoints[0], playerPos);
-			}
-		}
-
-		else
-		{
-			vPoints[0] = gV_FreestyleZones[-zone][0];
-			vPoints[7] = gV_FreestyleZones[-zone][1];
-
-			if(UsedFixes(gV_FreeStyleZonesFixes[-zone]))
-			{
-				CreateZonePoints(vPoints, 0.0, gV_FreeStyleZonesFixes[-zone][0], gV_FreeStyleZonesFixes[-zone][1], zone, true, false);
-			}
-
-			if(gF_FreeStyleMinusConstSin[-zone] != 0.0 || gF_FreeStyleMinusConstCos[-zone] != 0.0)
-			{
-				PointConstRotate(gF_FreeStyleMinusConstSin[-zone], gF_FreeStyleMinusConstCos[-zone], vPoints[0], playerPos);
-			}
-		}
-	}
-
-	// Checking if player is inside the box after rotation
-	for(int i = 0; i < 3; i++)
-	{
-		if(vPoints[0][i] >= playerPos[i] == vPoints[7][i] >= playerPos[i])
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
-// like InsideZone but for teleport zones
-bool InsideTeleportZone(int client, int zone)
-{
-	float fPlayerPos[3];
-	GetEntPropVector(client, Prop_Send, "m_vecOrigin", fPlayerPos);
-
-	fPlayerPos[2] += 5.0;
-
-	float vPoints[8][3];
-	vPoints[0] = gV_FreestyleZones[zone][0];
-	vPoints[7] = gV_FreestyleZones[zone][1];
-
-	if(UsedFixes(gV_FreeStyleZonesFixes[zone]))
-	{
-		CreateZonePoints(vPoints, 0.0, gV_FreeStyleZonesFixes[zone][0], gV_FreeStyleZonesFixes[zone][1], zone, true, false);
-	}
-
-	if(gF_FreeStyleMinusConstSin[zone] != 0.0 || gF_FreeStyleMinusConstCos[zone] != 0.0)
-	{
-		PointConstRotate(gF_FreeStyleMinusConstSin[zone], gF_FreeStyleMinusConstCos[zone], vPoints[0], fPlayerPos);
-	}
-
-	// Checking if player is inside the box after rotation
-	for(int i = 0; i < 3; i++)
-	{
-		if(vPoints[0][i] >= fPlayerPos[i] == vPoints[7][i] >= fPlayerPos[i])
-		{
-			return false;
-		}
-	}
-
-	return true;
-}
-
-/*
-* Graphically draws a zone
-*    if client == 0, it draws it for all players in the game
-*   if client index is between 0 and MaxClients+1, it draws for the specified client
-*/
-void DrawZone(float array[8][3], int beamsprite, int halosprite, int color[4], float life)
-{
+	// this loop is by blacky, and i have no clue what i'm doing
+	// math isn't my thing :/
 	for(int i = 0, i2 = 3; i2 >= 0; i += i2--)
 	{
 		for(int j = 1; j <= 7; j += (j / 2) + 1)
 		{
 			if(j != 7 - i)
 			{
-				TE_SetupBeamPoints(array[i], array[j], beamsprite, halosprite, 0, 0, life, 5.0, 5.0, 0, 0.0, color, 0);
+				TE_SetupBeamPoints(box[i], box[j], gI_BeamSprite, gI_HaloSprite, 0, 0, life, 3.5, 3.5, 0, 0.0, color, 0);
 				TE_SendToAll(0.0);
 			}
 		}
 	}
 }
 
-// Rotating point around 2d axis
-void PointRotate(float angle, float axis[3], float point[3])
+// by blacky
+// creates 3d box from 2 points
+void CreateZonePoints(float point[8][3])
 {
-	/*
-	a - rotation degree as radians
-	x - old X
-	x' - new X
-	y - old Y
-	y' - new Y
-
-	Rotation Transformation formula:
-	x' = x cos(a) - y sin(a)
-	y' = y cos(a) + x sin(a)
-	*/
-
-	float transTmp[3];
-	transTmp[0] = point[0];
-	transTmp[1] = point[1];
-
-	// Moving point for axis = (0, 0)
-	transTmp[0] -= axis[0];
-	transTmp[1] -= axis[1];
-
-	float radian = DegToRad(angle);
-	float rotTmp[3];
-
-	// Rotating point (0, 0) as axis
-	rotTmp[0] = transTmp[0] * Cosine(radian) - transTmp[1] * Sine(radian);
-	rotTmp[1] = transTmp[1] * Cosine(radian) + transTmp[0] * Sine(radian);
-
-	// Moving point back
-	rotTmp[0] += axis[0];
-	rotTmp[1] += axis[1];
-
-	point[0] = rotTmp[0];
-	point[1] = rotTmp[1];
-}
-
-// Rotating point around 2d axis with constant sin and cos
-void PointConstRotate(float sin, float cos, float axis[3], float point[3])
-{
-	/*
-	a - rotation degree as radians
-	x - old X
-	x' - new X
-	y - old Y
-	y' - new Y
-
-	Rotation Transformation formula:
-	x' = x cos(a) - y sin(a)
-	y' = y cos(a) + x sin(a)
-	*/
-
-	float transTmp[3];
-	transTmp[0] = point[0];
-	transTmp[1] = point[1];
-
-	// Moving point for axis = (0, 0)
-	transTmp[0] -= axis[0];
-	transTmp[1] -= axis[1];
-
-	float rotTmp[3];
-	// Rotating point (0, 0) as axis
-	rotTmp[0] = transTmp[0] * cos - transTmp[1] * sin;
-	rotTmp[1] = transTmp[1] * cos + transTmp[0] * sin;
-
-	// Moving point back
-	rotTmp[0] += axis[0];
-	rotTmp[1] += axis[1];
-
-	point[0] = rotTmp[0];
-	point[1] = rotTmp[1];
-}
-
-// Translate 2D Point
-void PointTranslate(float point[3], float t[2])
-{
-	point[0] += t[0];
-	point[1] += t[1];
-}
-
-/*
-* Generates 8 points of a zone given just 2 of its points
-* angle - rotated angle for not constant zone (preview zone)
-* fix1 - edge fixes
-* fix2 - edge fixes
-* zone - PLACEHOLDER for not constant zone, -PLACEHOLDER for index 0 freestyle zone, zone id (- for free style zone)
-* norotate - don't rotate zone points
-* all - calculate all 8 zone points
-*/
-void CreateZonePoints(float point[8][3], float angle, float fix1[2], float fix2[2], int zone, bool norotate, bool all)
-{
-	if(all)
+	for(int i = 1; i < 7; i++)
 	{
-		for(int i = 1; i < 7; i++)
+		for(int j = 0; j < 3; j++)
 		{
-			for(int j = 0; j < 3; j++)
-			{
-				point[i][j] = point[((i >> (2-j)) & 1) * 7][j];
-			}
-		}
-	}
-
-	if(fix1[0] != 0.0 || fix2[0] != 0.0 || fix1[1] != 0.0 || fix2[1] != 0.0)
-	{
-		TranslateZone(point, fix1, fix2);
-	}
-
-	if(zone == PLACEHOLDER)
-	{
-		for(int i = 1; i < 8; i++)
-		{
-			if(zone == PLACEHOLDER)
-			{
-				PointRotate(angle, point[0], point[i]);
-			}
-		}
-	}
-
-	else if(!norotate)
-	{
-		if(zone >= 0 && zone != -PLACEHOLDER)
-		{
-			RotateZone(point, gF_ConstSin[zone], gF_ConstCos[zone]);
-		}
-
-		else
-		{
-			if(zone == -PLACEHOLDER)
-			{
-				RotateZone(point, gF_FreeStyleConstSin[0], gF_FreeStyleConstCos[0]);
-			}
-
-			else
-			{
-				RotateZone(point, gF_FreeStyleConstSin[-zone], gF_FreeStyleConstCos[-zone]);
-			}
+			point[i][j] = point[((i >> (2-j)) & 1) * 7][j];
 		}
 	}
 }
 
-// Translating Zone
-void TranslateZone(float point[8][3], float fix1[2], float fix2[2])
+public bool InsideZone(int client, int zone)
 {
-	float fix[2];
-
-	// X Translate
-	fix[1] = 0.0;
-	fix[0] = fix1[0];
-
-	PointTranslate(point[0], fix);
-	PointTranslate(point[1], fix);
-	PointTranslate(point[2], fix);
-	PointTranslate(point[3], fix);
-
-	fix[0] = fix2[0];
-	PointTranslate(point[4], fix);
-	PointTranslate(point[5], fix);
-	PointTranslate(point[6], fix);
-	PointTranslate(point[7], fix);
-
-	// Y Translate
-	fix[0] = 0.0;
-	fix[1] = fix1[1];
-
-	PointTranslate(point[0], fix);
-	PointTranslate(point[1], fix);
-	PointTranslate(point[4], fix);
-	PointTranslate(point[5], fix);
-
-	fix[1] = fix2[1];
-
-	PointTranslate(point[2], fix);
-	PointTranslate(point[3], fix);
-	PointTranslate(point[6], fix);
-	PointTranslate(point[7], fix);
+	// TODO: reimplement, set to private
+	return false;
 }
 
-//Rotating Zone by constant sin and cos
-void RotateZone(float point[8][3], float sin, float cos)
+public bool InsideTeleportZone(int client, int zone)
 {
-	for(int i = 1; i < 8; i++)
-	{
-		PointConstRotate(sin, cos, point[0], point[i]);
-	}
+	// TODO: remove, use zone type instead
+	return false;
 }
 
-// thanks a lot for those stuff, I couldn't do it without you blacky!
 void SQL_SetPrefix()
 {
 	char[] sFile = new char[PLATFORM_MAX_PATH];
@@ -2076,7 +1493,7 @@ void SQL_DBConnect()
 		gB_MySQL = StrEqual(sDriver, "mysql", false);
 
 		char[] sQuery = new char[1024];
-		FormatEx(sQuery, 1024, "CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` VARCHAR(128), `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `rot_ang` FLOAT NOT NULL default 0, `fix1_x` FLOAT NOT NULL default 0, `fix1_y` FLOAT NOT NULL default 0, `fix2_x` FLOAT NOT NULL default 0, `fix2_y` FLOAT NOT NULL default 0, `destination_x` FLOAT NOT NULL default 0, `destination_y` FLOAT NOT NULL default 0, `destination_z` FLOAT NOT NULL default 0, PRIMARY KEY (`id`));", gS_MySQLPrefix);
+		FormatEx(sQuery, 1024, "CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` VARCHAR(128), `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`));", gS_MySQLPrefix);
 
 		gH_SQL.Query(SQL_CreateTable_Callback, sQuery);
 	}
@@ -2092,10 +1509,10 @@ public void SQL_CreateTable_Callback(Database db, DBResultSet results, const cha
 	}
 
 	char[] sQuery = new char[64];
-	FormatEx(sQuery, 64, "SELECT rot_ang FROM %smapzones LIMIT 1;", gS_MySQLPrefix);
+	FormatEx(sQuery, 64, "SELECT destination_x FROM %smapzones LIMIT 1;", gS_MySQLPrefix);
 	gH_SQL.Query(SQL_TableMigration1_Callback, sQuery);
 
-	FormatEx(sQuery, 64, "SELECT destination_x FROM %smapzones LIMIT 1;", gS_MySQLPrefix);
+	FormatEx(sQuery, 64, "SELECT track FROM %smapzones LIMIT 1;", gS_MySQLPrefix);
 	gH_SQL.Query(SQL_TableMigration2_Callback, sQuery);
 }
 
@@ -2107,26 +1524,24 @@ public void SQL_TableMigration1_Callback(Database db, DBResultSet results, const
 
 		if(gB_MySQL)
 		{
-			FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD (`rot_ang` FLOAT NOT NULL default 0, `fix1_x` FLOAT NOT NULL default 0, `fix1_y` FLOAT NOT NULL default 0, `fix2_x` FLOAT NOT NULL default 0, `fix2_y` FLOAT NOT NULL default 0);", gS_MySQLPrefix);
+			FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD (`destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0);", gS_MySQLPrefix);
 			gH_SQL.Query(SQL_AlterTable1_Callback, sQuery);
 		}
 
 		else
 		{
-			FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD COLUMN `rot_ang` FLOAT NOT NULL default 0;", gS_MySQLPrefix);
-			gH_SQL.Query(SQL_AlterTable1_Callback, sQuery);
+			char[] sAxis = new char[4];
+			strcopy(sAxis, 4, "xyz");
 
-			for(int i = 1; i <= 2; i++)
+			for(int i = 0; i < 3; i++)
 			{
-				FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD COLUMN `fix%d_x` FLOAT NOT NULL default 0;", gS_MySQLPrefix, i);
-				gH_SQL.Query(SQL_AlterTable1_Callback, sQuery);
-
-				FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD COLUMN `fix%d_y` FLOAT NOT NULL default 0;", gS_MySQLPrefix, i);
+				FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD COLUMN `destination_%c` FLOAT NOT NULL DEFAULT 0;", gS_MySQLPrefix, sAxis[i]);
 				gH_SQL.Query(SQL_AlterTable1_Callback, sQuery);
 			}
 		}
 	}
 }
+
 
 public void SQL_AlterTable1_Callback(Database db, DBResultSet results, const char[] error, any data)
 {
@@ -2143,11 +1558,21 @@ public void SQL_TableMigration2_Callback(Database db, DBResultSet results, const
 	if(results == null)
 	{
 		char[] sQuery = new char[256];
-		FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD (`destination_x` FLOAT NOT NULL default 0, `destination_y` FLOAT NOT NULL default 0, `destination_z` FLOAT NOT NULL default 0);", gS_MySQLPrefix);
+
+		if(gB_MySQL)
+		{
+			FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD (`track` INT NOT NULL DEFAULT 0);", gS_MySQLPrefix);
+		}
+
+		else
+		{
+			FormatEx(sQuery, 256, "ALTER TABLE `%smapzones` ADD COLUMN `track` INTEGER NOT NULL DEFAULT 0;", gS_MySQLPrefix);
+		}
 
 		gH_SQL.Query(SQL_AlterTable2_Callback, sQuery);
 	}
 }
+
 
 public void SQL_AlterTable2_Callback(Database db, DBResultSet results, const char[] error, any data)
 {
@@ -2164,11 +1589,11 @@ public void SQL_AlterTable2_Callback(Database db, DBResultSet results, const cha
 
 public void Shavit_OnRestart(int client)
 {
-	if(gB_TeleportToStart && !EmptyZone(gV_MapZones[Zone_Start][0]) && !EmptyZone(gV_MapZones[Zone_Start][1]))
+	if(gB_TeleportToStart && GetZoneIndex(Zone_Start) != -1)
 	{
 		Shavit_StartTimer(client);
 
-		if(!EmptyZone(gF_CustomSpawn))
+		if(!EmptyVector(gF_CustomSpawn))
 		{
 			TeleportEntity(client, gF_CustomSpawn, NULL_VECTOR, view_as<float>({0.0, 0.0, 0.0}));
 		}
@@ -2190,7 +1615,7 @@ public void Shavit_OnRestart(int client)
 
 public void Shavit_OnEnd(int client)
 {
-	if(gB_TeleportToEnd && !EmptyZone(gV_MapZones[Zone_End][0]) && !EmptyZone(gV_MapZones[Zone_End][1]))
+	if(gB_TeleportToEnd && GetZoneIndex(Zone_End) != -1)
 	{
 		float vCenter[3];
 		MakeVectorFromPoints(gV_MapZones[1][0], gV_MapZones[1][1], vCenter);
@@ -2207,4 +1632,145 @@ public void Shavit_OnEnd(int client)
 public void Shavit_OnDatabaseLoaded(Database db)
 {
 	gH_SQL = db;
+}
+
+bool EmptyVector(float vec[3])
+{
+	return (vec[0] == 0.0 && vec[1] == 0.0 && vec[2] == 0.0);
+}
+
+// returns -1 if there's no zone
+int GetZoneIndex(int type, int start = 0)
+{
+	if(gI_MapZones == 0)
+	{
+		return -1;
+	}
+
+	if(start != 0)
+	{
+		start++;
+	}
+
+	for(int i = start; i < gI_MapZones; i++)
+	{
+		if(gA_ZoneCache[i][bZoneInitialized] && gA_ZoneCache[i][iZoneType] == type)
+		{
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+public void Round_Start(Event event, const char[] name, bool dontBroadcast)
+{
+	CreateTimer(1.0, Timer_CreateZoneEntities);
+}
+
+public Action Timer_CreateZoneEntities(Handle Timer)
+{
+	CreateZoneEntities();
+}
+
+float abs(float input)
+{
+	if(input < 0.0)
+	{
+		return -input;
+	}
+
+	return input;
+}
+
+public void CreateZoneEntities()
+{
+	for(int i = 0; i < gI_MapZones; i++)
+	{
+		if(gA_ZoneCache[i][iEntityID] != -1)
+		{
+			SDKUnhook(gA_ZoneCache[i][iEntityID], SDKHook_StartTouchPost, StartTouchPost);
+			SDKUnhook(gA_ZoneCache[i][iEntityID], SDKHook_EndTouchPost, EndTouchPost);
+
+			gA_ZoneCache[i][iEntityID] = -1;
+		}
+
+		if(!gA_ZoneCache[i][bZoneInitialized])
+		{
+			continue;
+		}
+
+		int entity = CreateEntityByName("trigger_multiple");
+
+		if(entity == -1)
+		{
+			LogError("\"trigger_multiple\" creation failed, map %s.", gS_Map);
+
+			continue;
+		}
+
+		DispatchKeyValue(entity, "spawnflags", "4097");
+		
+		if(!DispatchSpawn(entity))
+		{
+			LogError("\"trigger_multiple\" spawning failed, map %s.", gS_Map);
+
+			continue;
+		}
+
+		ActivateEntity(entity);
+		SetEntityModel(entity, "models/props/cs_office/vending_machine.mdl");
+		SetEntProp(entity, Prop_Send, "m_fEffects", 32);
+
+		float center[3];
+		center[0] = (gV_MapZones[i][0][0] + gV_MapZones[i][1][0]) * 0.5;
+		center[1] = (gV_MapZones[i][0][1] + gV_MapZones[i][1][1]) * 0.5;
+		center[2] = (gV_MapZones[i][0][2] + gV_MapZones[i][1][2]) * 0.5;
+
+		TeleportEntity(entity, center, NULL_VECTOR, NULL_VECTOR);
+
+		float distance_x = abs(gV_MapZones[i][0][0] - gV_MapZones[i][1][0]);
+		float distance_y = abs(gV_MapZones[i][0][1] - gV_MapZones[i][1][1]);
+		float distance_z = abs(gV_MapZones[i][0][2] - gV_MapZones[i][1][2]);
+
+		float min[3];
+		min[0] = -(distance_x / 2);
+		min[1] = -(distance_y / 2);
+		min[2] = -(distance_z / 2);
+		SetEntPropVector(entity, Prop_Send, "m_vecMins", min);
+
+		float max[3];
+		max[0] = distance_x / 2;
+		max[1] = distance_y / 2;
+		max[2] = distance_z / 2;
+		SetEntPropVector(entity, Prop_Send, "m_vecMaxs", max);
+
+		SetEntProp(entity, Prop_Send, "m_nSolidType", 2);
+
+		SDKHook(entity, SDKHook_StartTouchPost, StartTouchPost);
+		SDKHook(entity, SDKHook_EndTouchPost, EndTouchPost);
+
+		gI_EntityZone[entity] = i;
+		gA_ZoneCache[i][iEntityID] = entity;
+	}
+}
+
+public void StartTouchPost(int entity, int other)
+{
+	if(!IsValidClient(other, true))
+	{
+		return;
+	}
+
+	Shavit_PrintToChat(other, "Entered: %s", gS_ZoneNames[gA_ZoneCache[gI_EntityZone[entity]][iZoneType]]);
+}
+
+public void EndTouchPost(int entity, int other)
+{
+	if(!IsValidClient(other, true))
+	{
+		return;
+	}
+
+	Shavit_PrintToChat(other, "Left: %s", gS_ZoneNames[gA_ZoneCache[gI_EntityZone[entity]][iZoneType]]);
 }

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -181,6 +181,7 @@ public void OnPluginStart()
 	RegAdminCmd("sm_delspawn", Command_DelSpawn,  ADMFLAG_RCON, "Deletes a custom spawn location");
 
 	// events
+	HookEvent("player_spawn", Player_Spawn);
 	HookEvent("round_start", Round_Start);
 
 	// forwards
@@ -1629,6 +1630,11 @@ int GetZoneIndex(int type, int start = 0)
 	}
 
 	return -1;
+}
+
+public void Player_Spawn(Event event, const char[] name, bool dontBroadcast)
+{
+	Reset(GetClientOfUserId(event.GetInt("userid")));
 }
 
 public void Round_Start(Event event, const char[] name, bool dontBroadcast)

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -65,6 +65,7 @@ enum
 	iGreen,
 	iBlue,
 	iAlpha,
+	fWidth,
 	ZONESETTINGS_SIZE
 }
 
@@ -385,14 +386,7 @@ bool LoadZonesConfig()
 		gA_ZoneSettings[i][iGreen] = dZoneSettings.GetInt("green", 255);
 		gA_ZoneSettings[i][iBlue] = dZoneSettings.GetInt("blue", 255);
 		gA_ZoneSettings[i][iAlpha] = dZoneSettings.GetInt("alpha", 255);
-
-		// debug
-		/*
-			char[] sName = new char[32];
-			dZoneSettings.GetName(sName, 32);
-
-			PrintToServer("-- [DEBUG] [%s] [visible %d] [r %d] [g %d] [b %d] [a %d]", sName, gA_ZoneSettings[i][bVisible], gA_ZoneSettings[i][iRed], gA_ZoneSettings[i][iGreen], gA_ZoneSettings[i][iBlue], gA_ZoneSettings[i][iAlpha]);
-		*/
+		gA_ZoneSettings[i][fWidth] = dZoneSettings.GetFloat("width", 2.0);
 	}
 
 	dZones.Dispose(true);
@@ -1381,7 +1375,7 @@ public Action Timer_DrawEverything(Handle Timer)
 	{
 		if(gA_ZoneCache[i][bZoneInitialized] && gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][bVisible])
 		{
-			DrawZone(gV_MapZones[i], GetZoneColors(i), gF_Interval);
+			DrawZone(gV_MapZones[i], GetZoneColors(i), gF_Interval, gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][fWidth]);
 		}
 	}
 
@@ -1439,7 +1433,7 @@ public Action Timer_Draw(Handle Timer, any data)
 
 		CreateZonePoints(points);
 
-		DrawZone(points, GetZoneColors(gI_ZoneType[client]), 0.1);
+		DrawZone(points, GetZoneColors(gI_ZoneType[client]), 0.1, gA_ZoneSettings[gI_ZoneType[client]][fWidth]);
 
 		if(gI_ZoneType[client] == Zone_Teleport && !EmptyVector(gV_Teleport[client]))
 		{
@@ -1459,7 +1453,7 @@ public Action Timer_Draw(Handle Timer, any data)
 	return Plugin_Continue;
 }
 
-void DrawZone(float points[8][3], int color[4], float life)
+void DrawZone(float points[8][3], int color[4], float life, float width)
 {
 	// this loop is by blacky, and i have no clue what i'm doing
 	// math isn't my thing :/
@@ -1469,7 +1463,7 @@ void DrawZone(float points[8][3], int color[4], float life)
 		{
 			if(j != 7 - i)
 			{
-				TE_SetupBeamPoints(points[i], points[j], gI_BeamSprite, gI_HaloSprite, 0, 0, life, 3.5, 3.5, 0, 0.0, color, 0);
+				TE_SetupBeamPoints(points[i], points[j], gI_BeamSprite, gI_HaloSprite, 0, 0, life, width, width, 0, 0.0, color, 0);
 				TE_SendToAll(0.0);
 			}
 		}

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -57,6 +57,11 @@
 		"#format"	"{1:d}"
 		"en"		"Grid snap: x{1}"
 	}
+	"WallSnap"
+	{
+		"#format"	"{1:T}"
+		"en"		"Snap to wall: {1}"
+	}
 	// ---------- Zone Menu ---------- //
 	"ZoneAdjustCancel"
 	{

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -95,18 +95,9 @@
 	{
 		"en"		"Deleted all map zones succesfully"
 	}
-	"ZoneEdge"
-	{
-		"en"		"edge"
-	}
 	"ZoneFirst"
 	{
 		"en"		"FIRST"
-	}
-	"ZoneEdgeChange"
-	{
-		"#format"	"{1:s},{2:s},{3:s},{4:s},{5:s},{6:.01f},{7:s}"
-		"en"		"{1} edge {2}{3}{4} by {5}{6} degrees{7}."
 	}
 	"ZoneIncreased"
 	{

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -149,10 +149,6 @@
 	{
 		"en"		"No"
 	}
-	"ZoneSetRotate"
-	{
-		"en"		"Rotate zone"
-	}
 	"ZoneSetTP"
 	{
 		"en"		"Yes (choose teleport destination first)"

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -58,22 +58,6 @@
 		"en"		"Grid snap: x{1}"
 	}
 	// ---------- Zone Menu ---------- //
-	"Edge_Back"
-	{
-		"en"		"Back"
-	}
-	"Edge_Front"
-	{
-		"en"		"Front"
-	}
-	"Edge_Left"
-	{
-		"en"		"Left"
-	}
-	"Edge_Right"
-	{
-		"en"		"Right"
-	}
 	"ZoneAdjustCancel"
 	{
 		"en"		"Cancel"
@@ -162,25 +146,6 @@
 		"#format"	"{1:d},{2:c}"
 		"en"		"Point {1} | {2} axis"
 	}
-	"ZoneRotate"
-	{
-		"en"		"Rotate the zone.\nUse 'sm_modifier <number>' to set a new modifier"
-	}
-	"ZoneRotateNegative"
-	{
-		"#format"	"{1:.01f}"
-		"en"		"Rotate by -{1} degrees"
-	}
-	"ZoneRotatePlus"
-	{
-		"#format"	"{1:.01f}"
-		"en"		"Rotate by +{1} degrees"
-	}
-	"ZoneRotateSuccessful"
-	{
-		"#format"	"{1:s},{2:.01f},{3:s}"
-		"en"		"Zone rotated by {1}{2}{3} degrees."
-	}
 	"ZoneSecond"
 	{
 		"en"		"SECOND"
@@ -196,10 +161,6 @@
 	"ZoneSetRotate"
 	{
 		"en"		"Rotate zone"
-	}
-	"ZoneSetSize"
-	{
-		"en"		"Modify width/length"
 	}
 	"ZoneSetTP"
 	{
@@ -230,5 +191,22 @@
 	"ZoneTeleportInsideZone"
 	{
 		"en"		"You may not place a destination inside the teleport zone."
+	}
+	"ZoneEditMain"
+	{
+		"en"		"Main"
+	}
+	"ZoneEditBonus"
+	{
+		"en"		"Bonus"
+	}
+	"ZoneEditTrack"
+	{
+		"#format"	"{1:s}"
+		"en"		"Zone track: {1}"
+	}
+	"ZoneChangeTrack"
+	{
+		"en"		"Change zone track"
 	}
 }


### PR DESCRIPTION
- Fixes #161.

I have restructured the whole zones plugin which will result in MASSIVE optimizations and ease of use, including:
* Tracks are now a thing. There isn't any implementation for them in other modules yet, but the backend is mostly ready.
* The whole code is much much better. It's easier to read, to understand and to work with.
* 3D boxes will not be generated often at all, but instead only once (when the zones are loaded from the database).
* The hard limit for zones right now is 64, but shouldn't be an issue to increase. AFAIK Source limits entities to a certain amount, and now zones are based on `trigger_multiple` so it's a failsafe. The value can be safely increased from within `shavit.inc` for CS:GO as the hard cap for entities is 4096 there.
* Zones use `trigger_multiple`s now, which results in lower CPU usage. Should make everything feel much more precise and responsive.
* Zones are now modular. There are forwards for entering and leaving zones too. See `Shavit_OnEnterZone` and `Shavit_OnLeaveZone`. New zones will be extremely easy to add.
* I have dropped support for drawing of flat zones. This is honestly because I'm absolutely crap at anything that has to do with basic math, and the previous solution would just flat out all the 8 zone points which is bad.
* There's an enumeration for zone cache, so I can add zone settings later on easily without any big refactors.
* You can now create multiple zones of each kind (except for start/end zone).
* I've dropped support for rotated/fixed zones due to working with `trigger_multiple` instead of pure math now.

Expect much higher server performance.

I'd love to see some testing before I merge this huge pull request! Please leave your feedback and report any issue/incompatibility that you may find.