### PR TITLE
Additions and fixes

### DIFF
--- a/addons/sourcemod/configs/shavit-zones.cfg
+++ b/addons/sourcemod/configs/shavit-zones.cfg
@@ -125,5 +125,29 @@
 			"alpha"		"175"
 			"width"		"2.5"
 		}
+
+		"Bonus Start"
+		{
+			"visible"	"1"
+			
+			"red"		"255"
+			"green"		"255"
+			"blue"		"255"
+			
+			"alpha"		"255"
+			"width"		"0.1"
+		}
+
+		"Bonus End"
+		{
+			"visible"	"1"
+			
+			"red"		"123"
+			"green"		"20"
+			"blue"		"250"
+			
+			"alpha"		"255"
+			"width"		"0.1"
+		}
 	}
 }

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -950,6 +950,23 @@ native ArrayList Shavit_GetReplayData(int client);
 native void Shavit_StopChatSound();
 
 /**
+ * Gets the map tier for a specified map.
+ * Use the map's display name.
+ *
+ * @param map						Map to get the tier of.
+ * @return							Map tier. 0 if no results were found.
+ */
+native int Shavit_GetMapTier(const char[] map);
+
+/**
+ * Gets a StringMap that contains all the cached map tiers.
+ * The returned StringMap must be deleted from memory after use!
+ *
+ * @return							StringMap with {const char[]: map, int: tier} structure.
+ */
+native StringMap Shavit_GetMapTiers();
+
+/**
  * Use this native when printing anything in chat if it's related to the timer.
  * This native will auto-assign colors and a chat prefix.
  *
@@ -1002,6 +1019,8 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetDatabase");
 	MarkNativeAsOptional("Shavit_GetDB");
 	MarkNativeAsOptional("Shavit_GetHUDSettings");
+	MarkNativeAsOptional("Shavit_GetMapTier");
+	MarkNativeAsOptional("Shavit_GetMapTiers");
 	MarkNativeAsOptional("Shavit_GetPlayerPB");
 	MarkNativeAsOptional("Shavit_GetPoints");
 	MarkNativeAsOptional("Shavit_GetRank");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -953,7 +953,7 @@ native void Shavit_SetReplayData(int client, ArrayList data);
 native ArrayList Shavit_GetReplayData(int client);
 
 /**
- * Reloads a specific replay into the repla bot cache.
+ * Reloads a specific replay into the replay bot cache.
  * Note: Not guaranteed to work with legacy replay bots.
  *
  * @param style						Replay style.

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -689,9 +689,19 @@ native int Shavit_GetRecordAmount(int style, int track);
  * @param style						Bhop style.
  * @param time						Time to check for.
  * @param track						Timer track.
- * @return							Amount of records.
+ * @return							Map rank.
  */
 native int Shavit_GetRankForTime(int style, float time, int track);
+
+/**
+ * Retrieves the time of a record from a specified rank.
+ *
+ * @param style						Bhop style.
+ * @param rank						Rank to retrieve the time from.
+ * @param track						Timer track.
+ * @return							Record time. 0.0 if none.
+ */
+native float Shavit_GetTimeForRank(int style, int rank, int track);
 
 /**
  * Checks if a mapzone exists.
@@ -1038,6 +1048,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetStyleSettings");
 	MarkNativeAsOptional("Shavit_GetStyleStrings");
 	MarkNativeAsOptional("Shavit_GetSync");
+	MarkNativeAsOptional("Shavit_GetTimeForRank");
 	MarkNativeAsOptional("Shavit_GetTimer");
 	MarkNativeAsOptional("Shavit_GetTimerStatus");
 	MarkNativeAsOptional("Shavit_GetWRCount");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -601,7 +601,7 @@ native int Shavit_GetClientJumps(int client);
  * Retrieve a client's bhopstyle
  *
  * @param client					Client index.
- * @return                          Bhop style.
+ * @return                          Style.
  */
 native int Shavit_GetBhopStyle(int client);
 
@@ -677,7 +677,7 @@ native void Shavit_GetPlayerPB(int client, int style, float &time, int track);
 /**
  * Get the amount of records on the current map/style on a track.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @param track						Timer track.
  * @return							Amount of records.
  */
@@ -686,7 +686,7 @@ native int Shavit_GetRecordAmount(int style, int track);
 /**
  * Calculate potential rank for a given style and time.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @param time						Time to check for.
  * @param track						Timer track.
  * @return							Map rank.
@@ -696,7 +696,7 @@ native int Shavit_GetRankForTime(int style, float time, int track);
 /**
  * Retrieves the time of a record from a specified rank.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @param rank						Rank to retrieve the time from.
  * @param track						Timer track.
  * @return							Record time. 0.0 if none.
@@ -749,7 +749,7 @@ native void Shavit_ResumeTimer(int client);
 /**
  * Retrieve the engine time of the replay bot's first frame.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @param time						Reference to save the time on.
  * @noreturn
  */
@@ -758,7 +758,7 @@ native void Shavit_GetReplayBotFirstFrame(int style, float &time);
 /**
  * Retrieve the replay bot's client index.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @return							Client index for the replay bot.
  */
 native int Shavit_GetReplayBotIndex(int style);
@@ -782,7 +782,7 @@ native int Shavit_GetReplayBotTrack(int client);
 /**
  * Retrieve the replay bot's current played frame.
  *
- * @param style						Bhop style.
+ * @param style						Style.
  * @return							Current played frame.
  */
 native int Shavit_GetReplayBotCurrentFrame(int style);
@@ -790,10 +790,11 @@ native int Shavit_GetReplayBotCurrentFrame(int style);
 /**
  * Checks if there's loaded replay data for a bhop style or not.
  *
- * @param style						Bhop style.
+ * @param style						Style.
+ * @param track						Track.
  * @return							Boolean value of if there's loaded replay data.
  */
-native bool Shavit_IsReplayDataLoaded(int style);
+native bool Shavit_IsReplayDataLoaded(int style, int track);
 
 /**
  * Gets player points.
@@ -952,6 +953,27 @@ native void Shavit_SetReplayData(int client, ArrayList data);
 native ArrayList Shavit_GetReplayData(int client);
 
 /**
+ * Reloads a specific replay into the repla bot cache.
+ * Note: Not guaranteed to work with legacy replay bots.
+ *
+ * @param style						Replay style.
+ * @param track						Replay track.
+ * @param restart					Restart the playback of the replay bot if it's playing?
+ * @param path						Path to the replay file. Use `BuildPath(Path_SM, ...)` to generate one. Leave as empty to use default.
+ * @return							Was the replay loaded?
+ */
+native bool Shavit_ReloadReplay(int style, int track, bool restart, char[] path = "");
+
+/**
+ * Reloads all of the replays for the map.
+ * Note: Not guaranteed to work with legacy replay bots.
+ *
+ * @param restart					Restart the playback of the replay bots?
+ * @return							Amount of loaded replays.
+ */
+native int Shavit_ReloadReplays(bool restart);
+
+/**
  * Use this native to stop the chat tick sound that happens in CS:S.
  * Call it before each Shavit_PrintToChat() or Shavit_PrintToChatAll().
  *
@@ -1064,6 +1086,8 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_PauseTimer");
 	MarkNativeAsOptional("Shavit_PrintToChat");
 	MarkNativeAsOptional("Shavit_RestartTimer");
+	MarkNativeAsOptional("Shavit_ReloadReplay");
+	MarkNativeAsOptional("Shavit_ReloadReplays");
 	MarkNativeAsOptional("Shavit_ResumeTimer");
 	MarkNativeAsOptional("Shavit_SaveSnapshot");
 	MarkNativeAsOptional("Shavit_SetPracticeMode");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -226,8 +226,7 @@ enum
 	TRACKS_SIZE
 };
 
-// let's not throw errors k?
-stock bool IsValidClient(int client, bool bAlive = false) // when bAlive is false = technical checks, when it's true = gameplay checks
+stock bool IsValidClient(int client, bool bAlive = false)
 {
 	return (client >= 1 && client <= MaxClients && IsClientConnected(client) && IsClientInGame(client) && !IsClientSourceTV(client) && (!bAlive || IsPlayerAlive(client)));
 }

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -982,6 +982,20 @@ native int Shavit_ReloadReplays(bool restart);
 native void Shavit_StopChatSound();
 
 /**
+ * Marks a map as a KZ map.
+ *
+ * @noreturn
+ */
+native void Shavit_MarkKZMap();
+
+/**
+ * Lets us know if the map was marked as a KZ map.
+ *
+ * @return							Boolean value.
+ */
+native bool Shavit_IsKZMap();
+
+/**
  * Gets the map tier for a specified map.
  * Use the map's display name.
  *
@@ -1079,15 +1093,17 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetWRTime");
 	MarkNativeAsOptional("Shavit_InsideZone");
 	MarkNativeAsOptional("Shavit_IsClientCreatingZone");
+	MarkNativeAsOptional("Shavit_IsKZMap");
 	MarkNativeAsOptional("Shavit_IsPracticeMode");
 	MarkNativeAsOptional("Shavit_IsReplayDataLoaded");
 	MarkNativeAsOptional("Shavit_LoadSnapshot");
+	MarkNativeAsOptional("Shavit_MarkKZMap");
 	MarkNativeAsOptional("Shavit_OpenStatsMenu");
 	MarkNativeAsOptional("Shavit_PauseTimer");
 	MarkNativeAsOptional("Shavit_PrintToChat");
-	MarkNativeAsOptional("Shavit_RestartTimer");
 	MarkNativeAsOptional("Shavit_ReloadReplay");
 	MarkNativeAsOptional("Shavit_ReloadReplays");
+	MarkNativeAsOptional("Shavit_RestartTimer");
 	MarkNativeAsOptional("Shavit_ResumeTimer");
 	MarkNativeAsOptional("Shavit_SaveSnapshot");
 	MarkNativeAsOptional("Shavit_SetPracticeMode");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -378,9 +378,10 @@ forward void Shavit_OnFinish_Post(int client, int style, float time, int jumps, 
  * @param strafes					Amount of strafes.
  * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
  * @param track						Timer track.
+ * @param oldwr						Time of the old WR. 0.0 if there's none.
  * @noreturn
  */
-forward void Shavit_OnWorldRecord(int client, int style, float time, int jumps, int strafes, float sync, int track);
+forward void Shavit_OnWorldRecord(int client, int style, float time, int jumps, int strafes, float sync, int track, float oldwr);
 
 /**
  * Called when an admin deletes a WR.

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -243,7 +243,7 @@ public Action Command_CCName(int client, int args)
 	if(args == 0 || strlen(sArgs) == 0)
 	{
 		Shavit_PrintToChat(client, "%T", "ArgumentsMissing", client, "sm_ccname <text>");
-		Shavit_PrintToChat(client, "%T", "ChatCurrent", client, sArgs);
+		Shavit_PrintToChat(client, "%T", "ChatCurrent", client, gS_CustomName[client]);
 
 		return Plugin_Handled;
 	}
@@ -293,7 +293,7 @@ public Action Command_CCMessage(int client, int args)
 	if(args == 0 || strlen(sArgs) == 0)
 	{
 		Shavit_PrintToChat(client, "%T", "ArgumentsMissing", client, "sm_ccmsg <text>");
-		Shavit_PrintToChat(client, "%T", "ChatCurrent", client, sArgs);
+		Shavit_PrintToChat(client, "%T", "ChatCurrent", client, gS_CustomMessage[client]);
 
 		return Plugin_Handled;
 	}

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -369,15 +369,18 @@ public Action CP_OnChatMessage(int &author, ArrayList recipients, char[] flagstr
 		FormatRandom(message, MAXLENGTH_MESSAGE);
 	}
 
+	#if defined DEBUG
+	PrintToServer("%N %s", author, flagstring);
+	#endif
+
 	bool allchat = (StrContains(flagstring, "_All") != -1);
 	int team = GetClientTeam(author);
 
 	recipients.Clear();
-	recipients.Push(author);
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
-		if(i != author && IsClientInGame(i) && (allchat || GetClientTeam(i) == team))
+		if(i == author || (IsClientInGame(i) && (allchat || GetClientTeam(i) == team)))
 		{
 			recipients.Push(i);
 		}

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -61,6 +61,11 @@ public Plugin myinfo =
 public void OnAllPluginsLoaded()
 {
 	gB_RTLer = LibraryExists("rtler");
+
+	if(gH_SQL == null)
+	{
+		Shavit_OnDatabaseLoaded();
+	}
 }
 
 public void OnPluginStart()

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -45,6 +45,7 @@ bool gB_Sounds = false;
 int gI_Cycle = 0;
 int gI_GradientColors[3];
 int gI_GradientDirection = -1;
+int gI_Styles = 0;
 
 Handle gH_HUDCookie = null;
 int gI_HUDSettings[MAXPLAYERS+1];
@@ -139,9 +140,14 @@ public void OnPluginStart()
 	{
 		for(int i = 1; i <= MaxClients; i++)
 		{
-			if(IsValidClient(i) && AreClientCookiesCached(i))
+			if(IsValidClient(i))
 			{
-				OnClientCookiesCached(i);
+				OnClientPutInServer(i);
+
+				if(AreClientCookiesCached(i))
+				{
+					OnClientCookiesCached(i);
+				}
 			}
 		}
 	}
@@ -222,6 +228,8 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 	{
 		styles = Shavit_GetStyleCount();
 	}
+
+	gI_Styles = styles;
 
 	for(int i = 0; i < styles; i++)
 	{
@@ -825,25 +833,7 @@ public void Bunnyhop_OnTouchGround(int client)
 
 public void Bunnyhop_OnJumpPressed(int client)
 {
-	if(gEV_Type != Engine_CSS)
-	{
-		return;
-	}
-
 	gI_ScrollCount[client] = BunnyhopStats.GetScrollCount(client);
-
-	if(gA_StyleSettings[gBS_Style[client]][bAutobhop])
-	{
-		return;
-	}
-
-	for(int i = 1; i <= MaxClients; i++)
-	{
-		if(i == client || (IsValidClient(i) && GetHUDTarget(i) == client))
-		{
-			UpdateCenterKeys(i);
-		}
-	}
 }
 
 void UpdateCenterKeys(int client)
@@ -868,7 +858,14 @@ void UpdateCenterKeys(int client)
 		(buttons & IN_FORWARD) > 0? "Ｗ":"ｰ", (buttons & IN_MOVELEFT) > 0? "Ａ":"ｰ",
 		(buttons & IN_BACK) > 0? "Ｓ":"ｰ", (buttons & IN_MOVERIGHT) > 0? "Ｄ":"ｰ");
 
-	if(gB_BhopStats && !gA_StyleSettings[gBS_Style[target]][bAutobhop])
+	int style = (IsFakeClient(target))? Shavit_GetReplayBotStyle(target):gBS_Style[target];
+
+	if(style < 0 || style > gI_Styles)
+	{
+		style = 0;
+	}
+
+	if(gB_BhopStats && !gA_StyleSettings[style][bAutobhop])
 	{
 		Format(sCenterText, 64, "%s\n　　%d　%d", sCenterText, gI_ScrollCount[target], gI_LastScrollCount[target]);
 	}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -892,11 +892,12 @@ void UpdateSpectatorList(int client, Panel panel, bool &draw)
 
 	int[] iSpectatorClients = new int[MaxClients];
 	int iSpectators = 0;
+	bool bIsAdmin = CheckCommandAccess(client, "admin_speclisthide", ADMFLAG_KICK);
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
 		if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target || GetClientTeam(i) < 1
-			|| CheckCommandAccess(i, "admin_speclisthide", ADMFLAG_KICK))
+			|| (!bIsAdmin && CheckCommandAccess(i, "admin_speclisthide", ADMFLAG_KICK)))
 		{
 			continue;
 		}
@@ -1006,11 +1007,12 @@ void UpdateKeyHint(int client)
 			{
 				int[] iSpectatorClients = new int[MaxClients];
 				int iSpectators = 0;
+				bool bIsAdmin = CheckCommandAccess(client, "admin_speclisthide", ADMFLAG_KICK);
 
 				for(int i = 1; i <= MaxClients; i++)
 				{
 					if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetEntPropEnt(i, Prop_Send, "m_hObserverTarget") != target
-						|| GetClientTeam(i) < 1 || CheckCommandAccess(i, "admin_speclisthide", ADMFLAG_KICK))
+						|| GetClientTeam(i) < 1 || (!bIsAdmin && CheckCommandAccess(i, "admin_speclisthide", ADMFLAG_KICK)))
 					{
 						continue;
 					}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -748,7 +748,7 @@ void UpdateHUD(int client)
 			float fWR = 0.0;
 			Shavit_GetWRTime(style, fWR, track);
 
-			if(time > fWR || !Shavit_IsReplayDataLoaded(style))
+			if(time > fWR || !Shavit_IsReplayDataLoaded(style, track))
 			{
 				PrintHintText(client, "%T", "NoReplayData", client);
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -157,7 +157,7 @@ int gI_RemoveRagdolls = 1;
 char gS_ClanTag[32] = "{styletag} :: {time}";
 bool gB_ClanTag = true;
 bool gB_DropAll = true;
-bool gB_ResetTargetname = true;
+bool gB_ResetTargetname = false;
 bool gB_RestoreStates = false;
 
 // dhooks
@@ -296,9 +296,9 @@ public void OnPluginStart()
 	gCV_Checkpoints = CreateConVar("shavit_misc_checkpoints", "1", "Allow players to save and teleport to checkpoints.", 0, true, 0.0, true, 1.0);
 	gCV_RemoveRagdolls = CreateConVar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = CreateConVar("shavit_misc_clantag", "{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style settings from shavit-styles.cfg.\n{style} - style name.\n{time} - formatted time.", 0);
-	gCV_DropAll = CreateConVar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 2.0);
-	gCV_ResetTargetname = CreateConVar("shavit_misc_resettargetname", "1", "Reset the player's targetname upon timer start?\nRecommended to leave enabled. Disable via per-map configs if it's problematic.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 2.0);
-	gCV_RestoreStates = CreateConVar("shavit_misc_restorestates", "0", "Save the players' timer/position etc.. when they die/change teams,\nand load the data when they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 2.0);
+	gCV_DropAll = CreateConVar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_ResetTargetname = CreateConVar("shavit_misc_resettargetname", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_RestoreStates = CreateConVar("shavit_misc_restorestates", "0", "Save the players' timer/position etc.. when they die/change teams,\nand load the data when they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 
 	gCV_GodMode.AddChangeHook(OnConVarChanged);
 	gCV_PreSpeed.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -179,6 +179,8 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 		gI_Styles = Shavit_GetStyleCount();
 	}
 
+	gI_RankedStyles = 0;
+
 	for(int i = 0; i < gI_Styles; i++)
 	{
 		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
@@ -765,7 +767,7 @@ public void SQL_Recalculate_Callback(Database db, DBResultSet results, const cha
 			return;
 		}
 
-		int max = ((gA_ValidMaps.Length * 2) * gI_RankedStyles);
+		int max = ((gA_ValidMaps.Length * TRACKS_SIZE) * gI_RankedStyles);
 		float current = ((float(++gI_Progress[client]) / max) * 100.0);
 
 		PrintToConsole(client, "- [%.01f%%] Recalculated \"%s\" (%s | %s).", current, sMap, gS_TrackNames[track], gS_StyleNames[style]);

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -554,7 +554,7 @@ public Action Command_Rank(int client, int args)
 	}
 
 	Shavit_PrintToChat(client, "%T", "Rank", client, gS_ChatStrings[sMessageVariable2], target, gS_ChatStrings[sMessageText],
-		gS_ChatStrings[sMessageVariable], gI_Rank[target], gS_ChatStrings[sMessageText],
+		gS_ChatStrings[sMessageVariable], (gI_Rank[target] > gI_RankedPlayers)? gI_RankedPlayers:gI_Rank[target], gS_ChatStrings[sMessageText],
 		gI_RankedPlayers,
 		gS_ChatStrings[sMessageVariable], gF_Points[target], gS_ChatStrings[sMessageText]);
 

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -596,6 +596,7 @@ public Action Command_SetTier(int client, int args)
 	}
 
 	gI_Tier = tier;
+	gA_MapTiers.SetValue(gS_Map, tier);
 
 	Call_StartForward(gH_Forwards_OnTierAssigned);
 	Call_PushString(gS_Map);

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -212,7 +212,6 @@ public void OnLibraryRemoved(const char[] name)
 public void Shavit_OnDatabaseLoaded()
 {
 	gH_SQL = Shavit_GetDatabase();
-
 	SetSQLInfo();
 }
 

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -546,7 +546,7 @@ public Action Command_Rank(int client, int args)
 		}
 	}
 
-	if(gI_Rank[target] == 0)
+	if(gF_Points[target] == 0.0)
 	{
 		Shavit_PrintToChat(client, "%T", "Unranked", client, gS_ChatStrings[sMessageVariable2], target, gS_ChatStrings[sMessageText]);
 

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -95,6 +95,8 @@ public Plugin myinfo =
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
+	CreateNative("Shavit_GetMapTier", Native_GetMapTier);
+	CreateNative("Shavit_GetMapTiers", Native_GetMapTiers);
 	CreateNative("Shavit_GetPoints", Native_GetPoints);
 	CreateNative("Shavit_GetRank", Native_GetRank);
 	CreateNative("Shavit_GetRankedPlayers", Native_GetRankedPlayers);
@@ -928,6 +930,26 @@ void GetTrackName(int client, int track, char[] output, int size)
 	static char sTrack[16];
 	FormatEx(sTrack, 16, "Track_%d", track);
 	FormatEx(output, size, "%T", sTrack, client);
+}
+
+public int Native_GetMapTier(Handle handler, int numParams)
+{
+	int tier = 0;
+
+	char[] sMap = new char[128];
+	GetNativeString(1, sMap, 128);
+
+	if(!gA_MapTiers.GetValue(sMap, tier))
+	{
+		return 0;
+	}
+
+	return tier;
+}
+
+public int Native_GetMapTiers(Handle handler, int numParams)
+{
+	return view_as<int>(CloneHandle(gA_MapTiers, handler));
 }
 
 public int Native_GetPoints(Handle handler, int numParams)

--- a/addons/sourcemod/scripting/shavit-timelimit.sp
+++ b/addons/sourcemod/scripting/shavit-timelimit.sp
@@ -60,6 +60,9 @@ int gI_MinimumTimes = 5;
 int gI_PlayerAmount = 25;
 bool gB_Style = true;
 
+// misc cache
+Handle gH_Timer = null;
+
 // table prefix
 char gS_MySQLPrefix[32];
 
@@ -128,6 +131,19 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gI_MinimumTimes = gCV_MinimumTimes.IntValue;
 	gI_PlayerAmount = gCV_PlayerAmount.IntValue;
 	gB_Style = gCV_Style.BoolValue;
+
+	if(convar == gCV_ForceMapEnd)
+	{
+		if(gB_ForceMapEnd)
+		{
+			gH_Timer = CreateTimer(1.0, Timer_PrintToChat, 0, TIMER_REPEAT);
+		}
+
+		else
+		{
+			delete gH_Timer;
+		}
+	}
 }
 
 public void OnConfigsExecuted()
@@ -168,9 +184,9 @@ public void OnMapStart()
 		SetLimit(RoundToNearest(gF_DefaultLimit));
 	}
 
-	if(gB_ForceMapEnd)
+	if(gB_ForceMapEnd && gH_Timer == null)
 	{
-		CreateTimer(1.0, Timer_PrintToChat, 0, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+		gH_Timer = CreateTimer(1.0, Timer_PrintToChat, 0, TIMER_REPEAT);
 	}
 }
 

--- a/addons/sourcemod/scripting/shavit-timelimit.sp
+++ b/addons/sourcemod/scripting/shavit-timelimit.sp
@@ -377,7 +377,7 @@ public Action Timer_PrintToChat(Handle Timer)
 		}
 	}
 	
-	if(timeleft < -3)
+	if(timeleft == -4)
 	{
 		CS_TerminateRound(0.0, CSRoundEnd_Draw, true);
 	}

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -56,7 +56,7 @@ float gF_WRTime[STYLE_LIMIT][TRACKS_SIZE];
 int gI_WRRecordID[STYLE_LIMIT][TRACKS_SIZE];
 char gS_WRName[STYLE_LIMIT][TRACKS_SIZE][MAX_NAME_LENGTH];
 int gI_RecordAmount[STYLE_LIMIT][TRACKS_SIZE];
-ArrayList gA_LeaderBoard[STYLE_LIMIT][TRACKS_SIZE];
+ArrayList gA_Leaderboard[STYLE_LIMIT][TRACKS_SIZE];
 float gF_PlayerRecord[MAXPLAYERS+1][STYLE_LIMIT][TRACKS_SIZE];
 
 // admin menu
@@ -175,7 +175,7 @@ public void OnPluginStart()
 	{
 		for(int j = 0; j < TRACKS_SIZE; j++)
 		{
-			gA_LeaderBoard[i][j] = new ArrayList();
+			gA_Leaderboard[i][j] = new ArrayList();
 			gI_RecordAmount[i][j] = 0;
 		}
 	}
@@ -365,19 +365,19 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 	}
 
 	// arrays
-	for(int i = 0; i < styles; i++)
+	for(int i = 0; i < STYLE_LIMIT; i++)
 	{
 		for(int j = 0; j < TRACKS_SIZE; j++)
 		{
-			gA_LeaderBoard[i][j].Clear();
-		}
-	}
+			if(i < styles)
+			{
+				gA_Leaderboard[i][j].Clear();
+			}
 
-	for(int i = styles; i < STYLE_LIMIT; i++)
-	{
-		for(int j = 0; j < TRACKS_SIZE; j++)
-		{
-			delete gA_LeaderBoard[i][j];
+			else
+			{
+				delete gA_Leaderboard[i][j];
+			}
 		}
 	}
 
@@ -543,7 +543,7 @@ public int Native_GetRankForTime(Handle handler, int numParams)
 	int style = GetNativeCell(1);
 	int track = GetNativeCell(3);
 
-	if(gA_LeaderBoard[style][track].Length == 0)
+	if(gA_Leaderboard[style][track].Length == 0)
 	{
 		return 1;
 	}
@@ -571,7 +571,7 @@ public int Native_GetTimeForRank(Handle handler, int numParams)
 		return view_as<int>(0.0);
 	}
 
-	return view_as<int>(gA_LeaderBoard[style][track].Get(rank - 1));
+	return view_as<int>(gA_Leaderboard[style][track].Get(rank - 1));
 }
 
 #if defined DEBUG
@@ -2183,7 +2183,7 @@ public void SQL_UpdateLeaderboards_Callback(Database db, DBResultSet results, co
 		for(int j = 0; j < TRACKS_SIZE; j++)
 		{
 			gI_RecordAmount[i][j] = 0;
-			gA_LeaderBoard[i][j].Clear();
+			gA_Leaderboard[i][j].Clear();
 		}
 	}
 
@@ -2197,7 +2197,7 @@ public void SQL_UpdateLeaderboards_Callback(Database db, DBResultSet results, co
 			continue;
 		}
 
-		gA_LeaderBoard[style][track].Push(results.FetchFloat(1));
+		gA_Leaderboard[style][track].Push(results.FetchFloat(1));
 	}
 
 	for(int i = 0; i < gI_Styles; i++)
@@ -2209,8 +2209,8 @@ public void SQL_UpdateLeaderboards_Callback(Database db, DBResultSet results, co
 
 		for(int j = 0; j < TRACKS_SIZE; j++)
 		{
-			SortADTArray(gA_LeaderBoard[i][j], Sort_Ascending, Sort_Float);
-			gI_RecordAmount[i][j] = gA_LeaderBoard[i][j].Length;
+			SortADTArray(gA_Leaderboard[i][j], Sort_Ascending, Sort_Float);
+			gI_RecordAmount[i][j] = gA_Leaderboard[i][j].Length;
 		}
 	}
 }
@@ -2222,11 +2222,11 @@ int GetRankForTime(int style, float time, int track)
 		return 1;
 	}
 
-	if(gA_LeaderBoard[style][track] != null && gA_LeaderBoard[style][track].Length > 0)
+	if(gA_Leaderboard[style][track] != null && gA_Leaderboard[style][track].Length > 0)
 	{
 		for(int i = 0; i < gI_RecordAmount[style][track]; i++)
 		{
-			if(time < gA_LeaderBoard[style][track].Get(i))
+			if(time < gA_Leaderboard[style][track].Get(i))
 			{
 				return ++i;
 			}

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -127,7 +127,7 @@ public void OnPluginStart()
 	#endif
 
 	// forwards
-	gH_OnWorldRecord = CreateGlobalForward("Shavit_OnWorldRecord", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
+	gH_OnWorldRecord = CreateGlobalForward("Shavit_OnWorldRecord", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	gH_OnFinish_Post = CreateGlobalForward("Shavit_OnFinish_Post", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	gH_OnWRDeleted = CreateGlobalForward("Shavit_OnWRDeleted", ET_Event, Param_Cell, Param_Cell, Param_Cell);
 	gH_OnWorstRecord = CreateGlobalForward("Shavit_OnWorstRecord", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
@@ -2022,6 +2022,7 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	if(overwrite > 0 && (time < gF_WRTime[style][track] || gF_WRTime[style][track] == 0.0)) // WR?
 	{
+		float oldwr = gF_WRTime[style][track];
 		gF_WRTime[style][track] = time;
 
 		Call_StartForward(gH_OnWorldRecord);
@@ -2032,7 +2033,12 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 		Call_PushCell(strafes);
 		Call_PushCell(sync);
 		Call_PushCell(track);
+		Call_PushCell(oldwr);
 		Call_Finish();
+
+		#if defined DEBUG
+		Shavit_PrintToChat(client, "old: %.01f new: %.01f", oldwr, time);
+		#endif
 	}
 
 	int iRank = GetRankForTime(style, time, track);

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1771,13 +1771,13 @@ public int SubMenu_Handler(Menu m, MenuAction action, int param1, int param2)
 
 		else
 		{
-			StartWRMenu(param1, gS_ClientMap[param1], gBS_LastWR[param1], Track_Main);
+			StartWRMenu(param1, gS_ClientMap[param1], gBS_LastWR[param1], gI_LastTrack[param1]);
 		}
 	}
 
 	else if(action == MenuAction_Cancel && param2 == MenuCancel_ExitBack)
 	{
-		StartWRMenu(param1, gS_ClientMap[param1], gBS_LastWR[param1], Track_Main);
+		StartWRMenu(param1, gS_ClientMap[param1], gBS_LastWR[param1], gI_LastTrack[param1]);
 	}
 
 	else if(action == MenuAction_End)

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -96,6 +96,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_GetPlayerPB", Native_GetPlayerPB);
 	CreateNative("Shavit_GetRankForTime", Native_GetRankForTime);
 	CreateNative("Shavit_GetRecordAmount", Native_GetRecordAmount);
+	CreateNative("Shavit_GetTimeForRank", Native_GetTimeForRank);
 	CreateNative("Shavit_GetWRName", Native_GetWRName);
 	CreateNative("Shavit_GetWRRecordID", Native_GetWRRecordID);
 	CreateNative("Shavit_GetWRTime", Native_GetWRTime);
@@ -553,6 +554,24 @@ public int Native_GetRankForTime(Handle handler, int numParams)
 public int Native_GetRecordAmount(Handle handler, int numParams)
 {
 	return gI_RecordAmount[GetNativeCell(1)][GetNativeCell(2)];
+}
+
+public int Native_GetTimeForRank(Handle handler, int numParams)
+{
+	int style = GetNativeCell(1);
+	int rank = GetNativeCell(2);
+	int track = GetNativeCell(3);
+
+	#if defined DEBUG
+	Shavit_PrintToChatAll("style %d | rank %d | track %d | amount %d", style, rank, track, gI_RecordAmount[style][track]);
+	#endif
+
+	if(rank > gI_RecordAmount[style][track])
+	{
+		return view_as<int>(0.0);
+	}
+
+	return view_as<int>(gA_LeaderBoard[style][track].Get(rank - 1));
 }
 
 #if defined DEBUG

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -2197,11 +2197,14 @@ int GetRankForTime(int style, float time, int track)
 		return 1;
 	}
 
-	for(int i = 0; i < gI_RecordAmount[style][track]; i++)
+	if(gA_LeaderBoard[style][track] != null && gA_LeaderBoard[style][track].Length > 0)
 	{
-		if(time < gA_LeaderBoard[style][track].Get(i))
+		for(int i = 0; i < gI_RecordAmount[style][track]; i++)
 		{
-			return ++i;
+			if(time < gA_LeaderBoard[style][track].Get(i))
+			{
+				return ++i;
+			}
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -501,7 +501,10 @@ public void OnMapStart()
 
 	// draw
 	// start drawing mapzones here
-	gH_DrawEverything = CreateTimer(gF_Interval, Timer_DrawEverything, INVALID_HANDLE, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+	if(gH_DrawEverything == null)
+	{
+		gH_DrawEverything = CreateTimer(gF_Interval, Timer_DrawEverything, INVALID_HANDLE, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+	}
 
 	if(gB_Late)
 	{
@@ -1755,13 +1758,23 @@ public Action Timer_DrawEverything(Handle Timer)
 		return Plugin_Continue;
 	}
 
-	for(int i = 0; i < gI_MapZones; i++)
+	static int iCycle = 0;
+	int iMaxZonesPerFrame = (gB_FlatZones)? 16:5;
+
+	for(int i = iCycle; i < gI_MapZones; i++)
 	{
 		if(gA_ZoneCache[i][bZoneInitialized] && gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][bVisible])
 		{
-			DrawZone(gV_MapZones_Visual[i], GetZoneColors(gA_ZoneCache[i][iZoneType]), gF_Interval, gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][fWidth], gB_FlatZones, gV_ZoneCenter[i]);
+			DrawZone(gV_MapZones_Visual[i], GetZoneColors(gA_ZoneCache[i][iZoneType]), RoundToCeil(float(gI_MapZones) / iMaxZonesPerFrame) * gF_Interval, gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][fWidth], gB_FlatZones, gV_ZoneCenter[i]);
+		}
+
+		if(++iCycle % iMaxZonesPerFrame == 0)
+		{
+			return Plugin_Continue;
 		}
 	}
+
+	iCycle = 0;
 
 	return Plugin_Continue;
 }

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -512,6 +512,11 @@ public void OnMapStart()
 	}
 }
 
+public void OnMapEnd()
+{
+	delete gH_DrawEverything;
+}
+
 public void Shavit_OnChatConfigLoaded()
 {
 	for(int i = 0; i < CHATSETTINGS_SIZE; i++)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -1761,6 +1761,11 @@ public Action Timer_DrawEverything(Handle Timer)
 	static int iCycle = 0;
 	int iMaxZonesPerFrame = (gB_FlatZones)? 16:5;
 
+	if(iCycle >= gI_MapZones)
+	{
+		iCycle = 0;
+	}
+
 	for(int i = iCycle; i < gI_MapZones; i++)
 	{
 		if(gA_ZoneCache[i][bZoneInitialized] && gA_ZoneSettings[gA_ZoneCache[i][iZoneType]][bVisible])

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2092,7 +2092,7 @@ public void Shavit_OnRestart(int client, int track)
 	{
 		Shavit_StartTimer(client, track);
 
-		if(!EmptyVector(gF_CustomSpawn))
+		if(track == Track_Main && !EmptyVector(gF_CustomSpawn))
 		{
 			TeleportEntity(client, gF_CustomSpawn, NULL_VECTOR, view_as<float>({0.0, 0.0, 0.0}));
 		}

--- a/addons/sourcemod/translations/shavit-misc.phrases.txt
+++ b/addons/sourcemod/translations/shavit-misc.phrases.txt
@@ -6,6 +6,11 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"You have to be {1}alive{2} to use this command."
 	}
+	"CommandAliveSpectate"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"You have to be {1}alive{2} or {1}spectate a player{2} to use this command."
+	}
 	"CommandDisabled"
 	{
 		"#format"	"{1:s},{2:s}"

--- a/addons/sourcemod/translations/shavit-misc.phrases.txt
+++ b/addons/sourcemod/translations/shavit-misc.phrases.txt
@@ -8,8 +8,8 @@
 	}
 	"CommandAliveSpectate"
 	{
-		"#format"	"{1:s},{2:s}"
-		"en"		"You have to be {1}alive{2} or {1}spectate a player{2} to use this command."
+		"#format"	"{1:s},{2:s},{3:s},{4:s}"
+		"en"		"You have to be {1}alive{2} or {3}spectate a player{4} to use this command."
 	}
 	"CommandDisabled"
 	{


### PR DESCRIPTION
New natives! As requested in #504

```sp
/**
 * Gets the map tier for a specified map.
 * Use the map's display name.
 *
 * @param map						Map to get the tier of.
 * @return							Map tier. 0 if no results were found.
 */
native int Shavit_GetMapTier(const char[] map);

/**
 * Gets a StringMap that contains all the cached map tiers.
 *
 * @return							StringMap with {const char: map, int: tier} structure.
 */
native StringMap Shavit_GetMapTiers();

```

Usage example:

```sp
#include <sourcemod>
#include <shavit>

public void OnPluginStart()
{
	RegConsoleCmd("sm_xd", xd);
}

public Action xd(int client, int args)
{
	char map[] = "de_nuke";
	int tier = Shavit_GetMapTier(map);

	ReplyToCommand(client, "[1] %s: %d", map, tier);

	StringMap maps = Shavit_GetMapTiers();

	if(maps.GetValue(map, tier))
	{
		ReplyToCommand(client, "[2] %s: %d", map, tier);
	}

	else
	{
		ReplyToCommand(client, "[2] %s has no entry", map);
	}

	delete maps;

	return Plugin_Handled;
}
```

* Fixed tier updates for the cache upon change.
* Fixed issue with `sm_recalcall` giving wrong percentage after map changes.
* Allowed admins to see others in spectator list.
* Fixed an error in rank-for-time calculation.
* Fixed !b teleporting to wrong spawn point.
* Fixed unranked message not showing up when using !rank.
* Fixed issues with replay playback where the bot gets massive amounts of speeds, gets stuck and kills the server's performance.
* Fixed issue for triggers breaking because of shavit-misc. Set `shavit_misc_resettargetname` to 0 if you're not on a new installation.
* Extended checkpoints so they work on spectators - you can now borrow someone else's run and try it!
* Added `oldwr` as a parameter to `Shavit_OnWorldRecord`. Also added `Shavit_GetTimeForRank`.
* (CS:S) Fixed not being able to draw more than 5 zones per frame.
* Fixed an issue where remote MySQL databases would not properly assign in shavit-chat.
* Fixed zones not appearing after changing to a map with more zones.
* Fixed !ccname and !ccmsg with no arguments not showing current setting.
* Fixed an issue that caused zones to be drawn twice therefore appearing with an incorrect color.
* Added `Shavit_ReloadReplay` and `Shavit_ReloadReplays` natives.
* Added replay bot integration with [Bunnyhop Statistics](https://github.com/shavitush/bhopstats) to simplify the process of replay analyzing.
* Added per-track beam colors. Edit `configs/shavit-zones.cfg` with "Bonus Start"/"Bonus End" entries below "Easybhop"!
* Added KZ buttons support going by the KZTimer standard.