### PR TITLE
More additions

### DIFF
--- a/configs/shavit-styles.cfg
+++ b/configs/shavit-styles.cfg
@@ -12,6 +12,7 @@
 		"shortname"			"NM" // short style name
 		"htmlcolor"			"797FD4" // HUD style color (CS:GO only)
 		"command"			"n; nm; normal" // commands to register for style changing, leave empty for no command. use a semicolon as a delimiter - requires server restart
+		"clantag"			"N" // short style name for the clantag, not exactly the same as shortname
 
 		// jumping settings
 		"autobhop"			"1" // enable autobhopping and +ds?
@@ -62,6 +63,7 @@
 		"shortname"			"SW"
 		"htmlcolor"			"B54CB3"
 		"command"			"sw; side; sideways"
+		"clantag"			"SW"
 
 		"block_a"			"1"
 		"block_d"			"1"
@@ -80,6 +82,7 @@
 		"shortname"			"W"
 		"htmlcolor"			"9A59F0"
 		"command"			"w; wonly"
+		"clantag"			"W"
 
 		"block_a"			"1"
 		"block_s"			"1"
@@ -98,6 +101,7 @@
 		"shortname"			"SCR"
 		"htmlcolor"			"279BC2"
 		"command"			"le; legit; scr; scroll"
+		"clantag"			"LE"
 
 		"autobhop"			"0"
 		"easybhop"			"0"
@@ -118,6 +122,7 @@
 		"shortname"			"400VEL"
 		"htmlcolor"			"C9BB8B"
 		"command"			"400; 400vel; vel"
+		"clantag"			"400"
 
 		"autobhop"			"0"
 		"easybhop"			"0"
@@ -139,6 +144,7 @@
 		"shortname"			"HSW"
 		"htmlcolor"			"B54CBB"
 		"command"			"hsw; halfside; halfsideways"
+		"clantag"			"HSW"
 
 		"force_hsw"			"1"
 
@@ -156,6 +162,7 @@
 		"shortname"			"D"
 		"htmlcolor"			"9C5BBA"
 		"command"			"d; donly"
+		"clantag"			"D"
 
 		"autobhop"			"1"
 		"easybhop"			"1"
@@ -180,6 +187,7 @@
 		"shortname"			"LG"
 		"htmlcolor"			"DB88C2"
 		"command"			"lg; lowgrav"
+		"clantag"			"LG"
 
 		"gravity"			"0.6"
 
@@ -192,6 +200,7 @@
 		"shortname"			"SLOW"
 		"htmlcolor"			"C288DB"
 		"command"			"slow; slowmo"
+		"clantag"			"SLOW"
 
 		"speed"				"0.5"
 		"halftime"			"1"

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -280,9 +280,9 @@ stock void FormatSeconds(float time, char[] newtime, int newtimesize, bool preci
  * (WARNING: Will be called every tick when the player stands at the start zone!)
  *
  * @param client					Client index.
- * @noreturn
+ * @return							Plugin_Continue to do nothing or anything else to not start the timer.
  */
-forward void Shavit_OnStart(int client);
+forward Action Shavit_OnStart(int client);
 
 /**
  * Called when a player uses the restart command.
@@ -307,6 +307,15 @@ forward void Shavit_OnEnd(int client);
  * @noreturn
  */
 forward void Shavit_OnStop(int client);
+
+/**
+ * Called before a player finishes a map.
+ *
+ * @param client					Client index.
+ * @param snapshot					A snapshot of the player's timer.
+ * @return							Plugin_Continue to do nothing, Plugin_Changed to change the variables or anything else to stop the timer from finishing.
+ */
+forward Action Shavit_OnFinishPre(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
 
 /**
  * Called when a player finishes a map. (touches the end zone)

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -84,6 +84,7 @@ enum
 	sShortName,
 	sHTMLColor,
 	sChangeCommand,
+	sClanTag,
 	STYLESTRINGS_SIZE
 };
 

--- a/scripting/shavit-chat.sp
+++ b/scripting/shavit-chat.sp
@@ -315,8 +315,8 @@ void LoadConfig()
 			char[] sMessage = new char[255];
 			kvConfig.GetString("message", sMessage, 255);
 
-			char[] sClanTag = new char[32];
-			kvConfig.GetString("clantag", sClanTag, 32);
+			char[] sCustomClanTag = new char[32];
+			kvConfig.GetString("clantag", sCustomClanTag, 32);
 
 			// custom
 			if(StrContains(sBuffer[0], "[U:") != -1)
@@ -336,9 +336,9 @@ void LoadConfig()
 					gSM_Custom_Message.SetString(sBuffer, sMessage);
 				}
 
-				if(strlen(sClanTag) > 0)
+				if(strlen(sCustomClanTag) > 0)
 				{
-					gSM_Custom_ClanTag.SetString(sBuffer, sClanTag);
+					gSM_Custom_ClanTag.SetString(sBuffer, sCustomClanTag);
 				}
 			}
 
@@ -371,7 +371,7 @@ void LoadConfig()
 				gD_ChatRanks[gI_TotalChatRanks].SetString("prefix", sPrefix, 32);
 				gD_ChatRanks[gI_TotalChatRanks].SetString("name", (strlen(sName) > 0)? sName:"{name}", MAX_NAME_LENGTH*2);
 				gD_ChatRanks[gI_TotalChatRanks].SetString("message", (strlen(sMessage) > 0)? sMessage:"{message}", 255);
-				gD_ChatRanks[gI_TotalChatRanks].SetString("clantag", (strlen(sClanTag) > 0)? sClanTag:"", 32);
+				gD_ChatRanks[gI_TotalChatRanks].SetString("clantag", (strlen(sCustomClanTag) > 0)? sCustomClanTag:"", 32);
 
 				if(iFrom == -1 && gI_UnassignedTitle == -1)
 				{
@@ -771,11 +771,11 @@ void FormatVariables(int client, char[] buffer, int maxlen, const char[] formatt
 	GetClientName(client, sName, MAX_NAME_LENGTH);
 	ReplaceString(sTempFormattingRules, maxlen, "{name}", sName);
 
-	char[] sClanTag = new char[32];
-	CS_GetClientClanTag(client, sClanTag, 32);
-	int iLen = strlen(sClanTag);
-	sClanTag[iLen] = (iLen > 0)? ' ':'\0';
-	ReplaceString(sTempFormattingRules, maxlen, "{clan}", sClanTag);
+	char[] sCustomClanTag = new char[32];
+	CS_GetClientClanTag(client, sCustomClanTag, 32);
+	int iLen = strlen(sCustomClanTag);
+	sCustomClanTag[iLen] = (iLen > 0)? ' ':'\0';
+	ReplaceString(sTempFormattingRules, maxlen, "{clan}", sCustomClanTag);
 
 	ReplaceString(sTempFormattingRules, maxlen, "{message}", message);
 

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -1254,6 +1254,7 @@ bool LoadStyles()
 		dStyle.GetString("shortname", gS_StyleStrings[i][sShortName], 128);
 		dStyle.GetString("htmlcolor", gS_StyleStrings[i][sHTMLColor], 128);
 		dStyle.GetString("command", gS_StyleStrings[i][sChangeCommand], 128);
+		dStyle.GetString("clantag", gS_StyleStrings[i][sClanTag], 128);
 
 		gA_StyleSettings[i][bAutobhop] = dStyle.GetBool("autobhop", true);
 		gA_StyleSettings[i][bEasybhop] = dStyle.GetBool("easybhop", true);

--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -755,7 +755,7 @@ void UpdateSpectatorList(int client, Panel panel, bool &draw)
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
-		if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target)
+		if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target || GetClientTeam(i) < 1)
 		{
 			continue;
 		}
@@ -866,7 +866,7 @@ void UpdateKeyHint(int client)
 
 				for(int i = 1; i <= MaxClients; i++)
 				{
-					if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target)
+					if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target || GetClientTeam(i) < 1)
 					{
 						continue;
 					}

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -684,11 +684,13 @@ public void OnClientDisconnect(int client)
 	}
 }
 
-public void Shavit_OnStart(int client)
+public Action Shavit_OnStart(int client)
 {
 	ClearFrames(client);
 
 	gB_Record[client] = true;
+
+	return Plugin_Continue;
 }
 
 public void Shavit_OnStop(int client)

--- a/translations/shavit-wr.phrases.txt
+++ b/translations/shavit-wr.phrases.txt
@@ -132,6 +132,10 @@
 	{
 		"en"		"Player stats"
 	}
+	"WRDeleteRecord"
+	{
+		"en"		"Delete record"
+	}
 	"WRPointsCap"
 	{
 		"en"		"Points"

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -62,6 +62,11 @@
 		"#format"	"{1:T}"
 		"en"		"Snap to wall: {1}"
 	}
+	"CursorZone"
+	{
+		"#format"	"{1:T}"
+		"en"		"Use cursor position: {1}"
+	}
 	// ---------- Zone Menu ---------- //
 	"ZoneAdjustCancel"
 	{


### PR DESCRIPTION
* Added the ability to create zones by aiming for convenience.
* Added return values for timer start/end, example:

```sp
#include <sourcemod>
#include <shavit>

public Action Shavit_OnStart(int client)
{
	char[] name = new char[MAX_NAME_LENGTH];
	GetClientName(client, name, MAX_NAME_LENGTH);

	// fuck you woe
	if(StrEqual(client, "woe"))
	{
		return Plugin_Stop;
	}

	return Plugin_Continue;
}

public Action Shavit_OnFinishPre(int client, any snapshot[TIMERSNAPSHOT_SIZE])
{
	snapshot[bsStyle] = view_as<BhopStyle>(1);
	snapshot[iJumps] = 1;

	return Plugin_Changed;
}
```

Documentation:

```sp
/**
 * Called when a player's timer starts.
 * (WARNING: Will be called every tick when the player stands at the start zone!)
 *
 * @param client					Client index.
 * @return							Plugin_Continue to do nothing or anything else to not start the timer.
 */
forward Action Shavit_OnStart(int client);

/**
 * Called before a player finishes a map.
 *
 * @param client					Client index.
 * @param snapshot					A snapshot of the player's timer.
 * @return							Plugin_Continue to do nothing, Plugin_Changed to change the variables or anything else to stop the timer from finishing.
 */
forward Action Shavit_OnFinishPre(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
```
* Added the ability to remove records right from the WR sub-menu. (Idea taken from bTimes 2)
![WR submenu screenshot](https://user-images.githubusercontent.com/3672466/28131747-8fa10fb8-6743-11e7-93df-2df781de0071.png)

* Implemented custom clan tags. See `shavit_misc_clantag`.
![Custom clan tags demonstration](https://user-images.githubusercontent.com/3672466/28133595-3efdc8de-6749-11e7-8aca-05fd16dcf13d.png)

* Fixed an issue where unassigned players would be included in spectator lists. (#288)