### PR TITLE
Additions (!replay, SurfHSW and more)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,1 +1,30 @@
-list a complete list of features and commands per plugin/module here when out of beta
+# shavit's simple bhop timer
+*a bhop server should be simple*
+
+### Features
+---
+
+###### shavit-core (REQUIRED)
+`bhoptimer`'s core.  
+It handles connections to the database and exposes an API (natives/forwards) for developers and other modules.  
+Calculations, gameplay mechanics and such are all handled by the core plugin.
+
+Includes *but not limited to*: Custom chat messages and colors, snapshots, pausing/resuming, styles (configurable), automatic bunnyhopping, strafe/sync meters that work for most playstyles, double-step fixer (+ds), practice mode, +strafe blocking, +left/right blocking, pre-jump blocking, HSW style (including SHSW) that cannot be abused with joypads, per-style `sv_airaccelerate` values, teleportation commands (start/end).
+
+###### shavit-zones (REQUIRED)
+The zones plugins handles everything related to map zones (such as start/end zone etc) and is necessary for `bhoptimer` to operate.  
+Zones are trigger based and are very lightweight.
+
+The zones plugin includes some less common features such as: Zone editing (after setup), snapping zones to walls/corners/grid, zone setup using the cursor's position, configurable sprite/colors for zoone types, zone tracks (main/bonus - can be extended), manual adjustments of coordinates before confirmations, teleport zones, glitch zones, no-limit zones (for styles like 400-velocity), flat/3D boxes for zone rendering, an API and more.
+
+###### shavit-hud
+The HUD plugin is `bhoptimer`'s OSD frontend.  
+It shows most (if not all) of the information that the player needs to see.  
+`shavit-hud` integrates with [Bunnyhop Statistics](https://github.com/shavitush/bhopstats) for CS:S.
+
+Some features are: Per-player settings (!hud), truevel and gradient-like display (CS:GO).
+
+###### shavit-misc
+This plugin handles miscellaneous things used in bunnyhop servers.
+
+Such as: Team handling (respawning/spectating too), spectators list (!specs), smart player hiding that works for spectating too, teleportation to other players, weapon commands (!knife/!usp/!glock) and ammo management, segmented checkpoints, noclipping (can be set to work for VIPs/admins only), drop-all, godmode, prespeed blocking, prespeed limitation, chat tidying, radar hiding, weapon drop cleaning, player collision removal, auto-respawning, spawn points generator, radio remobal, scoreboard manipulation, model opacity changes, fixed runspeed, automatic and configurable chat advertisements, player ragdoll removal and WR messages.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -15,7 +15,7 @@ Includes *but not limited to*: Custom chat messages and colors, snapshots, pausi
 The zones plugins handles everything related to map zones (such as start/end zone etc) and is necessary for `bhoptimer` to operate.  
 Zones are trigger based and are very lightweight.
 
-The zones plugin includes some less common features such as: Zone editing (after setup), snapping zones to walls/corners/grid, zone setup using the cursor's position, configurable sprite/colors for zoone types, zone tracks (main/bonus - can be extended), manual adjustments of coordinates before confirmations, teleport zones, glitch zones, no-limit zones (for styles like 400-velocity), flat/3D boxes for zone rendering, an API and more.
+The zones plugin includes some less common features such as: Zone editing (after setup), snapping zones to walls/corners/grid, zone setup using the cursor's position, configurable sprite/colors for zone types, zone tracks (main/bonus - can be extended), manual adjustments of coordinates before confirmations, teleport zones, glitch zones, no-limit zones (for styles like 400-velocity), flat/3D boxes for zone rendering, an API and more.
 
 #### shavit-hud
 The HUD plugin is `bhoptimer`'s OSD frontend.  
@@ -27,7 +27,7 @@ Some features are: Per-player settings (!hud), truevel and gradient-like display
 #### shavit-misc
 This plugin handles miscellaneous things used in bunnyhop servers.
 
-Such as: Team handling (respawning/spectating too), spectators list (!specs), smart player hiding that works for spectating too, teleportation to other players, weapon commands (!knife/!usp/!glock) and ammo management, segmented checkpoints, noclipping (can be set to work for VIPs/admins only), drop-all, godmode, prespeed blocking, prespeed limitation, chat tidying, radar hiding, weapon drop cleaning, player collision removal, auto-respawning, spawn points generator, radio remobal, scoreboard manipulation, model opacity changes, fixed runspeed, automatic and configurable chat advertisements, player ragdoll removal and WR messages.
+Such as: Team handling (respawning/spectating too), spectators list (!specs), smart player hiding that works for spectating too, teleportation to other players, weapon commands (!knife/!usp/!glock) and ammo management, segmented checkpoints, noclipping (can be set to work for VIPs/admins only), drop-all, godmode, prespeed blocking, prespeed limitation, chat tidying, radar hiding, weapon drop cleaning, player collision removal, auto-respawning, spawn points generator, radio removal, scoreboard manipulation, model opacity changes, fixed runspeed, automatic and configurable chat advertisements, player ragdoll removal and WR messages.
 
 #### shavit-replay
 Creates a replay bot that records the players' world records and playback them on command (!replay/automatic).  
@@ -40,7 +40,7 @@ Such as: Getting a world record, improving your own record, getting the worst re
 
 #### shavit-stats
 The statistics plugin is a statistics frontend for the players.  
-It displays rankings, maps done, maps left, server records, SteamID, country, map completion, last login date and more useful infromation!
+It displays rankings, maps done, maps left, server records, SteamID, country, map completion, last login date and more useful information!
 
 #### shavit-timelimit
 Sets a dynamic map time limit according to the average completion time of the map.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,47 +4,47 @@
 ### Features
 ---
 
-###### shavit-core (REQUIRED)
+#### shavit-core (REQUIRED)
 `bhoptimer`'s core.  
 It handles connections to the database and exposes an API (natives/forwards) for developers and other modules.  
 Calculations, gameplay mechanics and such are all handled by the core plugin.
 
 Includes *but not limited to*: Custom chat messages and colors, snapshots, pausing/resuming, styles (configurable), automatic bunnyhopping, strafe/sync meters that work for most playstyles, double-step fixer (+ds), practice mode, +strafe blocking, +left/right blocking, pre-jump blocking, HSW style (including SHSW) that cannot be abused with joypads, per-style `sv_airaccelerate` values, teleportation commands (start/end).
 
-###### shavit-zones (REQUIRED)
+#### shavit-zones (REQUIRED)
 The zones plugins handles everything related to map zones (such as start/end zone etc) and is necessary for `bhoptimer` to operate.  
 Zones are trigger based and are very lightweight.
 
 The zones plugin includes some less common features such as: Zone editing (after setup), snapping zones to walls/corners/grid, zone setup using the cursor's position, configurable sprite/colors for zoone types, zone tracks (main/bonus - can be extended), manual adjustments of coordinates before confirmations, teleport zones, glitch zones, no-limit zones (for styles like 400-velocity), flat/3D boxes for zone rendering, an API and more.
 
-###### shavit-hud
+#### shavit-hud
 The HUD plugin is `bhoptimer`'s OSD frontend.  
 It shows most (if not all) of the information that the player needs to see.  
 `shavit-hud` integrates with [Bunnyhop Statistics](https://github.com/shavitush/bhopstats) for CS:S.
 
 Some features are: Per-player settings (!hud), truevel and gradient-like display (CS:GO).
 
-###### shavit-misc
+#### shavit-misc
 This plugin handles miscellaneous things used in bunnyhop servers.
 
 Such as: Team handling (respawning/spectating too), spectators list (!specs), smart player hiding that works for spectating too, teleportation to other players, weapon commands (!knife/!usp/!glock) and ammo management, segmented checkpoints, noclipping (can be set to work for VIPs/admins only), drop-all, godmode, prespeed blocking, prespeed limitation, chat tidying, radar hiding, weapon drop cleaning, player collision removal, auto-respawning, spawn points generator, radio remobal, scoreboard manipulation, model opacity changes, fixed runspeed, automatic and configurable chat advertisements, player ragdoll removal and WR messages.
 
-###### shavit-replay
+#### shavit-replay
 Creates a replay bot that records the players' world records and playback them on command (!replay/automatic).  
 The replay bot playback can be stopped (if central) and the saved replay can be deleted by server administrators.  
 Replay bots will change their clan tags/names according to the server's configuration.
 
-###### shavit-sounds
+#### shavit-sounds
 Will play custom sounds when event actions happen.  
 Such as: Getting a world record, improving your own record, getting the worst record in the server, beating a map for the first time or setting a rank #X record.
 
-###### shavit-stats
+#### shavit-stats
 The statistics plugin is a statistics frontend for the players.  
 It displays rankings, maps done, maps left, server records, SteamID, country, map completion, last login date and more useful infromation!
 
-###### shavit-timelimit
+#### shavit-timelimit
 Sets a dynamic map time limit according to the average completion time of the map.
 
-###### shavit-wr
+#### shavit-wr
 Saves the players' records to the database and allows players to see the server's records.  
 The ability to see records for other maps also exists and can be lazily looked up (!wr map_name, or a part of the map's name).

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -28,3 +28,23 @@ Some features are: Per-player settings (!hud), truevel and gradient-like display
 This plugin handles miscellaneous things used in bunnyhop servers.
 
 Such as: Team handling (respawning/spectating too), spectators list (!specs), smart player hiding that works for spectating too, teleportation to other players, weapon commands (!knife/!usp/!glock) and ammo management, segmented checkpoints, noclipping (can be set to work for VIPs/admins only), drop-all, godmode, prespeed blocking, prespeed limitation, chat tidying, radar hiding, weapon drop cleaning, player collision removal, auto-respawning, spawn points generator, radio remobal, scoreboard manipulation, model opacity changes, fixed runspeed, automatic and configurable chat advertisements, player ragdoll removal and WR messages.
+
+###### shavit-replay
+Creates a replay bot that records the players' world records and playback them on command (!replay/automatic).  
+The replay bot playback can be stopped (if central) and the saved replay can be deleted by server administrators.  
+Replay bots will change their clan tags/names according to the server's configuration.
+
+###### shavit-sounds
+Will play custom sounds when event actions happen.  
+Such as: Getting a world record, improving your own record, getting the worst record in the server, beating a map for the first time or setting a rank #X record.
+
+###### shavit-stats
+The statistics plugin is a statistics frontend for the players.  
+It displays rankings, maps done, maps left, server records, SteamID, country, map completion, last login date and more useful infromation!
+
+###### shavit-timelimit
+Sets a dynamic map time limit according to the average completion time of the map.
+
+###### shavit-wr
+Saves the players' records to the database and allows players to see the server's records.  
+The ability to see records for other maps also exists and can be lazily looked up (!wr map_name, or a part of the map's name).

--- a/configs/shavit-advertisements.cfg
+++ b/configs/shavit-advertisements.cfg
@@ -17,8 +17,8 @@
 //
 "Advertisements"
 {
-    "0" "You may write {variable}!hide{text} to {variable2}hide{text} other players."
-    "1" "The command {variable}!r{text} will {variable2}restart your timer{text}."
-    "2" "{variable}!recent{text} can be used to see the latest world records set!"
-    "3" "{variable}!style{text} will open a menu with every {variable2}bhop style{text} the server has to offer."
+	"0" "You may write {variable}!hide{text} to {variable2}hide{text} other players."
+	"1" "The command {variable}!r{text} will {variable2}restart your timer{text}."
+	"2" "{variable}!recent{text} can be used to see the latest world records set!"
+	"3" "{variable}!style{text} will open a menu with every {variable2}bhop style{text} the server has to offer."
 }

--- a/configs/shavit-chat.cfg
+++ b/configs/shavit-chat.cfg
@@ -46,65 +46,65 @@
 //
 "Chat"
 {
-    "[U:1:204506329]" // my steamid for example, use steamid3
-    {
-        "prefix"        "{green}/dev/"
-        "name"          "{default}{team}{clan}{name}"
+	"[U:1:204506329]" // my steamid for example, use steamid3
+	{
+		"prefix"        "{green}/dev/"
+		"name"          "{default}{team}{clan}{name}"
 		"clantag"		"shave"
-    }
+	}
 
-    "-1" // lookup is due, shouldn't happen unless there's some error!
-    {
-        "rank_from"     "-1"
-        "rank_to"       "-1"
+	"-1" // lookup is due, shouldn't happen unless there's some error!
+	{
+		"rank_from"     "-1"
+		"rank_to"       "-1"
 
-        "prefix"        ""
-        "name"          "{team}{name}"
-        "message"       "{message}"
-    }
+		"prefix"        ""
+		"name"          "{team}{name}"
+		"message"       "{message}"
+	}
 
-    "0" // unranked
-    {
-        "rank_from"     "0"
-        "rank_to"       "0"
+	"0" // unranked
+	{
+		"rank_from"     "0"
+		"rank_to"       "0"
 
-        "prefix"        "[Unranked]"
-        "name"          "{team}{name}"
-        "message"       "{message}"
-    }
+		"prefix"        "[Unranked]"
+		"name"          "{team}{name}"
+		"message"       "{message}"
+	}
 
-    "1"
-    {
-        "rank_from"     "1"
-        "rank_to"       "1"
+	"1"
+	{
+		"rank_from"     "1"
+		"rank_to"       "1"
 
-        "prefix"        "{green}ONE TRUE GOD"
-        "name"          "{clan}{team}{name}"
-    }
+		"prefix"        "{green}ONE TRUE GOD"
+		"name"          "{clan}{team}{name}"
+	}
 
-    "2"
-    {
-        "rank_from"     "2"
-        "rank_to"       "2"
+	"2"
+	{
+		"rank_from"     "2"
+		"rank_to"       "2"
 
-        "prefix"        "LEGENDARY"
-        "name"          "{name}"
-    }
+		"prefix"        "LEGENDARY"
+		"name"          "{name}"
+	}
 
-    "3"
-    {
-        "rank_from"     "3"
-        "rank_to"       "3"
+	"3"
+	{
+		"rank_from"     "3"
+		"rank_to"       "3"
 
-        "prefix"        "HERO"
-        "name"          "{team}{name}"
-    }
+		"prefix"        "HERO"
+		"name"          "{team}{name}"
+	}
 
-    "4"
-    {
-        "rank_from"     "4"
-        "rank_to"       "infinity"
+	"4"
+	{
+		"rank_from"     "4"
+		"rank_to"       "infinity"
 
-        "prefix"        "scrub!"
-    }
+		"prefix"        "scrub!"
+	}
 }

--- a/configs/shavit-readme.txt
+++ b/configs/shavit-readme.txt
@@ -1,4 +1,8 @@
-shavit-sounds.cfg is the configuration file for timer sounds.
-shavit-prefix.txt is the configuration file for the plugin's mysql prefix. do not touch unless you know what you are doing!
+shavit-advertisements.cfg is the file used to determine how shavit-misc posts advertisements to the server.
 shavit-chat.cfg is the configuration file for chat titles, colors and all this kind of stuff.
+shavit-messages.cfg is the configuration file for chat colors/prefixes etc.
+shavit-prefix.txt is the configuration file for the plugin's mysql prefix. do not touch unless you know what you are doing!
+shavit-replay.cfg is the configuration file used for the replay bot's name styling.
+shavit-sounds.cfg is the configuration file for timer sounds.
+shavit-styles.cfg is used to configure custom style settings for the server.
 shavit-zones.cfg is where you can choose your own zone sprites. comment the CS:S lines and uncomment the CS:GO lines if you need.

--- a/configs/shavit-replay.cfg
+++ b/configs/shavit-replay.cfg
@@ -1,0 +1,32 @@
+// Configuration file for replay bot styling.
+//
+// WARNING: DO NOT DELETE/ADD YOUR OWN KEYS!
+// WARNING: IF YOU DISABLE THE CENTRAL REPLAY BOT - MAKE SURE BOT NAMES CONTAIN A VARIABLE OR YOU'LL END UP WITH A MESS!
+//
+// The replay bot clan/name styling will be loaded from this file.
+// A central bot is the replay bot that can play all styles. It's enabled by default with "shavit_replay_centralbot".
+//
+// Keys:
+// "clantag" - clan tag for replay bots (central or not) to use.
+// "namestyle" - this is the name style replay bots will use. Including the central bot, as long as it's during playback.
+// "centralname" - the central bot's idle name, AKA when nothing is playing.
+// "centralstyle" - {style} value for the central bot (when idle).
+// "centralstyletag" - {styletag} value for the central bot (when idle).
+// "unloaded" - text to show for unloaded replay data. (will never show up for central bots.)
+//
+// Variables:
+// {map} - current map.
+// {style} - the style name.
+// {styletag} - the style's tag. See "styletag" in "shavit-styles.cfg".
+// {time} - formatted time for the WR currently being played.
+// {player} - the name of the player that holds the record.
+//
+"Replay"
+{
+	"clantag" "REPLAY"
+	"namestyle" "{style} - {time}"
+	"centralname" "!replay"
+	"centralstyle" "!replay"
+	"centralstyletag" "!replay"
+	"unloaded" "{style} - N/A"
+}

--- a/configs/shavit-sounds.cfg
+++ b/configs/shavit-sounds.cfg
@@ -9,6 +9,7 @@
 // first - first record on map and style ever
 // personal - personal best
 // world - new server WR
+// worst - worst record for the track/style
 // number - rank on map, only one per rank (example: "1" "shavit/pro.mp3"), will play for every player. overrides others
 "first" "shavit/fr_1.mp3"
 "personal" "shavit/pb_1.mp3"

--- a/configs/shavit-styles.cfg
+++ b/configs/shavit-styles.cfg
@@ -34,7 +34,7 @@
 		"block_s"			"0" // block +back
 		"block_d"			"0" // block +moveright
 		"block_use"			"0" // block +use
-		"force_hsw"			"0" // force half-sideways
+		"force_hsw"			"0" // force half-sideways (1 - HSW, 2 - SHSW)
 		"block_pleft"		"0" // block +left (doesn't take effect with shavit_core_blockleftright 1)
 		"block_pright"		"0" // block +left (doesn't take effect with shavit_core_blockleftright 1)
 		"block_pstrafe"		"0" // stops timer on +strafe usage

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -220,6 +220,7 @@ enum
 	iZoneType,
 	iZoneTrack, // 0 - main, 1 - bonus
 	iEntityID,
+	iDatabaseID,
 	ZONECACHE_SIZE
 };
 

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -24,7 +24,7 @@
 #define _shavit_included
 
 #if !defined _dynamic_included
-  #include <dynamic>
+	#include <dynamic>
 #endif
 
 #pragma newdecls required
@@ -141,6 +141,7 @@ enum
 	iTotalMeasures,
 	iGoodGains,
 	fServerTime,
+	iSHSWCombination,
 	TIMERSNAPSHOT_SIZE
 };
 

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -100,7 +100,7 @@ enum
 	bBlockS,
 	bBlockD,
 	bBlockUse,
-	bForceHSW,
+	iForceHSW,
 	bBlockPLeft,
 	bBlockPRight,
 	bBlockPStrafe,

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -75,7 +75,8 @@ enum ReplayStatus(+=1)
 {
 	Replay_Start = 0,
 	Replay_Running,
-	Replay_End
+	Replay_End,
+	Replay_Idle
 };
 
 enum

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -57,12 +57,6 @@ enum ServerGame(+=1)
 	Game_Unknown
 };
 
-// old enum was used for style configuration and is now here for reference
-enum BhopStyle(+=1)
-{
-	Style_Default = 0
-};
-
 // status
 enum TimerStatus(+=1)
 {
@@ -331,7 +325,7 @@ forward Action Shavit_OnFinishPre(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
  * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
  * @noreturn
  */
-forward void Shavit_OnFinish(int client, BhopStyle style, float time, int jumps, int strafes, float sync);
+forward void Shavit_OnFinish(int client, int style, float time, int jumps, int strafes, float sync);
 
 /**
  * Like Shavit_OnFinish, but after the insertion query was called.
@@ -347,7 +341,7 @@ forward void Shavit_OnFinish(int client, BhopStyle style, float time, int jumps,
  * @param overwrite					1 - brand new record. 2 - update.
  * @noreturn
  */
-forward void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int jumps, int strafes, float sync, int rank, int overwrite);
+forward void Shavit_OnFinish_Post(int client, int style, float time, int jumps, int strafes, float sync, int rank, int overwrite);
 
 /**
  * Called when there's a new WR on the map.
@@ -360,7 +354,7 @@ forward void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int j
  * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
  * @noreturn
  */
-forward void Shavit_OnWorldRecord(int client, BhopStyle style, float time, int jumps, int strafes, float sync);
+forward void Shavit_OnWorldRecord(int client, int style, float time, int jumps, int strafes, float sync);
 
 /**
  * Called when an admin deletes a WR.
@@ -369,7 +363,7 @@ forward void Shavit_OnWorldRecord(int client, BhopStyle style, float time, int j
  * @param id						Record ID. -1 if mass deletion.
  * @noreturn
  */
-forward void Shavit_OnWRDeleted(BhopStyle style, int id);
+forward void Shavit_OnWRDeleted(int style, int id);
 
 /**
  * Called when a player's timer paused.
@@ -397,14 +391,14 @@ forward void Shavit_OnResume(int client);
 forward void Shavit_OnRankUpdated(int client);
 
 /**
- * Called when a player changes his bhopstyle.
+ * Called when a player changes their bhopstyle.
  *
  * @param client					Client index.
  * @param oldstyle					Old bhop style.
  * @param newstyle					New bhop style.
  * @noreturn
  */
-forward void Shavit_OnStyleChanged(int client, BhopStyle oldstyle, BhopStyle newstyle);
+forward void Shavit_OnStyleChanged(int client, int oldstyle, int newstyle);
 
 /**
  * Called when the styles configuration finishes loading and it's ready to load everything into the cache.
@@ -465,7 +459,7 @@ forward void Shavit_OnLeaveZone(int client, int type, int track, int id, int ent
  * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
  * @noreturn
  */
-forward void Shavit_OnWorstRecord(int client, BhopStyle style, float time, int jumps, int strafes, float sync);
+forward void Shavit_OnWorstRecord(int client, int style, float time, int jumps, int strafes, float sync);
 
 /**
  * Returns the game type the server is running.
@@ -511,7 +505,7 @@ native void Shavit_RestartTimer(int client);
 native void Shavit_StopTimer(int client);
 
 /**
- * Finishes the map for a player, with his current timer stats.
+ * Finishes the map for a player, with their current timer stats.
  * Will not teleport the player to anywhere, it's handled inside the mapzones plugin.
  *
  * @param client					Client index.
@@ -529,7 +523,7 @@ native void Shavit_FinishMap(int client);
  * @param started					Timer started?
  * @noreturn
  */
-native void Shavit_GetTimer(int client, float &time, int &jumps, BhopStyle &style, bool &started);
+native void Shavit_GetTimer(int client, float &time, int &jumps, int &style, bool &started);
 
 /**
  * Retrieve a client's current time.
@@ -553,7 +547,7 @@ native int Shavit_GetClientJumps(int client);
  * @param client					Client index.
  * @return                          Bhop style.
  */
-native BhopStyle Shavit_GetBhopStyle(int client);
+native int Shavit_GetBhopStyle(int client);
 
 /**
  * Retrieve a client's timer status
@@ -588,7 +582,7 @@ native float Shavit_GetSync(int client);
  * @param time						Reference to the time variable. 0.0 will be returned if no records.
  * @noreturn
  */
-native void Shavit_GetWRTime(BhopStyle style, float &time);
+native void Shavit_GetWRTime(int style, float &time);
 
 /**
  * Saves the WR's record ID for the current map on a variable.
@@ -598,7 +592,7 @@ native void Shavit_GetWRTime(BhopStyle style, float &time);
  * @param time						Reference to the time variable. 0.0 will be returned if no records.
  * @noreturn
  */
-native void Shavit_GetWRRecordID(BhopStyle style, int &recordid);
+native void Shavit_GetWRRecordID(int style, int &recordid);
 
 /**
  * Saves the WR's player name on the map on a variable.
@@ -608,7 +602,7 @@ native void Shavit_GetWRRecordID(BhopStyle style, int &recordid);
  * @param wrmaxlength				Max length for the string.
  * @noreturn
  */
-native void Shavit_GetWRName(BhopStyle style, char[] wrname, int wrmaxlength);
+native void Shavit_GetWRName(int style, char[] wrname, int wrmaxlength);
 
 /**
  * Saves the player's personal best time on a variable.
@@ -618,7 +612,7 @@ native void Shavit_GetWRName(BhopStyle style, char[] wrname, int wrmaxlength);
  * @param time						Reference to the time variable. 0.0 will be returned if no personal record.
  * @noreturn
  */
-native void Shavit_GetPlayerPB(int client, BhopStyle style, float &time);
+native void Shavit_GetPlayerPB(int client, int style, float &time);
 
 /**
  * Get the amount of records on the current map/style.
@@ -626,7 +620,7 @@ native void Shavit_GetPlayerPB(int client, BhopStyle style, float &time);
  * @param style						Bhop style.
  * @return							Amount of records.
  */
-native int Shavit_GetRecordAmount(BhopStyle style);
+native int Shavit_GetRecordAmount(int style);
 
 /**
  * Calculate potential rank for a given style and time.
@@ -635,7 +629,7 @@ native int Shavit_GetRecordAmount(BhopStyle style);
  * @param time						Time to check for.
  * @return							Amount of records.
  */
-native int Shavit_GetRankForTime(BhopStyle style, float time);
+native int Shavit_GetRankForTime(int style, float time);
 
 /**
  * Checks if a mapzone exists.
@@ -687,7 +681,7 @@ native void Shavit_ResumeTimer(int client);
  * @param time						Reference to save the time on.
  * @noreturn
  */
-native void Shavit_GetReplayBotFirstFrame(BhopStyle style, float &time);
+native void Shavit_GetReplayBotFirstFrame(int style, float &time);
 
 /**
  * Retrieve the replay bot's client index.
@@ -695,7 +689,7 @@ native void Shavit_GetReplayBotFirstFrame(BhopStyle style, float &time);
  * @param style						Bhop style.
  * @return							Client index for the replay bot.
  */
-native int Shavit_GetReplayBotIndex(BhopStyle style);
+native int Shavit_GetReplayBotIndex(int style);
 
 /**
  * Retrieve the replay bot's current played frame.
@@ -703,7 +697,7 @@ native int Shavit_GetReplayBotIndex(BhopStyle style);
  * @param style						Bhop style.
  * @return							Current played frame.
  */
-native int Shavit_GetReplayBotCurrentFrame(BhopStyle style);
+native int Shavit_GetReplayBotCurrentFrame(int style);
 
 /**
  * Checks if there's loaded replay data for a bhop style or not.
@@ -711,7 +705,7 @@ native int Shavit_GetReplayBotCurrentFrame(BhopStyle style);
  * @param style						Bhop style.
  * @return							Boolean value of if there's loaded replay data.
  */
-native bool Shavit_IsReplayDataLoaded(BhopStyle style);
+native bool Shavit_IsReplayDataLoaded(int style);
 
 /**
  * Gets player points.
@@ -787,7 +781,7 @@ native int Shavit_GetWRCount(int client);
 * @param StyleSettings				Reference to the settings array.
 * @return							SP_ERROR_NONE on success, anything else on failure.
 */
-native int Shavit_GetStyleSettings(BhopStyle style, any StyleSettings[STYLESETTINGS_SIZE]);
+native int Shavit_GetStyleSettings(int style, any StyleSettings[STYLESETTINGS_SIZE]);
 
 /**
  * Saves the style related strings on string references.
@@ -798,7 +792,7 @@ native int Shavit_GetStyleSettings(BhopStyle style, any StyleSettings[STYLESETTI
  * @param size						Max length for the buffer.
  * @return							SP_ERROR_NONE on success, anything else on failure.
  */
-native int Shavit_GetStyleStrings(BhopStyle style, int stringtype, char[] StyleStrings, int size);
+native int Shavit_GetStyleStrings(int style, int stringtype, char[] StyleStrings, int size);
 
 /**
  * Retrieves the amount of styles in the server.

--- a/scripting/include/shavit.inc
+++ b/scripting/include/shavit.inc
@@ -453,6 +453,20 @@ forward void Shavit_OnEnterZone(int client, int type, int track, int id, int ent
 forward void Shavit_OnLeaveZone(int client, int type, int track, int id, int entity);
 
 /**
+ * Called when a player gets the worst record in the server for the style.
+ * Note: Will be only called for ranked styles.
+ *
+ * @param client					Client index.
+ * @param style						Style the record was done on.
+ * @param time						Record time.
+ * @param jumps						Jumps amount.
+ * @param strafes					Amount of strafes.
+ * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
+ * @noreturn
+ */
+forward void Shavit_OnWorstRecord(int client, BhopStyle style, float time, int jumps, int strafes, float sync);
+
+/**
  * Returns the game type the server is running.
  *
  * @return							Game type. (See "enum ServerGame")
@@ -846,6 +860,7 @@ native void Shavit_SaveSnapshot(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
  *
  * @param client					Client index.
  * @param snapshot					Full snapshot of the client's timer.
+ * @noreturn
  */
 native void Shavit_LoadSnapshot(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
 
@@ -904,6 +919,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetRank");
 	MarkNativeAsOptional("Shavit_GetRankedPlayers");
 	MarkNativeAsOptional("Shavit_GetRankForTime");
+	MarkNativeAsOptional("Shavit_GetRecordAmount");
 	MarkNativeAsOptional("Shavit_GetReplayBotCurrentFrame");
 	MarkNativeAsOptional("Shavit_GetReplayBotFirstFrame");
 	MarkNativeAsOptional("Shavit_GetReplayBotIndex");

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -1630,21 +1630,13 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 					bool bStop = false;
 
 					// W/A S/D
-					if(gI_SHSW_FirstCombination[client] == 0)
-					{
-						if(iCombination != 0)
-						{
-							bStop = true;
-						}
-					}
-
+					if((gI_SHSW_FirstCombination[client] == 0 && iCombination != 0) ||
 					// W/D S/A
-					else if(gI_SHSW_FirstCombination[client] == 1)
+						(gI_SHSW_FirstCombination[client] == 1 && iCombination != 1) ||
+					// no valid combination & no valid input
+						(gI_SHSW_FirstCombination[client] == -1 && iCombination == -1))
 					{
-						if(iCombination != 1)
-						{
-							bStop = true;
-						}
+						bStop = true;
 					}
 
 					if(bStop)

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -64,7 +64,7 @@ float gF_PauseStartTime[MAXPLAYERS+1];
 float gF_PauseTotalTime[MAXPLAYERS+1];
 bool gB_ClientPaused[MAXPLAYERS+1];
 int gI_Jumps[MAXPLAYERS+1];
-BhopStyle gBS_Style[MAXPLAYERS+1];
+int gBS_Style[MAXPLAYERS+1];
 bool gB_Auto[MAXPLAYERS+1];
 int gI_ButtonCache[MAXPLAYERS+1];
 int gI_Strafes[MAXPLAYERS+1];
@@ -606,7 +606,7 @@ public Action Command_Style(int client, int args)
 			strcopy(sDisplay, 64, gS_StyleStrings[i][sStyleName]);
 		}
 
-		m.AddItem(sInfo, sDisplay, (view_as<int>(gBS_Style[client]) == i)? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
+		m.AddItem(sInfo, sDisplay, (gBS_Style[client] == i)? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
 	}
 
 	// should NEVER happen
@@ -628,9 +628,9 @@ public int StyleMenu_Handler(Menu m, MenuAction action, int param1, int param2)
 		char[] info = new char[16];
 		m.GetItem(param2, info, 16);
 
-		BhopStyle style = view_as<BhopStyle>(StringToInt(info));
+		int style = StringToInt(info);
 
-		if(view_as<int>(style) == -1)
+		if(style == -1)
 		{
 			return 0;
 		}
@@ -646,7 +646,7 @@ public int StyleMenu_Handler(Menu m, MenuAction action, int param1, int param2)
 	return 0;
 }
 
-void ChangeClientStyle(int client, BhopStyle style)
+void ChangeClientStyle(int client, int style)
 {
 	if(!IsValidClient(client))
 	{
@@ -679,7 +679,7 @@ void ChangeClientStyle(int client, BhopStyle style)
 	}
 
 	char[] sStyle = new char[4];
-	IntToString(view_as<int>(style), sStyle, 4);
+	IntToString(style, sStyle, 4);
 
 	SetClientCookie(client, gH_StyleCookie, sStyle);
 }
@@ -775,7 +775,7 @@ public int Native_GetClientJumps(Handle handler, int numParams)
 
 public int Native_GetBhopStyle(Handle handler, int numParams)
 {
-	return view_as<int>(gBS_Style[GetNativeCell(1)]);
+	return gBS_Style[GetNativeCell(1)];
 }
 
 public int Native_GetTimerStatus(Handle handler, int numParams)
@@ -1000,7 +1000,7 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	gF_PauseTotalTime[client] = view_as<float>(snapshot[fPauseTotalTime]);
 	gB_ClientPaused[client] = false; // Pausing is disabled in practice mode.
 	gI_Jumps[client] = view_as<int>(snapshot[iJumps]);
-	gBS_Style[client] = view_as<BhopStyle>(snapshot[bsStyle]);
+	gBS_Style[client] = snapshot[bsStyle];
 	gI_Strafes[client] = view_as<int>(snapshot[iStrafes]);
 	gI_TotalMeasures[client] = view_as<int>(snapshot[iTotalMeasures]);
 	gI_GoodGains[client] = view_as<int>(snapshot[iGoodGains]);
@@ -1146,7 +1146,7 @@ public void OnClientCookiesCached(int client)
 		style = StringToInt(sCookie);
 	}
 
-	gBS_Style[client] = view_as<BhopStyle>((style >= 0 && style < gI_Styles)? style:0);
+	gBS_Style[client] = (style >= 0 && style < gI_Styles)? style:0;
 
 	UpdateAutoBhop(client);
 }
@@ -1163,7 +1163,7 @@ public void OnClientPutInServer(int client)
 	gB_Auto[client] = true;
 	gB_DoubleSteps[client] = false;
 	gF_StrafeWarning[client] = 0.0;
-	gBS_Style[client] = view_as<BhopStyle>(0);
+	gBS_Style[client] = 0;
 	gB_PracticeMode[client] = false;
 	UpdateAutoBhop(client);
 
@@ -1320,7 +1320,7 @@ public Action Command_StyleChange(int client, int args)
 	char[] sCommand = new char[128];
 	GetCmdArg(0, sCommand, 128);
 
-	BhopStyle style = Style_Default;
+	int style = 0;
 
 	if(gSM_StyleCommands.GetValue(sCommand, style))
 	{

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -587,8 +587,8 @@ public Action Command_Style(int client, int args)
 		return Plugin_Handled;
 	}
 
-	Menu m = new Menu(StyleMenu_Handler);
-	m.SetTitle("%T\n%T\n ", "StyleMenuTitle", client, "StyleMenuCurrent", client, gS_StyleStrings[gBS_Style[client]][sStyleName]);
+	Menu menu = new Menu(StyleMenu_Handler);
+	menu.SetTitle("%T\n%T\n ", "StyleMenuTitle", client, "StyleMenuCurrent", client, gS_StyleStrings[gBS_Style[client]][sStyleName]);
 
 	for(int i = 0; i < gI_Styles; i++)
 	{
@@ -607,17 +607,22 @@ public Action Command_Style(int client, int args)
 			strcopy(sDisplay, 64, gS_StyleStrings[i][sStyleName]);
 		}
 
-		m.AddItem(sInfo, sDisplay, (gBS_Style[client] == i)? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
+		menu.AddItem(sInfo, sDisplay, (gBS_Style[client] == i)? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
 	}
 
 	// should NEVER happen
-	if(m.ItemCount == 0)
+	if(menu.ItemCount == 0)
 	{
-		m.AddItem("-1", "Nothing");
+		menu.AddItem("-1", "Nothing");
 	}
 
-	m.ExitButton = true;
-	m.Display(client, 20);
+	else if(menu.ItemCount <= ((gEV_Type == Engine_CSS)? 9:8))
+	{
+		menu.Pagination = MENU_NO_PAGINATION;
+	}
+
+	menu.ExitButton = true;
+	menu.Display(client, 20);
 
 	return Plugin_Handled;
 }

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -985,6 +985,7 @@ public int Native_SaveSnapshot(Handle handler, int numParams)
 	snapshot[iGoodGains] = gI_GoodGains[client];
 	snapshot[fServerTime] = GetEngineTime();
 	snapshot[fCurrentTime] = CalculateTime(client);
+	snapshot[iSHSWCombination] = gI_SHSW_FirstCombination[client];
 
 	return SetNativeArray(2, snapshot, TIMERSNAPSHOT_SIZE);
 }
@@ -1006,6 +1007,7 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	gI_TotalMeasures[client] = view_as<int>(snapshot[iTotalMeasures]);
 	gI_GoodGains[client] = view_as<int>(snapshot[iGoodGains]);
 	gF_StartTime[client] = GetEngineTime() - view_as<float>(snapshot[fCurrentTime]);
+	gI_SHSW_FirstCombination[client] = view_as<int>(snapshot[iSHSWCombination]);
 }
 
 void StartTimer(int client)

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -396,18 +396,10 @@ public void OnMapStart()
 
 public void OnConfigsExecuted()
 {
-	if(sv_enablebunnyhopping != null)
+	if(sv_enablebunnyhopping != null && gB_ForceBunnyhopping)
 	{
-		if(gB_ForceBunnyhopping)
-		{
-			sv_enablebunnyhopping.BoolValue = true;
-			sv_enablebunnyhopping.SetBounds(ConVarBound_Lower, true, 1.0);
-		}
-
-		else
-		{
-			sv_enablebunnyhopping.SetBounds(ConVarBound_Lower, true, 0.0);
-		}
+		sv_enablebunnyhopping.BoolValue = true;
+		sv_enablebunnyhopping.SetBounds(ConVarBound_Lower, true, 1.0);
 	}
 }
 

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -1049,8 +1049,8 @@ void StartTimer(int client)
 	gB_ClientPaused[client] = false;
 	gB_PracticeMode[client] = false;
 
-	SetEntityGravity(client, gA_StyleSettings[gBS_Style[client]][fGravityMultiplier]);
-	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", gA_StyleSettings[gBS_Style[client]][fSpeedMultiplier]);
+	SetEntityGravity(client, view_as<float>(gA_StyleSettings[gBS_Style[client]][fGravityMultiplier]));
+	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_StyleSettings[gBS_Style[client]][fSpeedMultiplier]));
 }
 
 void StopTimer(int client)

--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -74,6 +74,7 @@ int gI_GoodGains[MAXPLAYERS+1];
 bool gB_DoubleSteps[MAXPLAYERS+1];
 float gF_StrafeWarning[MAXPLAYERS+1];
 bool gB_PracticeMode[MAXPLAYERS+1];
+int gI_SHSW_FirstCombination[MAXPLAYERS+1]; // 0 - W/A S/A 1- W/D S/D
 
 float gF_HSW_Requirement = 0.0;
 StringMap gSM_StyleCommands = null;
@@ -1033,6 +1034,7 @@ void StartTimer(int client)
 		if(result == Plugin_Continue)
 		{
 			gB_TimerEnabled[client] = true;
+			gI_SHSW_FirstCombination[client] = -1;
 		}
 
 		else if(result == Plugin_Handled || result == Plugin_Stop)
@@ -1165,6 +1167,7 @@ public void OnClientPutInServer(int client)
 	gF_StrafeWarning[client] = 0.0;
 	gBS_Style[client] = 0;
 	gB_PracticeMode[client] = false;
+	gI_SHSW_FirstCombination[client] = -1;
 	UpdateAutoBhop(client);
 
 	if(AreClientCookiesCached(client))
@@ -1271,7 +1274,7 @@ bool LoadStyles()
 		gA_StyleSettings[i][bBlockS] = dStyle.GetBool("block_s", false);
 		gA_StyleSettings[i][bBlockD] = dStyle.GetBool("block_d", false);
 		gA_StyleSettings[i][bBlockUse] = dStyle.GetBool("block_use", false);
-		gA_StyleSettings[i][bForceHSW] = dStyle.GetBool("force_hsw", false);
+		gA_StyleSettings[i][iForceHSW] = dStyle.GetInt("force_hsw", 0);
 		gA_StyleSettings[i][bBlockPLeft] = dStyle.GetBool("block_pleft", false);
 		gA_StyleSettings[i][bBlockPRight] = dStyle.GetBool("block_pright", false);
 		gA_StyleSettings[i][bBlockPStrafe] = dStyle.GetBool("block_pstrafe", false);
@@ -1593,7 +1596,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 			// Theory about blocking non-HSW strafes while playing HSW:
 			// Block S and W without A or D.
 			// Block A and D without S or W.
-			if(gA_StyleSettings[gBS_Style[client]][bForceHSW])
+			if(gA_StyleSettings[gBS_Style[client]][iForceHSW] > 0)
 			{
 				bool bForward = ((buttons & IN_FORWARD) > 0 || vel[0] > gF_HSW_Requirement);
 				bool bMoveLeft = ((buttons & IN_MOVELEFT) > 0 || vel[1] < -gF_HSW_Requirement);

--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -431,7 +431,7 @@ void UpdateHUD(int client)
 	char[] sHintText = new char[512];
 	strcopy(sHintText, 512, "");
 
-	if((gI_HUDSettings[client] & HUD_ZONEHUD) > 0)
+	if(!IsFakeClient(target) && (gI_HUDSettings[client] & HUD_ZONEHUD) > 0)
 	{
 		if(Shavit_InsideZone(target, Zone_Start, -1))
 		{

--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -59,7 +59,7 @@ int gI_HUDSettings[MAXPLAYERS+1];
 int gI_NameLength = MAX_NAME_LENGTH;
 int gI_LastScrollCount[MAXPLAYERS+1];
 int gI_ScrollCount[MAXPLAYERS+1];
-BhopStyle gBS_Style[MAXPLAYERS+1];
+int gBS_Style[MAXPLAYERS+1];
 
 bool gB_Late = false;
 
@@ -214,9 +214,9 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 
 	for(int i = 0; i < styles; i++)
 	{
-		Shavit_GetStyleSettings(view_as<BhopStyle>(i), gA_StyleSettings[i]);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sStyleName, gS_StyleStrings[i][sStyleName], 128);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sHTMLColor, gS_StyleStrings[i][sHTMLColor], 128);
+		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
+		Shavit_GetStyleStrings(i, sStyleName, gS_StyleStrings[i][sStyleName], 128);
+		Shavit_GetStyleStrings(i, sHTMLColor, gS_StyleStrings[i][sHTMLColor], 128);
 	}
 
 	gI_Styles = styles;
@@ -591,13 +591,13 @@ void UpdateHUD(int client)
 
 		else if(gB_Replay)
 		{
-			BhopStyle style = view_as<BhopStyle>(0);
+			int style = 0;
 
 			for(int i = 0; i < gI_Styles; i++)
 			{
-				if(Shavit_GetReplayBotIndex(view_as<BhopStyle>(i)) == target)
+				if(Shavit_GetReplayBotIndex(i) == target)
 				{
-					style = view_as<BhopStyle>(i);
+					style = i;
 
 					break;
 				}
@@ -938,7 +938,7 @@ public int PanelHandler_Nothing(Menu m, MenuAction action, int param1, int param
 	return 0;
 }
 
-public void Shavit_OnStyleChanged(int client, BhopStyle oldstyle, BhopStyle newstyle)
+public void Shavit_OnStyleChanged(int client, int oldstyle, int newstyle)
 {
 	UpdateTopLeftHUD(client, false);
 

--- a/scripting/shavit-hud.sp
+++ b/scripting/shavit-hud.sp
@@ -932,7 +932,6 @@ int GetHUDTarget(int client)
 	return target;
 }
 
-
 public int PanelHandler_Nothing(Menu m, MenuAction action, int param1, int param2)
 {
 	// i don't need anything here

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -621,11 +621,6 @@ public MRESReturn DHook_GetMaxPlayerSpeed(int pThis, Handle hReturn)
 
 public Action Timer_Scoreboard(Handle Timer)
 {
-	if(!gB_Scoreboard)
-	{
-		return Plugin_Continue;
-	}
-
 	for(int i = 1; i <= MaxClients; i++)
 	{
 		if(!IsValidClient(i) || IsFakeClient(i))
@@ -633,9 +628,12 @@ public Action Timer_Scoreboard(Handle Timer)
 			continue;
 		}
 
-		UpdateScoreboard(i);
+		if(gB_Scoreboard)
+		{
+			UpdateScoreboard(i);
+		}
 
-		if(gB_ClanTag && IsPlayerAlive(i))
+		if(gB_ClanTag)
 		{
 			UpdateClanTag(i);
 		}
@@ -723,14 +721,16 @@ void UpdateClanTag(int client)
 {
 	char[] sTime = new char[16];
 
-	if(Shavit_GetTimerStatus(client) == Timer_Stopped)
+	float fTime = Shavit_GetClientTime(client);
+
+	if(Shavit_GetTimerStatus(client) == Timer_Stopped || fTime <= 0.0)
 	{
 		strcopy(sTime, 16, "N/A");
 	}
 
 	else
 	{
-		int time = RoundToFloor(Shavit_GetClientTime(client));
+		int time = RoundToFloor(fTime);
 
 		if(time < 60)
 		{
@@ -1682,6 +1682,11 @@ public void Player_Spawn(Event event, const char[] name, bool dontBroadcast)
 		{
 			UpdateScoreboard(client);
 		}
+
+		if(gB_ClanTag)
+		{
+			UpdateClanTag(client);
+		}
 	}
 
 	if(gB_NoBlock)
@@ -1786,6 +1791,7 @@ public void Shavit_OnFinish(int client)
 	}
 
 	UpdateScoreboard(client);
+	UpdateClanTag(client);
 }
 
 public Action Command_Drop(int client, const char[] command, int argc)

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -712,29 +712,38 @@ void UpdateScoreboard(int client)
 
 void UpdateClanTag(int client)
 {
-	int time = RoundToFloor(Shavit_GetClientTime(client));
 	char[] sTime = new char[16];
 
-	if(time < 60)
+	if(Shavit_GetTimerStatus(client) == Timer_Stopped)
 	{
-		IntToString(time, sTime, 16);
+		strcopy(sTime, 16, "N/A");
 	}
 
 	else
 	{
-		int minutes = (time / 60);
-		int seconds = (time % 60);
+		int time = RoundToFloor(Shavit_GetClientTime(client));
 
-		if(time < 3600)
+		if(time < 60)
 		{
-			FormatEx(sTime, 16, "%d:%s%d", minutes, (seconds < 10)? "0":"", seconds);
+			IntToString(time, sTime, 16);
 		}
 
 		else
 		{
-			minutes %= 60;
+			int minutes = (time / 60);
+			int seconds = (time % 60);
 
-			FormatEx(sTime, 16, "%d:%s%d:%s%d", (time / 3600), (minutes < 10)? "0":"", minutes, (seconds < 10)? "0":"", seconds);
+			if(time < 3600)
+			{
+				FormatEx(sTime, 16, "%d:%s%d", minutes, (seconds < 10)? "0":"", seconds);
+			}
+
+			else
+			{
+				minutes %= 60;
+
+				FormatEx(sTime, 16, "%d:%s%d:%s%d", (time / 3600), (minutes < 10)? "0":"", minutes, (seconds < 10)? "0":"", seconds);
+			}
 		}
 	}
 

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -68,7 +68,7 @@ int gI_AdvertisementsCycle = 0;
 char gS_CurrentMap[192];
 ConVar gCV_Hostname = null;
 ConVar gCV_Hostport = null;
-BhopStyle gBS_Style[MAXPLAYERS+1];
+int gBS_Style[MAXPLAYERS+1];
 float gF_Checkpoints[MAXPLAYERS+1][CP_MAX][3][3]; // 3 - position, angles, velocity
 int gI_CheckpointsSettings[MAXPLAYERS+1];
 any gA_CheckpointsSnapshots[MAXPLAYERS+1][CP_MAX][TIMERSNAPSHOT_SIZE];
@@ -374,9 +374,9 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 
 	for(int i = 0; i < styles; i++)
 	{
-		Shavit_GetStyleSettings(view_as<BhopStyle>(i), gA_StyleSettings[i]);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sStyleName, gS_StyleStrings[i][sStyleName], 128);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sClanTag, gS_StyleStrings[i][sClanTag], 128);
+		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
+		Shavit_GetStyleStrings(i, sStyleName, gS_StyleStrings[i][sStyleName], 128);
+		Shavit_GetStyleStrings(i, sClanTag, gS_StyleStrings[i][sClanTag], 128);
 	}
 }
 
@@ -393,7 +393,7 @@ public void Shavit_OnChatConfigLoaded()
 	}
 }
 
-public void Shavit_OnStyleChanged(int client, BhopStyle oldstyle, BhopStyle newstyle)
+public void Shavit_OnStyleChanged(int client, int oldstyle, int newstyle)
 {
 	gBS_Style[client] = newstyle;
 }
@@ -697,7 +697,7 @@ public Action Timer_Advertisement(Handle Timer)
 void UpdateScoreboard(int client)
 {
 	float fPB = 0.0;
-	Shavit_GetPlayerPB(client, view_as<BhopStyle>(0), fPB);
+	Shavit_GetPlayerPB(client, 0, fPB);
 
 	int iScore = (fPB != 0.0 && fPB < 2000)? -RoundToFloor(fPB):-2000;
 
@@ -872,7 +872,7 @@ void ResetCheckpoints(int client)
 		gA_CheckpointsSnapshots[client][i][fPauseTotalTime] = 0.0;
 		gA_CheckpointsSnapshots[client][i][bClientPaused] = false;
 		gA_CheckpointsSnapshots[client][i][iJumps] = 0;
-		gA_CheckpointsSnapshots[client][i][bsStyle] = view_as<BhopStyle>(0);
+		gA_CheckpointsSnapshots[client][i][bsStyle] = 0;
 		gA_CheckpointsSnapshots[client][i][iStrafes] = 0;
 		gA_CheckpointsSnapshots[client][i][iTotalMeasures] = 0;
 		gA_CheckpointsSnapshots[client][i][iGoodGains] = 0;
@@ -1592,7 +1592,7 @@ public Action Command_Specs(int client, int args)
 	return Plugin_Handled;
 }
 
-public void Shavit_OnWorldRecord(int client, BhopStyle style, float time, int jumps)
+public void Shavit_OnWorldRecord(int client, int style, float time, int jumps)
 {
 	char[] sUpperCase = new char[64];
 	strcopy(sUpperCase, 64, gS_StyleStrings[style][sStyleName]);

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1468,6 +1468,11 @@ void SaveCheckpoint(int client, int index)
 
 void TeleportToCheckpoint(int client, int index)
 {
+	if(IsNullVector(gF_Checkpoints[client][index][0]))
+	{
+		return;
+	}
+
 	Shavit_SetPracticeMode(client, true, !Shavit_InsideZone(client, Track_Main, Zone_Start));
 	Shavit_LoadSnapshot(client, gA_CheckpointsSnapshots[client][index]);
 

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1249,11 +1249,11 @@ public Action Command_Save(int client, int args)
 
 		return Plugin_Handled;
 	}
-
-	int index = 0;
-
+	
 	if(args > 0)
 	{
+		int index = 0;
+
 		char[] arg = new char[4];
 		GetCmdArg(1, arg, 4);
 
@@ -1263,11 +1263,28 @@ public Action Command_Save(int client, int args)
 		{
 			index = (parsed - 1);
 		}
+
+		SaveCheckpoint(client, index);
+
+		Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 	}
 
-	SaveCheckpoint(client, index);
+	else
+	{
+		if(gA_CheckpointsCache[client][iCheckpoints] < CP_MAX)
+		{
+			SaveCheckpoint(client, gA_CheckpointsCache[client][iCheckpoints]);
+			gA_CheckpointsCache[client][iCurrentCheckpoint] = ++gA_CheckpointsCache[client][iCheckpoints];
+		}
 
-	Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+		else
+		{
+			SaveCheckpoint(client, (CP_MAX - 1));
+			gA_CheckpointsCache[client][iCurrentCheckpoint] = CP_MAX;
+		}
+
+		Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gA_CheckpointsCache[client][iCurrentCheckpoint], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+	}
 
 	return Plugin_Handled;
 }
@@ -1387,6 +1404,12 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 		{
 			case 0:
 			{
+				// fight an exploit
+				if(gA_CheckpointsCache[param1][iCheckpoints] >= CP_MAX)
+				{
+					return 0;
+				}
+
 				SaveCheckpoint(param1, gA_CheckpointsCache[param1][iCheckpoints]);
 				gA_CheckpointsCache[param1][iCurrentCheckpoint] = ++gA_CheckpointsCache[param1][iCheckpoints];
 			}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -243,8 +243,8 @@ public void OnPluginStart()
 	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "3", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit to shavit_misc_prespeedlimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to shavit_misc_prespeedlimit and block bunnyhopping.", 0, true, 0.0, true, 3.0);
 	gCV_HideTeamChanges = CreateConVar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = CreateConVar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_RespawnOnRestart = CreateConVar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if he uses the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_StartOnSpawn = CreateConVar("shavit_misc_startonspawn", "1", "Restart the timer for a player after he spawns?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_RespawnOnRestart = CreateConVar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if they use the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_StartOnSpawn = CreateConVar("shavit_misc_startonspawn", "1", "Restart the timer for a player after they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_PrespeedLimit = CreateConVar("shavit_misc_prespeedlimit", "280.00", "Prespeed limitation in startzone.", 0, true, 10.0, false);
 	gCV_HideRadar = CreateConVar("shavit_misc_hideradar", "1", "Should the plugin hide the in-game radar?", 0, true, 0.0, true, 1.0);
 	gCV_TeleportCommands = CreateConVar("shavit_misc_tpcmds", "1", "Enable teleport-related commands? (sm_goto/sm_tpto)\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -867,10 +867,7 @@ void ResetCheckpoints(int client)
 	{
 		for(int j = 0; j < sizeof(gF_Checkpoints[][]); j++)
 		{
-			for(int k = 0; k < sizeof(gF_Checkpoints[][][]); k++)
-			{
-				gF_Checkpoints[client][i][j][k] = 0.0;
-			}
+			gF_Checkpoints[client][i][j] = NULL_VECTOR;
 		}
 	}
 
@@ -1090,7 +1087,6 @@ public Action Command_Teleport(int client, int args)
 		}
 
 		menu.ExitButton = true;
-
 		menu.Display(client, 60);
 	}
 
@@ -1307,6 +1303,13 @@ public Action Command_Tele(int client, int args)
 		}
 	}
 
+	if(IsNullVector(gF_Checkpoints[client][index][0]))
+	{
+		Shavit_PrintToChat(client, "%T", "MiscCheckpointsEmpty", client, (index + 1), gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
+
+		return Plugin_Handled;
+	}
+
 	TeleportToCheckpoint(client, index);
 
 	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
@@ -1378,6 +1381,8 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 {
 	if(action == MenuAction_Select)
 	{
+		int current = gA_CheckpointsCache[param1][iCurrentCheckpoint];
+
 		switch(param2)
 		{
 			case 0:
@@ -1388,12 +1393,12 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 
 			case 1:
 			{
-				TeleportToCheckpoint(param1, gA_CheckpointsCache[param1][iCurrentCheckpoint] - 1);
+				TeleportToCheckpoint(param1, current - 1);
 			}
 
 			case 2:
 			{
-				if(gA_CheckpointsCache[param1][iCurrentCheckpoint] > 1)
+				if(current > 1)
 				{
 					gA_CheckpointsCache[param1][iCurrentCheckpoint]--;
 				}
@@ -1401,7 +1406,7 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 
 			case 3:
 			{
-				if(gA_CheckpointsCache[param1][iCurrentCheckpoint] < CP_MAX)
+				if(current < CP_MAX && !IsNullVector(gF_Checkpoints[param1][current][0]))
 				{
 					gA_CheckpointsCache[param1][iCurrentCheckpoint]++;
 				}
@@ -1832,4 +1837,9 @@ public Action Command_Drop(int client, const char[] command, int argc)
 	}
 
 	return Plugin_Handled;
+}
+
+bool IsNullVector(float vec[3])
+{
+	return (vec[0] == NULL_VECTOR[0] && vec[1] == NULL_VECTOR[1] && vec[2] == NULL_VECTOR[2]);
 }

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1468,7 +1468,7 @@ void SaveCheckpoint(int client, int index)
 
 void TeleportToCheckpoint(int client, int index)
 {
-	if(index >= 0 && index < CP_MAX && IsNullVector(gF_Checkpoints[client][index][0]))
+	if(index < 0 || index >= CP_MAX || IsNullVector(gF_Checkpoints[client][index][0]))
 	{
 		return;
 	}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1288,7 +1288,7 @@ public Action Command_Tele(int client, int args)
 		return Plugin_Handled;
 	}
 
-	int index = 0;
+	int index = (gA_CheckpointsCache[client][iCurrentCheckpoint] - 1);
 
 	if(args > 0)
 	{

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1353,8 +1353,9 @@ public Action OpenCheckpointsMenu(int client, int item)
 	FormatEx(sDisplay, 64, "%T", "MiscCheckpointUseVelocity", client);
 	menu.AddItem(sInfo, sDisplay);
 
+	menu.Pagination = MENU_NO_PAGINATION;
 	menu.ExitButton = true;
-	menu.Display(client, 60);
+	menu.Display(client, MENU_TIME_FOREVER);
 
 	return Plugin_Handled;
 }

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -878,6 +878,7 @@ void ResetCheckpoints(int client)
 		gA_CheckpointsSnapshots[client][i][iStrafes] = 0;
 		gA_CheckpointsSnapshots[client][i][iTotalMeasures] = 0;
 		gA_CheckpointsSnapshots[client][i][iGoodGains] = 0;
+		gA_CheckpointsSnapshots[client][i][iSHSWCombination] = -1;
 	}
 
 	gA_CheckpointsCache[client][iCheckpoints] = 0;

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1468,7 +1468,7 @@ void SaveCheckpoint(int client, int index)
 
 void TeleportToCheckpoint(int client, int index)
 {
-	if(IsNullVector(gF_Checkpoints[client][index][0]))
+	if(index >= 0 && index < CP_MAX && IsNullVector(gF_Checkpoints[client][index][0]))
 	{
 		return;
 	}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1471,6 +1471,8 @@ void TeleportToCheckpoint(int client, int index)
 	Shavit_SetPracticeMode(client, true, !Shavit_InsideZone(client, Track_Main, Zone_Start));
 	Shavit_LoadSnapshot(client, gA_CheckpointsSnapshots[client][index]);
 
+	bool bInStart = Shavit_InsideZone(client, Zone_Start, -1);
+
 	TeleportEntity(client, gF_Checkpoints[client][index][0],
 		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0)? gF_Checkpoints[client][index][1]:NULL_VECTOR,
 		((gI_CheckpointsSettings[client] & CP_VELOCITY) > 0)? gF_Checkpoints[client][index][2]:NULL_VECTOR);
@@ -1478,6 +1480,11 @@ void TeleportToCheckpoint(int client, int index)
 	SetEntityMoveType(client, view_as<MoveType>(gA_PlayerCheckPointsCache[client][index][iCPMoveType]));
 	SetEntityGravity(client, view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPGravity]));
 	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPSpeed]));
+
+	if(bInStart)
+	{
+		Shavit_StopTimer(client);
+	}
 }
 
 public Action Command_Noclip(int client, int args)

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -102,6 +102,7 @@ ConVar gCV_AdvertisementInterval = null;
 ConVar gCV_Checkpoints = null;
 ConVar gCV_RemoveRagdolls = null;
 ConVar gCV_ClanTag = null;
+ConVar gCV_DropAll = null;
 
 // cached cvars
 int gI_GodMode = 3;
@@ -128,6 +129,7 @@ bool gB_Checkpoints = true;
 int gI_RemoveRagdolls = 1;
 char gS_ClanTag[32] = "{styletag} :: {time}";
 bool gB_ClanTag = true;
+bool gB_DropAll = true;
 
 // dhooks
 Handle gH_GetPlayerMaxSpeed = null;
@@ -224,6 +226,7 @@ public void OnPluginStart()
 	HookEvent("player_team", Player_Notifications, EventHookMode_Pre);
 	HookEvent("player_death", Player_Notifications, EventHookMode_Pre);
 	HookEvent("weapon_fire", Weapon_Fire);
+	AddCommandListener(Command_Drop, "drop");
 
 	// phrases
 	LoadTranslations("common.phrases");
@@ -257,6 +260,7 @@ public void OnPluginStart()
 	gCV_Checkpoints = CreateConVar("shavit_misc_checkpoints", "1", "Allow players to save and teleport to checkpoints.", 0, true, 0.0, true, 1.0);
 	gCV_RemoveRagdolls = CreateConVar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = CreateConVar("shavit_misc_clantag", "{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style settings from shavit-styles.cfg.\n{style} - style name.\n{time} - formatted time.", 0);
+	gCV_DropAll = CreateConVar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 2.0);
 
 	gCV_GodMode.AddChangeHook(OnConVarChanged);
 	gCV_PreSpeed.AddChangeHook(OnConVarChanged);
@@ -281,6 +285,7 @@ public void OnPluginStart()
 	gCV_Checkpoints.AddChangeHook(OnConVarChanged);
 	gCV_RemoveRagdolls.AddChangeHook(OnConVarChanged);
 	gCV_ClanTag.AddChangeHook(OnConVarChanged);
+	gCV_DropAll.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 
@@ -418,6 +423,8 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_Checkpoints = gCV_Checkpoints.BoolValue;
 	gI_RemoveRagdolls = gCV_RemoveRagdolls.IntValue;
 	gCV_ClanTag.GetString(gS_ClanTag, 32);
+	gB_DropAll = gCV_DropAll.BoolValue;
+
 	gB_ClanTag = !StrEqual(gS_ClanTag, "0");
 }
 
@@ -1776,4 +1783,21 @@ public void Shavit_OnFinish(int client)
 	}
 
 	UpdateScoreboard(client);
+}
+
+public Action Command_Drop(int client, const char[] command, int argc)
+{
+	if(!gB_DropAll)
+	{
+		return Plugin_Continue;
+	}
+
+	int weapon = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
+
+	if(weapon != -1 && IsValidEntity(weapon))
+	{
+		CS_DropWeapon(client, weapon, true);
+	}
+
+	return Plugin_Handled;
 }

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -197,6 +197,8 @@ public void OnPluginStart()
 	// checkpoints
 	RegConsoleCmd("sm_cpmenu", Command_Checkpoints, "Opens the checkpoints menu.");
 	RegConsoleCmd("sm_cp", Command_Checkpoints, "Opens the checkpoints menu. Alias for sm_cpmenu.");
+	RegConsoleCmd("sm_checkpoint", Command_Checkpoints, "Opens the checkpoints menu. Alias for sm_cpmenu.");
+	RegConsoleCmd("sm_checkpoints", Command_Checkpoints, "Opens the checkpoints menu. Alias for sm_cpmenu.");
 	RegConsoleCmd("sm_save", Command_Save, "Saves checkpoint (default: 1). Usage: sm_save [number]");
 	RegConsoleCmd("sm_tele", Command_Tele, "Teleports to checkpoint (default: 1). Usage: sm_tele [number]");
 	gH_CheckpointsCookie = RegClientCookie("shavit_checkpoints", "Checkpoints settings", CookieAccess_Protected);

--- a/scripting/shavit-rankings.sp
+++ b/scripting/shavit-rankings.sp
@@ -352,7 +352,7 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 
 	for(int i = 0; i < styles; i++)
 	{
-		Shavit_GetStyleSettings(view_as<BhopStyle>(i), gA_StyleSettings[i]);
+		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
 	}
 
 	gI_Styles = styles;
@@ -377,7 +377,7 @@ public Action Command_Points(int client, int args)
 	GetMapDisplayName(gS_Map, sDisplayMap, strlen(gS_Map) + 1);
 
 	float fWRTime = 0.0;
-	Shavit_GetWRTime(view_as<BhopStyle>(0), fWRTime);
+	Shavit_GetWRTime(0, fWRTime);
 
 	if(fWRTime < 0.0)
 	{
@@ -671,7 +671,7 @@ void UpdateRecordPoints()
 	}
 
 	float fDefaultWR = 0.0;
-	Shavit_GetWRTime(view_as<BhopStyle>(0), fDefaultWR);
+	Shavit_GetWRTime(0, fDefaultWR);
 
 	char[] sQuery = new char[512];
 
@@ -683,7 +683,7 @@ void UpdateRecordPoints()
 		}
 
 		float fStyleWR = 0.0;
-		Shavit_GetWRTime(view_as<BhopStyle>(i), fStyleWR);
+		Shavit_GetWRTime(i, fStyleWR);
 
 		float fMeasureTime = 0.0;
 
@@ -762,7 +762,7 @@ public void SQL_WeighPoints_Callback(Database db, DBResultSet results, const cha
 float CalculatePoints(float time, BhopStyle style, float tier)
 {
 	float fWRTime = 0.0;
-	Shavit_GetWRTime(view_as<BhopStyle>(0), fWRTime);
+	Shavit_GetWRTime(0, fWRTime);
 
 	if(tier <= 0.0 || fWRTime <= 0.0)
 	{
@@ -773,7 +773,7 @@ float CalculatePoints(float time, BhopStyle style, float tier)
 }
 #endif
 
-public void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int jumps, int strafes, float sync, int rank)
+public void Shavit_OnFinish_Post(int client, int style, float time, int jumps, int strafes, float sync, int rank)
 {
 	#if defined DEBUG
 	Shavit_PrintToChat(client, "Points: %.02f", CalculatePoints(time, style, gF_IdealTime, gF_MapPoints));

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -226,7 +226,7 @@ public Action Cron(Handle Timer)
 
 	for(int i = 0; i < gI_Styles; i++)
 	{
-		Shavit_GetWRTime(view_as<BhopStyle>(i), fWRTimes[i]);
+		Shavit_GetWRTime(i, fWRTimes[i]);
 
 		if(!gB_CentralBot && gI_ReplayBotClient[i] != 0)
 		{
@@ -257,7 +257,7 @@ public Action Cron(Handle Timer)
 			continue;
 		}
 
-		BhopStyle style = Shavit_GetBhopStyle(i);
+		int style = Shavit_GetBhopStyle(i);
 
 		if(!ReplayEnabled(style) || (fWRTimes[style] > 0.0 && Shavit_GetClientTime(i) > fWRTimes[style]))
 		{
@@ -386,7 +386,7 @@ public void OnMapStart()
 			CreateDirectory(sPath, 511);
 		}
 
-		bool loaded = LoadReplay(view_as<BhopStyle>(i));
+		bool loaded = LoadReplay(i);
 
 		if(!gB_CentralBot)
 		{
@@ -424,9 +424,9 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 
 	for(int i = 0; i < styles; i++)
 	{
-		Shavit_GetStyleSettings(view_as<BhopStyle>(i), gA_StyleSettings[i]);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sStyleName, gS_StyleStrings[i][sStyleName], 128);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sShortName, gS_StyleStrings[i][sShortName], 128);
+		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
+		Shavit_GetStyleStrings(i, sStyleName, gS_StyleStrings[i][sStyleName], 128);
+		Shavit_GetStyleStrings(i, sShortName, gS_StyleStrings[i][sShortName], 128);
 	}
 
 	gI_Styles = styles;
@@ -440,7 +440,7 @@ public void Shavit_OnChatConfigLoaded()
 	}
 }
 
-bool LoadReplay(BhopStyle style)
+bool LoadReplay(int style)
 {
 	if(!ReplayEnabled(style))
 	{
@@ -516,7 +516,7 @@ bool LoadReplay(BhopStyle style)
 	return false;
 }
 
-bool SaveReplay(BhopStyle style)
+bool SaveReplay(int style)
 {
 	if(!ReplayEnabled(style))
 	{
@@ -642,7 +642,7 @@ void UpdateReplayInfo(int client, int style, float time)
 	CS_SetClientClanTag(client, "REPLAY");
 
 	float fWRTime = 0.0;
-	Shavit_GetWRTime(view_as<BhopStyle>(style), fWRTime);
+	Shavit_GetWRTime(style, fWRTime);
 
 	char[] sTime = new char[16];
 	FormatSeconds((time == -1.0)? fWRTime:time, sTime, 16);
@@ -664,7 +664,7 @@ void UpdateReplayInfo(int client, int style, float time)
 				else
 				{
 					char[] sWRName = new char[16];
-					Shavit_GetWRName(view_as<BhopStyle>(style), sWRName, 16);
+					Shavit_GetWRName(style, sWRName, 16);
 
 					FormatEx(sName, MAX_NAME_LENGTH, "[%s] %s - %s", gS_StyleStrings[style][sShortName], sWRName, sTime);
 				}
@@ -775,7 +775,7 @@ public void Shavit_OnStop(int client)
 	ClearFrames(client);
 }
 
-public void Shavit_OnFinish(int client, BhopStyle style, float time)
+public void Shavit_OnFinish(int client, int style, float time)
 {
 	float fWRTime = 0.0;
 	Shavit_GetWRTime(style, fWRTime);
@@ -788,7 +788,7 @@ public void Shavit_OnFinish(int client, BhopStyle style, float time)
 	gB_Record[client] = false;
 }
 
-public void Shavit_OnWorldRecord(int client, BhopStyle style, float time)
+public void Shavit_OnWorldRecord(int client, int style, float time)
 {
 	if(gI_PlayerFrames[client] == 0)
 	{
@@ -809,7 +809,7 @@ public void Shavit_OnWorldRecord(int client, BhopStyle style, float time)
 
 	if(ReplayEnabled(style) && !gB_CentralBot && gI_ReplayBotClient[style] != 0)
 	{
-		UpdateReplayInfo(gI_ReplayBotClient[style], view_as<int>(style), time);
+		UpdateReplayInfo(gI_ReplayBotClient[style], style, time);
 		CS_RespawnPlayer(gI_ReplayBotClient[style]);
 
 		gRS_ReplayStatus[style] = Replay_Running;
@@ -1120,9 +1120,9 @@ void ClearFrames(int client)
 	gI_PlayerFrames[client] = 0;
 }
 
-public void Shavit_OnWRDeleted(BhopStyle style)
+public void Shavit_OnWRDeleted(int style)
 {
-	DeleteReplay(view_as<int>(style));
+	DeleteReplay(style);
 }
 
 public Action Command_DeleteReplay(int client, int args)
@@ -1168,9 +1168,9 @@ public int DeleteReplay_Callback(Menu menu, MenuAction action, int param1, int p
 		char[] sInfo = new char[4];
 		char[] sMenuItem = new char[64];
 		menu.GetItem(param2, sInfo, 4);
-		BhopStyle style = view_as<BhopStyle>(StringToInt(sInfo));
+		int style = StringToInt(sInfo);
 
-		if(style == view_as<BhopStyle>(-1))
+		if(style == -1)
 		{
 			return 0;
 		}

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -176,6 +176,11 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gI_NameStyle = gCV_NameStyle.IntValue;
 	gI_DefaultTeam = gCV_NameStyle.IntValue;
 	gB_CentralBot = gCV_CentralBot.BoolValue;
+
+	if(convar == gCV_CentralBot)
+	{
+		OnMapStart();
+	}
 }
 
 public int Native_GetReplayBotFirstFrame(Handle handler, int numParams)

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -789,7 +789,7 @@ public void Shavit_OnFinish(int client, BhopStyle style, float time)
 
 public void Shavit_OnWorldRecord(int client, BhopStyle style, float time)
 {
-	if(!ReplayEnabled(style) || gI_PlayerFrames[client] == 0)
+	if(gI_PlayerFrames[client] == 0)
 	{
 		return;
 	}
@@ -802,11 +802,11 @@ public void Shavit_OnWorldRecord(int client, BhopStyle style, float time)
 	}
 
 	gA_Frames[style] = gA_PlayerFrames[client].Clone();
-
 	ClearFrames(client);
+
 	SaveReplay(style);
 
-	if(!gB_CentralBot && gI_ReplayBotClient[style] != 0)
+	if(ReplayEnabled(style) && !gB_CentralBot && gI_ReplayBotClient[style] != 0)
 	{
 		UpdateReplayInfo(gI_ReplayBotClient[style], view_as<int>(style), time);
 		CS_RespawnPlayer(gI_ReplayBotClient[style]);

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -51,6 +51,7 @@ float gF_StartTick[STYLE_LIMIT];
 ReplayStatus gRS_ReplayStatus[STYLE_LIMIT];
 int gI_FrameCount[STYLE_LIMIT];
 
+bool gB_Button[MAXPLAYERS+1];
 int gI_PlayerFrames[MAXPLAYERS+1];
 ArrayList gA_PlayerFrames[MAXPLAYERS+1];
 bool gB_Record[MAXPLAYERS+1];
@@ -835,15 +836,35 @@ public void Shavit_OnResume(int client)
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3])
 {
-	if(!IsPlayerAlive(client) || !gB_Enabled)
+	if(!gB_Enabled)
 	{
+		return Plugin_Continue;
+	}
+
+	if(!IsPlayerAlive(client))
+	{
+		if((buttons & IN_USE) > 0)
+		{
+			if(!gB_Button[client] && GetSpectatorTarget(client) == gA_CentralCache[iCentralClient])
+			{
+				OpenReplayMenu(client);
+			}
+
+			gB_Button[client] = true;
+		}
+
+		else
+		{
+			gB_Button[client] = false;
+		}
+
 		return Plugin_Continue;
 	}
 
 	float vecCurrentPosition[3];
 	GetClientAbsOrigin(client, vecCurrentPosition);
 
-	int iReplayBotStyle = view_as<int>(GetReplayStyle(client));
+	int iReplayBotStyle = GetReplayStyle(client);
 
 	if(iReplayBotStyle != -1 && ReplayEnabled(iReplayBotStyle))
 	{

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -1344,6 +1344,16 @@ Action OpenReplayMenu(int client)
 		menu.AddItem(sInfo, gS_StyleStrings[i][sStyleName], (gI_FrameCount[i] > 0)? ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 	}
 
+	if(menu.ItemCount == 0)
+	{
+		menu.AddItem("-1", "ERROR");
+	}
+
+	else if(menu.ItemCount <= ((gEV_Type == Engine_CSS)? 9:8))
+	{
+		menu.Pagination = MENU_NO_PAGINATION;
+	}
+
 	menu.ExitButton = true;
 	menu.Display(client, 20);
 
@@ -1367,7 +1377,7 @@ public int MenuHandler_Replay(Menu menu, MenuAction action, int param1, int para
 
 		int style = StringToInt(info);
 
-		if(!ReplayEnabled(style) || gI_FrameCount[style] == 0 || gA_CentralCache[iCentralClient] <= 0)
+		if(style == -1 || !ReplayEnabled(style) || gI_FrameCount[style] == 0 || gA_CentralCache[iCentralClient] <= 0)
 		{
 			return 0;
 		}

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -376,13 +376,13 @@ public void OnMapStart()
 	{
 		gA_Frames[i] = new ArrayList(6);
 
+		gI_ReplayTick[i] = 0;
+		gI_FrameCount[i] = 0;
+
 		if(!ReplayEnabled(i))
 		{
 			continue;
 		}
-
-		gI_ReplayTick[i] = 0;
-		gI_FrameCount[i] = 0;
 
 		BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot/%d", i);
 
@@ -906,7 +906,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				gI_ReplayTick[iReplayBotStyle] = 0;
 				gRS_ReplayStatus[iReplayBotStyle] = gA_CentralCache[iCentralReplayStatus] = Replay_End;
 
-				CreateTimer(gF_ReplayDelay / 2.0, EndReplay, iReplayBotStyle, TIMER_FLAG_NO_MAPCHANGE);
+				CreateTimer((gF_ReplayDelay / 2.0), EndReplay, iReplayBotStyle, TIMER_FLAG_NO_MAPCHANGE);
 
 				SetEntityMoveType(client, MOVETYPE_NONE);
 

--- a/scripting/shavit-replay.sp
+++ b/scripting/shavit-replay.sp
@@ -174,7 +174,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gF_ReplayDelay = gCV_ReplayDelay.FloatValue;
 	gF_TimeLimit = gCV_TimeLimit.FloatValue;
 	gI_NameStyle = gCV_NameStyle.IntValue;
-	gI_DefaultTeam = gCV_NameStyle.IntValue;
+	gI_DefaultTeam = gCV_DefaultTeam.IntValue;
 	gB_CentralBot = gCV_CentralBot.BoolValue;
 
 	if(convar == gCV_CentralBot)

--- a/scripting/shavit-sounds.sp
+++ b/scripting/shavit-sounds.sp
@@ -277,7 +277,7 @@ void PlayEventSound(int client, bool everyone, const char[] sound)
 
 		int iObserverMode = GetEntProp(client, Prop_Send, "m_iObserverMode");
 
-		// add player and his spectators
+		// add player and their spectators
 		if(i == client || (IsClientObserver(i) && (iObserverMode >= 3 || iObserverMode <= 5) && GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") == client))
 		{
 			clients[count++] = i;

--- a/scripting/shavit-sounds.sp
+++ b/scripting/shavit-sounds.sp
@@ -203,7 +203,7 @@ public void OnMapStart()
 	delete fFile;
 }
 
-public void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int jumps, int strafes, float sync, int rank, int overwrite)
+public void Shavit_OnFinish_Post(int client, int style, float time, int jumps, int strafes, float sync, int rank, int overwrite)
 {
 	float fOldTime = 0.0;
 	Shavit_GetPlayerPB(client, style, fOldTime);
@@ -242,7 +242,7 @@ public void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int ju
 	}
 }
 
-public void Shavit_OnWorstRecord(int client, BhopStyle style, float time, int jumps, int strafes, float sync)
+public void Shavit_OnWorstRecord(int client, int style, float time, int jumps, int strafes, float sync)
 {
 	if(gA_WorstSounds.Length != 0 && Shavit_GetRecordAmount(style) >= gI_MinimiumWorst)
 	{

--- a/scripting/shavit-sounds.sp
+++ b/scripting/shavit-sounds.sp
@@ -35,7 +35,14 @@ EngineVersion gEV_Type = Engine_Unknown;
 ArrayList gA_FirstSounds = null;
 ArrayList gA_PersonalSounds = null;
 ArrayList gA_WorldSounds = null;
+ArrayList gA_WorstSounds = null;
 StringMap gSM_RankSounds = null;
+
+// cvars
+ConVar gCV_MinimiumWorst = null;
+
+// cached cvars
+int gI_MinimiumWorst = 10;
 
 public Plugin myinfo =
 {
@@ -71,10 +78,23 @@ public void OnPluginStart()
 	gA_FirstSounds = new ArrayList(PLATFORM_MAX_PATH);
 	gA_PersonalSounds = new ArrayList(PLATFORM_MAX_PATH);
 	gA_WorldSounds = new ArrayList(PLATFORM_MAX_PATH);
+	gA_WorstSounds = new ArrayList(PLATFORM_MAX_PATH);
 	gSM_RankSounds = new StringMap();
 
 	// modules
 	gB_HUD = LibraryExists("shavit-hud");
+
+	// cvars
+	gCV_MinimiumWorst = CreateConVar("shavit_sounds_minimumworst", "10", "Minimum amount of records to be saved for a \"worst\" sound to play.", 0, true, 1.0);
+
+	gCV_MinimiumWorst.AddChangeHook(OnConVarChanged);
+
+	AutoExecConfig();
+}
+
+public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
+{
+	gI_MinimiumWorst = gCV_MinimiumWorst.IntValue;
 }
 
 public void OnLibraryAdded(const char[] name)
@@ -98,6 +118,7 @@ public void OnMapStart()
 	gA_FirstSounds.Clear();
 	gA_PersonalSounds.Clear();
 	gA_WorldSounds.Clear();
+	gA_WorstSounds.Clear();
 	gSM_RankSounds.Clear();
 
 	char[] sFile = new char[PLATFORM_MAX_PATH];
@@ -144,9 +165,14 @@ public void OnMapStart()
 				gA_WorldSounds.PushString(sExploded[1]);
 			}
 
+			else if(StrEqual(sExploded[0], "worst"))
+			{
+				gA_WorstSounds.PushString(sExploded[1]);
+			}
+
 			else if(StrEqual(sExploded[0], "worse"))
 			{
-				PrintToServer("\"worse\" sounds are not supported anymore.");
+				LogError("\"worse\" sounds are not supported anymore.");
 			}
 
 			else
@@ -183,7 +209,6 @@ public void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int ju
 	Shavit_GetPlayerPB(client, style, fOldTime);
 
 	char[] sSound = new char[PLATFORM_MAX_PATH];
-
 	bool bEveryone = false;
 
 	char[] sRank = new char[8];
@@ -214,6 +239,20 @@ public void Shavit_OnFinish_Post(int client, BhopStyle style, float time, int ju
 	if(StrContains(sSound, ".") != -1) // file has an extension?
 	{
 		PlayEventSound(client, bEveryone, sSound);
+	}
+}
+
+public void Shavit_OnWorstRecord(int client, BhopStyle style, float time, int jumps, int strafes, float sync)
+{
+	if(gA_WorstSounds.Length != 0 && Shavit_GetRecordAmount(style) >= gI_MinimiumWorst)
+	{
+		char[] sSound = new char[PLATFORM_MAX_PATH];
+		gA_WorstSounds.GetString(GetRandomInt(0, gA_WorstSounds.Length - 1), sSound, PLATFORM_MAX_PATH);
+
+		if(StrContains(sSound, ".") != -1)
+		{
+			PlayEventSound(client, false, sSound);
+		}
 	}
 }
 

--- a/scripting/shavit-sounds.sp
+++ b/scripting/shavit-sounds.sp
@@ -39,10 +39,10 @@ ArrayList gA_WorstSounds = null;
 StringMap gSM_RankSounds = null;
 
 // cvars
-ConVar gCV_MinimiumWorst = null;
+ConVar gCV_MinimumWorst = null;
 
 // cached cvars
-int gI_MinimiumWorst = 10;
+int gI_MinimumWorst = 10;
 
 public Plugin myinfo =
 {
@@ -85,16 +85,16 @@ public void OnPluginStart()
 	gB_HUD = LibraryExists("shavit-hud");
 
 	// cvars
-	gCV_MinimiumWorst = CreateConVar("shavit_sounds_minimumworst", "10", "Minimum amount of records to be saved for a \"worst\" sound to play.", 0, true, 1.0);
+	gCV_MinimumWorst = CreateConVar("shavit_sounds_minimumworst", "10", "Minimum amount of records to be saved for a \"worst\" sound to play.", 0, true, 1.0);
 
-	gCV_MinimiumWorst.AddChangeHook(OnConVarChanged);
+	gCV_MinimumWorst.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 }
 
 public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	gI_MinimiumWorst = gCV_MinimiumWorst.IntValue;
+	gI_MinimumWorst = gCV_MinimumWorst.IntValue;
 }
 
 public void OnLibraryAdded(const char[] name)
@@ -244,7 +244,7 @@ public void Shavit_OnFinish_Post(int client, int style, float time, int jumps, i
 
 public void Shavit_OnWorstRecord(int client, int style, float time, int jumps, int strafes, float sync)
 {
-	if(gA_WorstSounds.Length != 0 && Shavit_GetRecordAmount(style) >= gI_MinimiumWorst)
+	if(gA_WorstSounds.Length != 0 && Shavit_GetRecordAmount(style) >= gI_MinimumWorst)
 	{
 		char[] sSound = new char[PLATFORM_MAX_PATH];
 		gA_WorstSounds.GetString(GetRandomInt(0, gA_WorstSounds.Length - 1), sSound, PLATFORM_MAX_PATH);

--- a/scripting/shavit-stats.sp
+++ b/scripting/shavit-stats.sp
@@ -44,7 +44,7 @@ char gS_MySQLPrefix[32];
 
 // cache
 int gI_MapType[MAXPLAYERS+1];
-BhopStyle gBS_Style[MAXPLAYERS+1];
+int gBS_Style[MAXPLAYERS+1];
 char gS_TargetAuth[MAXPLAYERS+1][32];
 char gS_TargetName[MAXPLAYERS+1][MAX_NAME_LENGTH];
 int gI_WRAmount[MAXPLAYERS+1];
@@ -142,9 +142,9 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 
 	for(int i = 0; i < styles; i++)
 	{
-		Shavit_GetStyleSettings(view_as<BhopStyle>(i), gA_StyleSettings[i]);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sStyleName, gS_StyleStrings[i][sStyleName], 128);
-		Shavit_GetStyleStrings(view_as<BhopStyle>(i), sShortName, gS_StyleStrings[i][sShortName], 128);
+		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
+		Shavit_GetStyleStrings(i, sStyleName, gS_StyleStrings[i][sStyleName], 128);
+		Shavit_GetStyleStrings(i, sShortName, gS_StyleStrings[i][sShortName], 128);
 	}
 
 	gI_Styles = styles;
@@ -476,7 +476,7 @@ public int MenuHandler_ProfileHandler(Menu m, MenuAction action, int param1, int
 
 		m.GetItem(param2, sInfo, 32);
 
-		gBS_Style[param1] = view_as<BhopStyle>(StringToInt(sInfo));
+		gBS_Style[param1] = StringToInt(sInfo);
 
 		Menu menu = new Menu(MenuHandler_TypeHandler);
 		menu.SetTitle("%T", "MapsMenu", param1, gS_StyleStrings[gBS_Style[param1]][sShortName]);
@@ -550,12 +550,12 @@ void ShowMaps(int client)
 
 	if(gI_MapType[client] == MAPSDONE)
 	{
-		FormatEx(sQuery, 512, "SELECT a.map, a.time, a.jumps, a.id, COUNT(b.map) + 1 rank, a.points FROM %splayertimes a LEFT JOIN %splayertimes b ON a.time > b.time AND a.map = b.map AND a.style = b.style WHERE a.auth = '%s' AND a.style = %d GROUP BY a.map ORDER BY a.%s;", gS_MySQLPrefix, gS_MySQLPrefix, gS_TargetAuth[client], view_as<int>(gBS_Style[client]), (gB_Rankings)? "points":"map");
+		FormatEx(sQuery, 512, "SELECT a.map, a.time, a.jumps, a.id, COUNT(b.map) + 1 rank, a.points FROM %splayertimes a LEFT JOIN %splayertimes b ON a.time > b.time AND a.map = b.map AND a.style = b.style WHERE a.auth = '%s' AND a.style = %d GROUP BY a.map ORDER BY a.%s;", gS_MySQLPrefix, gS_MySQLPrefix, gS_TargetAuth[client], gBS_Style[client], (gB_Rankings)? "points":"map");
 	}
 
 	else
 	{
-		FormatEx(sQuery, 512, "SELECT DISTINCT m.map FROM %smapzones m LEFT JOIN %splayertimes r ON r.map = m.map AND r.auth = '%s' AND r.style = %d WHERE r.map IS NULL ORDER BY m.map;", gS_MySQLPrefix, gS_MySQLPrefix, gS_TargetAuth[client], view_as<int>(gBS_Style[client]));
+		FormatEx(sQuery, 512, "SELECT DISTINCT m.map FROM %smapzones m LEFT JOIN %splayertimes r ON r.map = m.map AND r.auth = '%s' AND r.style = %d WHERE r.map IS NULL ORDER BY m.map;", gS_MySQLPrefix, gS_MySQLPrefix, gS_TargetAuth[client], gBS_Style[client]);
 	}
 
 	gH_SQL.Query(ShowMapsCallback, sQuery, GetClientSerial(client), DBPrio_High);
@@ -724,7 +724,7 @@ public void SQL_SubMenu_Callback(Database db, DBResultSet results, const char[] 
 		m.AddItem("-1", sDisplay);
 
 		// 3 - style
-		BhopStyle style = view_as<BhopStyle>(results.FetchInt(3));
+		int style = results.FetchInt(3);
 		FormatEx(sDisplay, 128, "%T: %s", "Style", client, gS_StyleStrings[style][sStyleName]);
 		m.AddItem("-1", sDisplay);
 

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -1780,13 +1780,13 @@ int GetRankForTime(BhopStyle style, float time)
 	return (gI_RecordAmount[style] + 1);
 }
 
-public bool GuessBestMapName(const char[] input, char[] output, int size)
+void GuessBestMapName(const char[] input, char[] output, int size)
 {
 	if(gA_ValidMaps.FindString(input) != -1)
 	{
 		strcopy(output, size, input);
 
-		return true;
+		return;
 	}
 
 	char[] sCache = new char[128];
@@ -1799,11 +1799,9 @@ public bool GuessBestMapName(const char[] input, char[] output, int size)
 		{
 			strcopy(output, size, sCache);
 
-			return true;
+			return;
 		}
 	}
-
-	return false;
 }
 
 public void Shavit_OnDatabaseLoaded(Database db)

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -1407,7 +1407,7 @@ public int SubMenu_Handler(Menu m, MenuAction action, int param1, int param2)
 			{
 				case 0:
 				{
-					Shavit_OpenStatsMenu(param1, sInfo);
+					Shavit_OpenStatsMenu(param1, sExploded[1]);
 				}
 
 				case 1:

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -457,7 +457,17 @@ void UpdateWRCache()
 	char sQuery[512];
 	// thanks Ollie Jones from stackoverflow! http://stackoverflow.com/a/36239523/5335680
 	// was a bit confused with this one :s
-	FormatEx(sQuery, 512, "SELECT p.style, p.id, TRUNCATE(LEAST(s.time, p.time), 3), u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style ORDER BY date ASC) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style ORDER BY date ASC;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
+
+	if(gB_MySQL)
+	{
+		FormatEx(sQuery, 512, "SELECT p.style, p.id, TRUNCATE(LEAST(s.time, p.time), 3), u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style ORDER BY date ASC) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style ORDER BY date ASC;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
+	}
+
+	// sorry, LEAST() isn't available for SQLITE!
+	else
+	{
+		FormatEx(sQuery, 512, "SELECT p.style, p.id, s.time, u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
+	}
 
 	gH_SQL.Query(SQL_UpdateWRCache_Callback, sQuery, 0, DBPrio_Low);
 }

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -442,7 +442,7 @@ void UpdateWRCache()
 	char sQuery[512];
 	// thanks Ollie Jones from stackoverflow! http://stackoverflow.com/a/36239523/5335680
 	// was a bit confused with this one :s
-	FormatEx(sQuery, 512, "SELECT p.style, p.id, s.time, u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
+	FormatEx(sQuery, 512, "SELECT p.style, p.id, TRUNCATE(LEAST(s.time, p.time), 3), u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style ORDER BY date ASC) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style ORDER BY date ASC;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
 
 	gH_SQL.Query(SQL_UpdateWRCache_Callback, sQuery, 0, DBPrio_Low);
 }

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -652,8 +652,8 @@ public int MenuHandler_Delete(Menu m, MenuAction action, int param1, int param2)
 void OpenDelete(int client, int style)
 {
 	char[] sQuery = new char[512];
-	FormatEx(sQuery, 512, "SELECT p.id, u.name, p.time, p.jumps FROM %splayertimes p JOIN %susers u ON p.auth = u.auth WHERE map = '%s' AND style = '%d' ORDER BY time ASC LIMIT 1000;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, style);
 
+	FormatEx(sQuery, 512, "SELECT p.id, u.name, p.time, p.jumps FROM %splayertimes p JOIN %susers u ON p.auth = u.auth WHERE map = '%s' AND style = '%d' ORDER BY time ASC, date ASC LIMIT 1000;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, style);
 	DataPack datapack = new DataPack();
 	datapack.WriteCell(GetClientSerial(client));
 	datapack.WriteCell(style);
@@ -982,8 +982,8 @@ void StartWRMenu(int client, const char[] map, int style)
 	gH_SQL.Escape(map, sEscapedMap, iLength);
 
 	char[] sQuery = new char[512];
-	FormatEx(sQuery, 512, "SELECT p.id, u.name, p.time, p.jumps, p.auth FROM %splayertimes p JOIN %susers u ON p.auth = u.auth WHERE map = '%s' AND style = %d ORDER BY time ASC;", gS_MySQLPrefix, gS_MySQLPrefix, sEscapedMap, style);
 
+	FormatEx(sQuery, 512, "SELECT p.id, u.name, p.time, p.jumps, p.auth FROM %splayertimes p JOIN %susers u ON p.auth = u.auth WHERE map = '%s' AND style = %d ORDER BY time ASC, date ASC;", gS_MySQLPrefix, gS_MySQLPrefix, sEscapedMap, style);
 	gH_SQL.Query(SQL_WR_Callback, sQuery, dp, DBPrio_High);
 
 	return;
@@ -1083,7 +1083,7 @@ public void SQL_WR_Callback(Database db, DBResultSet results, const char[] error
 
 		if(gF_PlayerRecord[client][gBS_LastWR[client]] == 0.0)
 		{
-			FormatEx(sRanks, 32, "(%d %T%s)", iRecords, "WRRecord", client, (iRecords != 1)? "s":"");
+			FormatEx(sRanks, 32, "(%d %T)", iRecords, "WRRecord", client);
 		}
 
 		else
@@ -1718,8 +1718,8 @@ public void SQL_OnFinish_Callback(Database db, DBResultSet results, const char[]
 void UpdateLeaderboards()
 {
 	char[] sQuery = new char[192];
-	FormatEx(sQuery, 192, "SELECT style, time FROM %splayertimes WHERE map = '%s' ORDER BY time ASC;", gS_MySQLPrefix, gS_Map);
 
+	FormatEx(sQuery, 192, "SELECT style, time FROM %splayertimes WHERE map = '%s' ORDER BY time ASC, date ASC;", gS_MySQLPrefix, gS_Map);
 	gH_SQL.Query(SQL_UpdateLeaderboards_Callback, sQuery, 0, DBPrio_Low);
 }
 

--- a/scripting/shavit-wr.sp
+++ b/scripting/shavit-wr.sp
@@ -442,7 +442,7 @@ void UpdateWRCache()
 	char sQuery[512];
 	// thanks Ollie Jones from stackoverflow! http://stackoverflow.com/a/36239523/5335680
 	// was a bit confused with this one :s
-	FormatEx(sQuery, 512, "SELECT p.style, p.id, s.time, u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time FROM %splayertimes WHERE map = '%s' GROUP BY style) s ON p.style = s.style AND p.time = s.time JOIN %susers u ON p.auth = u.auth GROUP BY p.style;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
+	FormatEx(sQuery, 512, "SELECT p.style, p.id, s.time, u.name FROM %splayertimes p JOIN(SELECT style, MIN(time) time, map FROM %splayertimes WHERE map = '%s' GROUP BY style) s ON p.style = s.style AND p.time = s.time AND p.map = s.map JOIN %susers u ON p.auth = u.auth GROUP BY p.style;", gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, gS_MySQLPrefix);
 
 	gH_SQL.Query(SQL_UpdateWRCache_Callback, sQuery, 0, DBPrio_Low);
 }
@@ -1609,8 +1609,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 		Call_PushCell(strafes);
 		Call_PushCell(sync);
 		Call_Finish();
-
-		UpdateWRCache();
 	}
 
 	int iRank = GetRankForTime(style, time);

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1237,7 +1237,7 @@ public int ZoneCreation_Handler(Menu menu, MenuAction action, int param1, int pa
 
 bool SnapToWall(float pos[3], int client, float final[3])
 {
-	if(AreVectorsEqual(pos, gV_OldPosition[client]) && EmptyVector(gV_WallSnap[client]))
+	if(AreVectorsEqual(pos, gV_OldPosition[client]))
 	{
 		final = gV_WallSnap[client];
 
@@ -1247,28 +1247,24 @@ bool SnapToWall(float pos[3], int client, float final[3])
 	bool snap = false;
 	
 	float end[3];
+	float temp[3];
 
 	for(int i = 0; i < 4; i++)
 	{
 		end = pos;
-		
+
 		int axis = (i / 2);
-		end[axis] += ((i % 2)? -gI_GridSnap[client]:gI_GridSnap[client]);
+		end[axis] += (((i % 2) == 1)? -gI_GridSnap[client]:gI_GridSnap[client]);
 
 		TR_TraceRayFilter(pos, end, MASK_SOLID, RayType_EndPoint, TraceFilter_NoClients, client);
 
 		if(TR_DidHit())
 		{
-			TR_GetEndPosition(end);
-			pos[axis] = end[axis];
+			TR_GetEndPosition(temp);
+			final[axis] = temp[axis];
 
 			snap = true;
 		}
-	}
-
-	if(snap)
-	{
-		final = end;
 	}
 
 	return snap;

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -201,7 +201,6 @@ public void OnPluginStart()
 
 	// events
 	HookEvent("player_spawn", Player_Spawn);
-	HookEvent("player_death", Player_Death);
 	HookEvent("round_start", Round_Start);
 
 	// forwards
@@ -539,10 +538,10 @@ void UnloadZones(int zone)
 			{
 				for(int j = 1; j <= MaxClients; j++)
 				{
-					if(IsValidClient(j) && gB_InsideZoneID[j][gA_ZoneCache[i][iDatabaseID]]) // no alive check because it may happen to dead players too
+					if(IsValidClient(j) && gB_InsideZoneID[j][i]) // no alive check because it may happen to dead players too
 					{
 						gB_InsideZone[j][gA_ZoneCache[i][iZoneType]][gA_ZoneCache[i][iZoneTrack]] = false;
-						gB_InsideZoneID[j][gA_ZoneCache[i][iDatabaseID]] = false;
+						gB_InsideZoneID[j][i] = false;
 					}
 				}
 
@@ -2063,20 +2062,6 @@ public void Player_Spawn(Event event, const char[] name, bool dontBroadcast)
 	Reset(GetClientOfUserId(event.GetInt("userid")));
 }
 
-public void Player_Death(Event event, const char[] name, bool dontBroadcast)
-{
-	int client = GetClientOfUserId(event.GetInt("userid"));
-	
-	for(int i = 0; i < gI_MapZones; i++)
-	{
-		if(gB_InsideZoneID[client][gA_ZoneCache[i][iDatabaseID]])
-		{
-			gB_InsideZone[client][gA_ZoneCache[i][iZoneType]][gA_ZoneCache[i][iZoneTrack]] = false;
-			gB_InsideZoneID[client][gA_ZoneCache[i][iDatabaseID]] = false;
-		}
-	}
-}
-
 public void Round_Start(Event event, const char[] name, bool dontBroadcast)
 {
 	CreateTimer(1.0, Timer_CreateZoneEntities);
@@ -2171,7 +2156,7 @@ public void CreateZoneEntities()
 
 public void StartTouchPost(int entity, int other)
 {
-	if(other < 1 || other > MaxClients || !IsPlayerAlive(other) || !gA_ZoneCache[gI_EntityZone[entity]][bZoneInitialized])
+	if(other < 1 || other > MaxClients || !gA_ZoneCache[gI_EntityZone[entity]][bZoneInitialized] || IsFakeClient(other))
 	{
 		return;
 	}
@@ -2228,7 +2213,7 @@ public void StartTouchPost(int entity, int other)
 
 public void EndTouchPost(int entity, int other)
 {
-	if(other < 1 || other > MaxClients || !IsPlayerAlive(other))
+	if(other < 1 || other > MaxClients || IsFakeClient(other))
 	{
 		return;
 	}
@@ -2247,7 +2232,7 @@ public void EndTouchPost(int entity, int other)
 
 public void TouchPost(int entity, int other)
 {
-	if(other < 1 || other > MaxClients || !IsPlayerAlive(other))
+	if(other < 1 || other > MaxClients || IsFakeClient(other))
 	{
 		return;
 	}

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1210,6 +1210,11 @@ public int ZoneCreation_Handler(Menu menu, MenuAction action, int param1, int pa
 				if(gB_SnapToWall[param1])
 				{
 					gB_CursorTracing[param1] = false;
+
+					if(gI_GridSnap[param1] < 32)
+					{
+						gI_GridSnap[param1] = 32;
+					}
 				}
 			}
 

--- a/scripting/shavit-zones.sp
+++ b/scripting/shavit-zones.sp
@@ -1244,10 +1244,13 @@ bool SnapToWall(float pos[3], int client, float final[3])
 		return true;
 	}
 
-	bool snap = false;
-	
+	bool hit = false;
+
 	float end[3];
 	float temp[3];
+
+	float prefinal[3];
+	prefinal = pos;
 
 	for(int i = 0; i < 4; i++)
 	{
@@ -1261,13 +1264,19 @@ bool SnapToWall(float pos[3], int client, float final[3])
 		if(TR_DidHit())
 		{
 			TR_GetEndPosition(temp);
-			final[axis] = temp[axis];
-
-			snap = true;
+			prefinal[axis] = temp[axis];
+			hit = true;
 		}
 	}
 
-	return snap;
+	if(hit && GetVectorDistance(prefinal, pos) <= gI_GridSnap[client])
+	{
+		final = prefinal;
+
+		return true;
+	}
+
+	return false;
 }
 
 public bool TraceFilter_NoClients(int entity, int contentsMask, any data)
@@ -2068,7 +2077,7 @@ public Action Timer_CreateZoneEntities(Handle Timer)
 	CreateZoneEntities();
 }
 
-float abs(float input)
+float Abs(float input)
 {
 	if(input < 0.0)
 	{
@@ -2123,9 +2132,9 @@ public void CreateZoneEntities()
 
 		TeleportEntity(entity, gV_ZoneCenter[i], NULL_VECTOR, NULL_VECTOR);
 
-		float distance_x = abs(gV_MapZones[i][0][0] - gV_MapZones[i][7][0]);
-		float distance_y = abs(gV_MapZones[i][0][1] - gV_MapZones[i][7][1]);
-		float distance_z = abs(gV_MapZones[i][0][2] - gV_MapZones[i][7][2]);
+		float distance_x = Abs(gV_MapZones[i][0][0] - gV_MapZones[i][7][0]);
+		float distance_y = Abs(gV_MapZones[i][0][1] - gV_MapZones[i][7][1]);
+		float distance_z = Abs(gV_MapZones[i][0][2] - gV_MapZones[i][7][2]);
 
 		float min[3];
 		min[0] = -(distance_x / 2) + 16.0;

--- a/translations/shavit-core.phrases.txt
+++ b/translations/shavit-core.phrases.txt
@@ -64,6 +64,16 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"{1}WARNING: {2}You're now in practice mode. Your times WILL NOT be saved and will be only displayed to you!"
 	}
+	"SHSWCombination0"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"Your SHSW combination is {1}W/A & S/D{2}."
+	}
+	"SHSWCombination1"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"Your SHSW combination is {1}W/D & S/A{2}."
+	}
 	// ---------- Pauses ---------- //
 	"MessagePause"
 	{

--- a/translations/shavit-hud.phrases.txt
+++ b/translations/shavit-hud.phrases.txt
@@ -112,7 +112,7 @@
 	}
 	"NoReplayData"
 	{
-		"en"		"No replay data loaded"
+		"en"		"No replay data loaded\nPress USE to play"
 	}
 	// ---------- Panels ---------- //
 	"SpectatorPersonal"

--- a/translations/shavit-hud.phrases.txt
+++ b/translations/shavit-hud.phrases.txt
@@ -112,7 +112,7 @@
 	}
 	"NoReplayData"
 	{
-		"en"		"No replay data loaded\nPress USE to play"
+		"en"		"No replay data loaded\nPress USE or beat #1 to play"
 	}
 	// ---------- Panels ---------- //
 	"SpectatorPersonal"

--- a/translations/shavit-misc.phrases.txt
+++ b/translations/shavit-misc.phrases.txt
@@ -73,6 +73,11 @@
 		"#format"	"{1:d},{2:s},{3:s}"
 		"en"		"{2}Teleported{3} to checkpoint ({1})."
 	}
+	"MiscCheckpointsEmpty"
+	{
+		"#format"	"{1:d},{2:s},{3:s}"
+		"en"		"Checkpoint {1} is {2}empty{3}."
+	}
 	// ---------- Menus ---------- //
 	"TeleportMenuTitle"
 	{

--- a/translations/shavit-replay.phrases.txt
+++ b/translations/shavit-replay.phrases.txt
@@ -33,4 +33,26 @@
 		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Could not delete replay for {1}{2}{3}."
 	}
+	// ---------- Central Replay Menu ---------- //
+	"CentralReplaySpectator"
+	{
+		"#format"	"{1:s},{2:s},{3:s},{4:s}"
+		"en"		"You have to {1}spectate{2} the {3}central bot{4} to use this feature."
+	}
+	"CentralReplayTitle"
+	{
+		"en"		"Select a replay style to play:"
+	}
+	"CentralReplayPlaying"
+	{
+		"en"		"The replay bot is busy, try again when it's idle."
+	}
+	"CentralReplayStop"
+	{
+		"en"		"Stop the current replay."
+	}
+	"CentralReplayStopped"
+	{
+		"en"		"Forcibly stopped replay."
+	}
 }

--- a/translations/shavit-wr.phrases.txt
+++ b/translations/shavit-wr.phrases.txt
@@ -142,7 +142,7 @@
 	}
 	"WRRecord"
 	{
-		"en"		"record"
+		"en"		"records"
 	}
 	"WRRecordFor"
 	{

--- a/translations/shavit-wr.phrases.txt
+++ b/translations/shavit-wr.phrases.txt
@@ -14,15 +14,16 @@
 		"#format"	"{1:s},{2:s},{3:s}"
 		"en"		"Deleted ALL records for {1}{2}{3}."
 	}
+	"DeletedRecordsStyle"
+	{
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"Deleted ALL records for {1}{2}{3}."
+	}
 	// ---------- Client Menus ---------- //
 	"ListClientRecords"
 	{
 		"#format"	"{1:s},{2:s}"
 		"en"		"Records for {1}:\n({2})"
-	}
-	"ListClientRecordsNone"
-	{
-		"en"		"No records found."
 	}
 	// ---------- Completion Messages ---------- //
 	"FirstCompletion"
@@ -78,6 +79,25 @@
 	"MenuResponseYes"
 	{
 		"en"		"YES!!! DELETE ALL THE RECORDS!!! THIS ACTION IS IRREVERSIBLE!"
+	}
+	"DeleteStyleRecords"
+	{
+		"en"		"Delete ALL map records for a style"
+	}
+	"DeleteStyleRecordsRecordsMenuTitle"
+	{
+		"#format"	"{1:s}"
+		"en"		"Choose a style to delete all the records of for '{1}':"
+	}
+	"DeleteConfirmStyle"
+	{
+		"#format"	"{1:s}"
+		"en"		"Are you sure you want to delete ALL THE RECORDS for {1}?"
+	}
+	"MenuResponseYesStyle"
+	{
+		"#format"	"{1:s}"
+		"en"		"YES!!! DELETE THE RECORDS FOR {1}!!! THIS ACTION IS IRREVERSIBLE!"
 	}
 	// ---------- Errors ---------- //
 	"DatabaseError"

--- a/translations/shavit-zones.phrases.txt
+++ b/translations/shavit-zones.phrases.txt
@@ -206,4 +206,20 @@
 	{
 		"en"		"Change zone track"
 	}
+	"ZoneEdit"
+	{
+		"en"		"Edit a map zone"
+	}
+	"ZoneEditTitle"
+	{
+		"en"		"Choose a zone to edit:"
+	}
+	"ZoneInside"
+	{
+		"en"		"(Inside!)"
+	}
+	"ZoneEditRefresh"
+	{
+		"en"		"Refresh menu"
+	}
 }


### PR DESCRIPTION
I'm trying to speed up development, as you can see :)

* Added zone edit capabilities. (As requested in #299)
![Zone edit](https://user-images.githubusercontent.com/3672466/28152811-10c83cd0-67ab-11e7-93c9-a7ce3eb9b0fa.png)

* Made zone deletion menu mark zones if you're inside them.
![Zone deletion](https://user-images.githubusercontent.com/3672466/28152836-2d158582-67ab-11e7-9a8b-8a3489bee28b.png)

* Added sounds for `worst` record and added `Shavit_OnWorstRecord`, as requested in #293. Also re-implemented `Shavit_GetRecordAmount` because the implementation disappeared for some reason..

* Added 'smart' map lookup for `sm_wr` (per #268). You can now write `sm_map dges2` for a lazy lookup of `bhop_badges2`, or `sm_wr yonk` for a lookup of `kz_bhop_yonkoma` etc. For the yonkoma example, the first map (sorted by alphabet ascendance) will be chosen.  So `bhop_kz_yonkoma_ez` will be the first result if it's present in the server.

* Implemented `shavit_misc_dropall` to allow every weapon to be dropped (including knife/grenades).

* Added a central replay bot as requested in #195. Use with `!replay`, toggle with `shavit_replay_centralbot`. The command `!replay stop` can be used to stop the current replay playback (and is also available from the `!replay` menu itself.) - RCON flag is required. You can also open the `!replay` by pressing USE (default: E) while spectating the central bot! (Idea from bTimes)
![New replay menu demonstration](https://user-images.githubusercontent.com/3672466/28177365-4013544a-6803-11e7-903a-f84d112ebdc9.png)

* Allowed replays to save to disk even if the style has them disabled.

* Removed `BhopStyle` - no idea why I thought it's a better idea than regular integers to begin with..

* Fixed `shavit_replay_defaultteam` changes not taking effect. Fortunately I found this one myself before the plugin is out of beta..

* Fixed leaving zones not registering properly after changing teams or deleting the zones. (#391)

* Removed pagination and lifetime from the checkpoints menu (#392). Added `sm_checkpoint and sm_checkpoints` aliases to it too.

* Added a file where you can configure the styling for the replay bots' names. See `sourcemod/configs/shavit-replay.cfg`! (#390)

* Re-implemented wall snapping during zone setup so it snaps to corners and walls. It will also adjust the grid snap to 32 automatically (if it's lower) for easier times.

* Implemented a Surf-HSW style setting as requested in #239. Set `force_hsw` in the style configuration file to 2 in order to use this setting.

* Fixed player stats not opening from the WR submenu.

* Fixed an issue with the WR cache updating identical recorded times from different maps. (#377)

* Added physics settings (move type, speed multiplier and gravity) to checkpoints to avoid situations that are impossible in realtime. (#398)

* Added the ability to delete all records for one style, as requested in #397.