### PR TITLE
Add "shavit_misc_noblood" for hiding blood effects.

### DIFF
--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -2094,28 +2094,30 @@ public Action Shotgun_Shot(const char[] te_name, const int[] Players, int numCli
 
 public Action EffectDispatch(const char[] te_name, const Players[], int numClients, float delay)
 {
+	if(!gB_NoBlood)
+	{
+		return Plugin_Continue;
+	}
+
 	int iEffectIndex = TE_ReadNum("m_iEffectName");
 	int nHitBox = TE_ReadNum("m_nHitBox");
-	char sEffectName[64];
 
-	GetEffectName(iEffectIndex, sEffectName, 64);
+	char[] sEffectName = new char[32];
+	GetEffectName(iEffectIndex, sEffectName, 32);
 
-	if(gB_NoBlood)
+	if(StrEqual(sEffectName, "csblood"))
 	{
-		if(StrEqual(sEffectName, "csblood"))
+		return Plugin_Handled;
+	}
+
+	if(StrEqual(sEffectName, "ParticleEffect"))
+	{
+		char[] sParticleEffectName = new char[32];
+		GetParticleEffectName(nHitBox, sParticleEffectName, 32);
+
+		if(StrEqual(sParticleEffectName, "impact_helmet_headshot") || StrEqual(sParticleEffectName, "impact_physics_dust"))
 		{
 			return Plugin_Handled;
-		}
-
-		if(StrEqual(sEffectName, "ParticleEffect"))
-		{
-			char sParticleEffectName[64];
-			GetParticleEffectName(nHitBox, sParticleEffectName, 64);
-
-			if(StrEqual(sParticleEffectName, "impact_helmet_headshot") || StrEqual(sParticleEffectName, "impact_physics_dust"))
-			{
-				return Plugin_Handled;
-			}
 		}
 	}
 
@@ -2124,29 +2126,32 @@ public Action EffectDispatch(const char[] te_name, const Players[], int numClien
 
 public Action WorldDecal(const char[] te_name, const Players[], int numClients, float delay)
 {
-	float vecOrigin[3];
-	int nIndex = TE_ReadNum("m_nIndex");
-	char sDecalName[64];
-
-	TE_ReadVector("m_vecOrigin", vecOrigin);
-	GetDecalName(nIndex, sDecalName, 64);
-    
-	if(gB_NoBlood)
+	if(!gB_NoBlood)
 	{
-		if(StrContains(sDecalName, "decals/blood") == 0 && StrContains(sDecalName, "_subrect") != -1)
-		{
-			return Plugin_Handled;
-		}
+		return Plugin_Continue;
+	}
+
+	float vecOrigin[3];
+	TE_ReadVector("m_vecOrigin", vecOrigin);
+	
+	int nIndex = TE_ReadNum("m_nIndex");
+
+	char[] sDecalName = new char[32];
+	GetDecalName(nIndex, sDecalName, 32);
+
+	if(StrContains(sDecalName, "decals/blood") == 0 && StrContains(sDecalName, "_subrect") != -1)
+	{
+		return Plugin_Handled;
 	}
 
 	return Plugin_Continue;
 }
 
-public int GetParticleEffectName(int index, char[] sEffectName, int maxlen)
+static int GetParticleEffectName(int index, char[] sEffectName, int maxlen)
 {
 	int table = INVALID_STRING_TABLE;
 	
-	if (table == INVALID_STRING_TABLE)
+	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("ParticleEffectNames");
 	}
@@ -2154,11 +2159,11 @@ public int GetParticleEffectName(int index, char[] sEffectName, int maxlen)
 	return ReadStringTable(table, index, sEffectName, maxlen);
 }
 
-public int GetEffectName(int index, char[] sEffectName, int maxlen)
+static int GetEffectName(int index, char[] sEffectName, int maxlen)
 {
 	int table = INVALID_STRING_TABLE;
 	
-	if (table == INVALID_STRING_TABLE)
+	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("EffectDispatch");
 	}
@@ -2166,11 +2171,11 @@ public int GetEffectName(int index, char[] sEffectName, int maxlen)
 	return ReadStringTable(table, index, sEffectName, maxlen);
 }
 
-public int GetDecalName(int index, char[] sDecalName, int maxlen)
+static int GetDecalName(int index, char[] sDecalName, int maxlen)
 {
 	int table = INVALID_STRING_TABLE;
 	
-	if (table == INVALID_STRING_TABLE)
+	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("decalprecache");
 	}

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -2133,7 +2133,7 @@ public Action WorldDecal(const char[] te_name, const Players[], int numClients, 
 
 	float vecOrigin[3];
 	TE_ReadVector("m_vecOrigin", vecOrigin);
-	
+
 	int nIndex = TE_ReadNum("m_nIndex");
 
 	char[] sDecalName = new char[32];
@@ -2147,39 +2147,39 @@ public Action WorldDecal(const char[] te_name, const Players[], int numClients, 
 	return Plugin_Continue;
 }
 
-static int GetParticleEffectName(int index, char[] sEffectName, int maxlen)
+int GetParticleEffectName(int index, char[] sEffectName, int maxlen)
 {
-	int table = INVALID_STRING_TABLE;
-	
+	static int table = INVALID_STRING_TABLE;
+
 	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("ParticleEffectNames");
 	}
-	
+
 	return ReadStringTable(table, index, sEffectName, maxlen);
 }
 
-static int GetEffectName(int index, char[] sEffectName, int maxlen)
+int GetEffectName(int index, char[] sEffectName, int maxlen)
 {
-	int table = INVALID_STRING_TABLE;
-	
+	static int table = INVALID_STRING_TABLE;
+
 	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("EffectDispatch");
 	}
-	
+
 	return ReadStringTable(table, index, sEffectName, maxlen);
 }
 
-static int GetDecalName(int index, char[] sDecalName, int maxlen)
+int GetDecalName(int index, char[] sDecalName, int maxlen)
 {
-	int table = INVALID_STRING_TABLE;
-	
+	static int table = INVALID_STRING_TABLE;
+
 	if(table == INVALID_STRING_TABLE)
 	{
 		table = FindStringTable("decalprecache");
 	}
-	
+
 	return ReadStringTable(table, index, sDecalName, maxlen);
 }
 


### PR DESCRIPTION
Hides all the blood effects including decals, splashes and other particles. Especially useful on hard maps where everyone is sitting at the spawn, hitting each other just to make the map "slightly" more red. :>
Not to mention that blood decals can sometimes make maps slightly harder if you have a lot of them in one place.