### PR TITLE
fix it saying you teleported when you might've not

### DIFF
--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1412,8 +1412,6 @@ public Action Command_Tele(int client, int args)
 
 	TeleportToCheckpoint(client, index);
 
-	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
-
 	return Plugin_Handled;
 }
 
@@ -1610,6 +1608,8 @@ void TeleportToCheckpoint(int client, int index)
 	{
 		Shavit_StopTimer(client);
 	}
+	
+	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 }
 
 public Action Command_Noclip(int client, int args)

--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1410,7 +1410,7 @@ public Action Command_Tele(int client, int args)
 		return Plugin_Handled;
 	}
 
-	TeleportToCheckpoint(client, index);
+	TeleportToCheckpoint(client, index, false);
 
 	return Plugin_Handled;
 }
@@ -1497,7 +1497,7 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 
 			case 1:
 			{
-				TeleportToCheckpoint(param1, current - 1);
+				TeleportToCheckpoint(param1, current - 1, true);
 			}
 
 			case 2:
@@ -1573,7 +1573,7 @@ void SaveCheckpoint(int client, int index)
 	Shavit_SaveSnapshot(client, gA_CheckpointsSnapshots[client][index]);
 }
 
-void TeleportToCheckpoint(int client, int index)
+void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 {
 	if(index < 0 || index >= CP_MAX || IsNullVector(gF_Checkpoints[client][index][0]))
 	{
@@ -1609,7 +1609,10 @@ void TeleportToCheckpoint(int client, int index)
 		Shavit_StopTimer(client);
 	}
 	
-	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+	if(!suppressMessage)
+	{
+		Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+	}
 }
 
 public Action Command_Noclip(int client, int args)


### PR DESCRIPTION
example: make a checkpoint then hold +duck and try to teleport to it with !tele or sm_tele and it'll say that you must be ducking to teleport and it also says you teleported while you were not teleported