### PR TITLE
Remove current style text from style menu

### DIFF
--- a/scripting/shavit-core.sp
+++ b/scripting/shavit-core.sp
@@ -580,7 +580,7 @@ public Action Command_Style(int client, int args)
 	}
 
 	Menu menu = new Menu(StyleMenu_Handler);
-	menu.SetTitle("%T\n%T\n ", "StyleMenuTitle", client, "StyleMenuCurrent", client, gS_StyleStrings[gBS_Style[client]][sStyleName]);
+	menu.SetTitle("%T", "StyleMenuTitle", client);
 
 	for(int i = 0; i < gI_Styles; i++)
 	{

--- a/translations/shavit-core.phrases.txt
+++ b/translations/shavit-core.phrases.txt
@@ -29,21 +29,16 @@
 	// ---------- Menus ---------- //
 	"StyleMenuTitle"
 	{
-		"en"		"Choose a style"
+		"en"		"Choose a style:"
 	}
 	"StyleSelection"
 	{
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"You have selected to play {1}{2}{3}."
+		"en"		"You have chosen to play {1}{2}{3}."
 	}
 	"StyleUnranked"
 	{
 		"en"		"[Unranked]"
-	}
-	"StyleMenuCurrent"
-	{
-		"#format"	"{1:s}"
-		"en"		"Current: {1}"
 	}
 	// ---------- Misc ---------- //
 	"LeftRightCheat"


### PR DESCRIPTION
This isn't really needed anymore since a player's current style appears in their HUD and is greyed out in the menu. I've also changed the layout a little simply so it matches the !wr menu appearance.