### PR TITLE
Additions and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Including a records system, map zones (start/end marks etc), bonuses, HUD with u
 * [Bunnyhop Statistics](https://forums.alliedmods.net/showthread.php?t=286135) - to show amount of scrolls for non-auto styles in the key display. CS:S only!
 * [SteamWorks](https://forums.alliedmods.net/showthread.php?t=229556) - for the `{serverip}` advertisement variable.
 * [Chat-Processor](https://github.com/Drixevel/Chat-Processor) - if you're enabling the `shavit-chat` module.
-* A MySQL database if you want to use the rankings plugin.
+* A MySQL database (preferably locally hosted) if your database is likely to grow or want to use the rankings plugin. MySQL server version of 5.5.5 or above (MariaDB equivalent works too) is recommended.
 
 #  Installation:
 1. If you want to use MySQL (**VERY RECOMMENDED**) add a database entry in addons/sourcemod/configs/databases.cfg, call it "shavit". The plugin also supports the "sqlite" driver. You can also skip this step and not modify databases.cfg.

--- a/addons/sourcemod/configs/shavit-replay.cfg
+++ b/addons/sourcemod/configs/shavit-replay.cfg
@@ -19,7 +19,7 @@
 // {style} - the style name.
 // {styletag} - the style's tag. See "styletag" in "shavit-styles.cfg".
 // {time} - formatted time for the WR currently being played.
-// {player} - the name of the player that holds the record.
+// {player} - the name of the player that holds the *record*, might be incorrect for replays from the beta version of bhoptimer.
 // {track} - track that the bot replays. Translated from the server's defined language.
 //
 "Replay"

--- a/addons/sourcemod/configs/shavit-styles.cfg
+++ b/addons/sourcemod/configs/shavit-styles.cfg
@@ -58,6 +58,7 @@
 
 		// Special flags
 		"special"			"0" // For third-party modules. The core plugins will not need this setting.
+		"specialstring"		"" // For third-party modules. The core plugins will not need this setting.
 	}
 
 	"1"

--- a/addons/sourcemod/configs/shavit-zones.cfg
+++ b/addons/sourcemod/configs/shavit-zones.cfg
@@ -149,5 +149,95 @@
 			"alpha"		"255"
 			"width"		"0.1"
 		}
+
+		"Bonus Glitch_Respawn"
+		{
+			"visible"	"0"
+			
+			"red"		"255"
+			"green"		"200"
+			"blue"		"0"
+			
+			"alpha"		"255"
+			"width"		"0.1"
+		}
+
+		"Bonus Glitch_Stop"
+		{
+			"visible"	"0"
+			
+			"red"		"255"
+			"green"		"200"
+			"blue"		"0"
+			
+			"alpha"		"255"
+			"width"		"0.1"
+		}
+
+		"Bonus Glitch_Slay"
+		{
+			"visible"	"0"
+			
+			"red"		"255"
+			"green"		"200"
+			"blue"		"0"
+			
+			"alpha"		"255"
+			"width"		"0.1"
+		}
+
+		"Bonus Freestyle"
+		{
+			"visible"	"1"
+			
+			"red"		"25"
+			"green"		"25"
+			"blue"		"255"
+			
+			"alpha"		"195"
+			"width"		"0.1"
+		}
+
+		"Bonus Nolimit"
+		{
+			"visible"	"1"
+			
+			"red"		"247"
+			"green"		"3"
+			"blue"		"255"
+			
+			"alpha"		"50"
+			"width"		"0.1"
+		}
+
+		"Bonus Teleport"
+		{
+			"visible"	"0"
+			
+			"red"		"255"
+			"green"		"200"
+			"blue"		"0"
+			
+			"alpha"		"255"
+			"width"		"2.0"
+		}
+
+		// This is unused, ignore it.
+		"Bonus SPAWN POINT"
+		{
+
+		}
+
+		"Bonus Easybhop"
+		{
+			"visible"	"1"
+			
+			"red"		"57"
+			"green"		"196"
+			"blue"		"92"
+			
+			"alpha"		"175"
+			"width"		"1.75"
+		}
 	}
 }

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -74,6 +74,7 @@ enum
 	sHTMLColor,
 	sChangeCommand,
 	sClanTag,
+	sSpecialString,
 	STYLESTRINGS_SIZE
 };
 

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -747,7 +747,7 @@ native void Shavit_PauseTimer(int client);
 native void Shavit_ResumeTimer(int client);
 
 /**
- * Retrieve the engine time of the replay bot's first frame.
+ * Retrieves the engine time of the replay bot's first frame.
  *
  * @param style						Style.
  * @param time						Reference to save the time on.
@@ -786,6 +786,44 @@ native int Shavit_GetReplayBotTrack(int client);
  * @return							Current played frame.
  */
 native int Shavit_GetReplayBotCurrentFrame(int style);
+
+/**
+ * Retrieves a replay's frame count.
+ *
+ * @param style						Style.
+ * @param track						Track.
+ * @noreturn
+ */
+native int Shavit_GetReplayFrameCount(int style, int track);
+
+/**
+ * Retrieves a replay's total length in seconds.
+ *
+ * @param style						Style.
+ * @param track						Track.
+ * @noreturn
+ */
+native float Shavit_GetReplayLength(int style, int track);
+
+/**
+ * Retrieves an actively playing replay's time.
+ *
+ * @param style						Style.
+ * @param track						Track. (ignored for non-central bots)
+ * @noreturn
+ */
+native float Shavit_GetReplayTime(int style, int track);
+
+/**
+ * Retrieves a replay holder's name.
+ *
+ * @param style						Style.
+ * @param track						Track.
+ * @param buffer					Buffer string.
+ * @param length					String length.
+ * @noreturn
+ */
+native void Shavit_GetReplayName(int style, int track, char[] buffer, int length);
 
 /**
  * Checks if there's loaded replay data for a bhop style or not.
@@ -1079,6 +1117,10 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetReplayBotStyle");
 	MarkNativeAsOptional("Shavit_GetReplayBotTrack");
 	MarkNativeAsOptional("Shavit_GetReplayData");
+	MarkNativeAsOptional("Shavit_GetReplayFrameCount");
+	MarkNativeAsOptional("Shavit_GetReplayLength");
+	MarkNativeAsOptional("Shavit_GetReplayName");
+	MarkNativeAsOptional("Shavit_GetReplayTime");
 	MarkNativeAsOptional("Shavit_GetStrafeCount");
 	MarkNativeAsOptional("Shavit_GetStyleCount");
 	MarkNativeAsOptional("Shavit_GetStyleSettings");

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -463,8 +463,12 @@ void SQL_DBConnect()
 {
 	if(gH_SQL != null)
 	{
+		char[] sDriver = new char[8];
+		gH_SQL.Driver.GetIdentifier(sDriver, 8);
+		bool bMySQL = StrEqual(sDriver, "mysql", false);
+
 		char[] sQuery = new char[512];
-		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%schat` (`auth` CHAR(32) NOT NULL, `name` INT NOT NULL DEFAULT 0, `ccname` CHAR(128), `message` INT NOT NULL DEFAULT 0, `ccmessage` CHAR(16), PRIMARY KEY (`auth`));", gS_MySQLPrefix);
+		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%schat` (`auth` CHAR(32) NOT NULL, `name` INT NOT NULL DEFAULT 0, `ccname` CHAR(128), `message` INT NOT NULL DEFAULT 0, `ccmessage` CHAR(16), PRIMARY KEY (`auth`))%s;", gS_MySQLPrefix, (bMySQL)? " ENGINE=INNODB":"");
 		
 		gH_SQL.Query(SQL_CreateTable_Callback, sQuery, 0, DBPrio_High);
 	}

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1496,6 +1496,7 @@ bool LoadStyles()
 		kv.GetString("htmlcolor", gS_StyleStrings[i][sHTMLColor], 128, "<MISSING STYLE HTML COLOR>");
 		kv.GetString("command", gS_StyleStrings[i][sChangeCommand], 128, "");
 		kv.GetString("clantag", gS_StyleStrings[i][sClanTag], 128, "<MISSING STYLE CLAN TAG>");
+		kv.GetString("specialstring", gS_StyleStrings[i][sSpecialString], 128, "");
 
 		gA_StyleSettings[i][bAutobhop] = view_as<bool>(kv.GetNum("autobhop", 1));
 		gA_StyleSettings[i][bEasybhop] = view_as<bool>(kv.GetNum("easybhop", 1));

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1174,6 +1174,8 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	any[] snapshot = new any[TIMERSNAPSHOT_SIZE];
 	GetNativeArray(2, snapshot, TIMERSNAPSHOT_SIZE);
 
+	gI_Track[client] = view_as<int>(snapshot[iTimerTrack]);
+
 	if(gBS_Style[client] != snapshot[bsStyle])
 	{
 		CallOnStyleChanged(client, gBS_Style[client], snapshot[bsStyle], false);
@@ -1189,8 +1191,7 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	gI_TotalMeasures[client] = view_as<int>(snapshot[iTotalMeasures]);
 	gI_GoodGains[client] = view_as<int>(snapshot[iGoodGains]);
 	gF_StartTime[client] = GetEngineTime() - view_as<float>(snapshot[fCurrentTime]);
-	gI_SHSW_FirstCombination[client] = view_as<int>(snapshot[iSHSWCombination]);
-	gI_Track[client] = view_as<int>(snapshot[iTimerTrack]);
+	gI_SHSW_FirstCombination[client] = view_as<int>(snapshot[iSHSWCombination]);\
 }
 
 public int Native_MarkKZMap(Handle handler, int numParams)
@@ -1228,7 +1229,7 @@ void StartTimer(int client, int track)
 	float fSpeed[3];
 	GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);
 
-	if(!gB_NoZAxisSpeed || gA_StyleSettings[gBS_Style[client]][bPrespeed] || fSpeed[2] == 0.0 || SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0)) <= 280.0)
+	if(!gB_NoZAxisSpeed || gA_StyleSettings[gBS_Style[client]][bPrespeed] || (fSpeed[2] == 0.0 && SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0)) <= 280.0))
 	{
 		gI_Strafes[client] = 0;
 		gI_Jumps[client] = 0;
@@ -1247,6 +1248,13 @@ void StartTimer(int client, int track)
 		{
 			gB_TimerEnabled[client] = true;
 			gI_SHSW_FirstCombination[client] = -1;
+
+			gF_PauseTotalTime[client] = 0.0;
+			gB_ClientPaused[client] = false;
+			gB_PracticeMode[client] = false;
+
+			SetEntityGravity(client, view_as<float>(gA_StyleSettings[gBS_Style[client]][fGravityMultiplier]));
+			SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_StyleSettings[gBS_Style[client]][fSpeedMultiplier]));
 		}
 
 		else if(result == Plugin_Handled || result == Plugin_Stop)
@@ -1254,13 +1262,6 @@ void StartTimer(int client, int track)
 			gB_TimerEnabled[client] = false;
 		}
 	}
-
-	gF_PauseTotalTime[client] = 0.0;
-	gB_ClientPaused[client] = false;
-	gB_PracticeMode[client] = false;
-
-	SetEntityGravity(client, view_as<float>(gA_StyleSettings[gBS_Style[client]][fGravityMultiplier]));
-	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_StyleSettings[gBS_Style[client]][fSpeedMultiplier]));
 }
 
 void StopTimer(int client)

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -281,7 +281,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_finishtest", Command_FinishTest);
 	#endif
 
-	CreateConVar("shavit_version", SHAVIT_VERSION, "Plugin version.", (FCVAR_NOTIFY|FCVAR_DONTRECORD));
+	CreateConVar("shavit_version", SHAVIT_VERSION, "Plugin version.", (FCVAR_NOTIFY | FCVAR_DONTRECORD));
 
 	gCV_Autobhop = CreateConVar("shavit_core_autobhop", "1", "Enable autobhop?\nWill be forced to not work if STYLE_AUTOBHOP is not defined for a style!", FCVAR_NOTIFY, true, 0.0, true, 1.0);
 	gCV_LeftRight = CreateConVar("shavit_core_blockleftright", "1", "Block +left/right?", 0, true, 0.0, true, 1.0);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1883,8 +1883,10 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		}
 	}
 
+	bool bOnLadder = (GetEntityMoveType(client) == MOVETYPE_LADDER);
+
 	// key blocking
-	if(!Shavit_InsideZone(client, Zone_Freestyle, -1))
+	if(!bOnLadder && !Shavit_InsideZone(client, Zone_Freestyle, -1))
 	{
 		// block E
 		if(gA_StyleSettings[gBS_Style[client]][bBlockUse] && (buttons & IN_USE) > 0)
@@ -2024,7 +2026,6 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	if(gA_StyleSettings[gBS_Style[client]][bAutobhop] && gB_Autobhop && gB_Auto[client])
 	{
 		bool bInWater = (GetEntProp(client, Prop_Send, "m_nWaterLevel") >= 2);
-		bool bOnLadder = (GetEntityMoveType(client) == MOVETYPE_LADDER);
 
 		if((buttons & IN_JUMP) > 0 && iGroundEntity == -1 && !bOnLadder && !bInWater)
 		{

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1687,7 +1687,7 @@ void SQL_DBConnect()
 
 	if(gB_MySQL)
 	{
-		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%susers` (`auth` CHAR(32) NOT NULL, `name` VARCHAR(32), `country` CHAR(32), `ip` CHAR(64), `lastlogin` INT NOT NULL DEFAULT -1, `points` FLOAT NOT NULL DEFAULT 0, PRIMARY KEY (`auth`));", gS_MySQLPrefix);
+		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%susers` (`auth` CHAR(32) NOT NULL, `name` VARCHAR(32), `country` CHAR(32), `ip` CHAR(64), `lastlogin` INT NOT NULL DEFAULT -1, `points` FLOAT NOT NULL DEFAULT 0, PRIMARY KEY (`auth`), INDEX `points` (`points`)) ENGINE=INNODB;", gS_MySQLPrefix);
 	}
 
 	else

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -108,7 +108,7 @@ bool gB_Restart = true;
 bool gB_Pause = true;
 bool gB_NoStaminaReset = true;
 bool gB_AllowTimerWithoutZone = false;
-bool gB_BlockPreJump = true;
+bool gB_BlockPreJump = false;
 bool gB_NoZAxisSpeed = true;
 bool gB_VelocityTeleport = false;
 
@@ -289,7 +289,7 @@ public void OnPluginStart()
 	gCV_Pause = CreateConVar("shavit_core_pause", "1", "Allow pausing?", 0, true, 0.0, true, 1.0);
 	gCV_NoStaminaReset = CreateConVar("shavit_core_nostaminareset", "1", "Disables the built-in stamina reset.\nAlso known as 'easybhop'.\nWill be forced to not work if STYLE_EASYBHOP is not defined for a style!", 0, true, 0.0, true, 1.0);
 	gCV_AllowTimerWithoutZone = CreateConVar("shavit_core_timernozone", "0", "Allow the timer to start if there's no start zone?", 0, true, 0.0, true, 1.0);
-	gCV_BlockPreJump = CreateConVar("shavit_core_blockprejump", "1", "Prevents jumping in the start zone.", 0, true, 0.0, true, 1.0);
+	gCV_BlockPreJump = CreateConVar("shavit_core_blockprejump", "0", "Prevents jumping in the start zone.", 0, true, 0.0, true, 1.0);
 	gCV_NoZAxisSpeed = CreateConVar("shavit_core_nozaxisspeed", "1", "Don't start timer if vertical speed exists (btimes style).", 0, true, 0.0, true, 1.0);
 	gCV_VelocityTeleport = CreateConVar("shavit_core_velocityteleport", "0", "Teleport the client when changing its velocity? (for special styles)", 0, true, 0.0, true, 1.0);
 

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -77,7 +77,6 @@ bool gB_PracticeMode[MAXPLAYERS+1];
 int gI_SHSW_FirstCombination[MAXPLAYERS+1];
 int gI_Track[MAXPLAYERS+1];
 
-float gF_HSW_Requirement = 0.0;
 StringMap gSM_StyleCommands = null;
 
 // cookies
@@ -210,14 +209,12 @@ public void OnPluginStart()
 	if(gEV_Type == Engine_CSS)
 	{
 		gSG_Type = Game_CSS;
-		gF_HSW_Requirement = 399.00;
 	}
 
 	else if(gEV_Type == Engine_CSGO)
 	{
 		gSG_Type = Game_CSGO;
-		gF_HSW_Requirement = 449.00;
-
+		
 		sv_autobunnyhopping = FindConVar("sv_autobunnyhopping");
 		sv_autobunnyhopping.BoolValue = false;
 	}
@@ -627,7 +624,7 @@ public Action Command_TogglePause(int client, int args)
 #if defined DEBUG
 public Action Command_FinishTest(int client, int args)
 {
-	Shavit_FinishMap(client);
+	Shavit_FinishMap(client, gI_Track[client]);
 
 	return Plugin_Handled;
 }
@@ -1883,6 +1880,16 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		}
 	}
 
+	#if defined DEBUG
+	static int cycle = 0;
+
+	if(++cycle % 50 == 0)
+	{
+		Shavit_StopChatSound();
+		Shavit_PrintToChat(client, "vel[0]: %.01f | vel[1]: %.01f", vel[0], vel[1]);
+	}
+	#endif
+
 	bool bOnLadder = (GetEntityMoveType(client) == MOVETYPE_LADDER);
 
 	// key blocking
@@ -1929,10 +1936,10 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				bool bSHSW = (gA_StyleSettings[gBS_Style[client]][iForceHSW] == 2) && !bInStart; // don't decide on the first valid input until out of start zone!
 				int iCombination = -1;
 
-				bool bForward = ((buttons & IN_FORWARD) > 0 && vel[0] > gF_HSW_Requirement);
-				bool bMoveLeft = ((buttons & IN_MOVELEFT) > 0 && vel[1] < -gF_HSW_Requirement);
-				bool bBack = ((buttons & IN_BACK) > 0 && vel[0] < -gF_HSW_Requirement);
-				bool bMoveRight = ((buttons & IN_MOVERIGHT) > 0 && vel[1] > gF_HSW_Requirement);
+				bool bForward = ((buttons & IN_FORWARD) > 0 && vel[0] >= 200.0);
+				bool bMoveLeft = ((buttons & IN_MOVELEFT) > 0 && vel[1] <= -200.0);
+				bool bBack = ((buttons & IN_BACK) > 0 && vel[0] <= -200.0);
+				bool bMoveRight = ((buttons & IN_MOVERIGHT) > 0 && vel[1] >= 200.0);
 
 				if(bSHSW)
 				{

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -772,8 +772,6 @@ void ChangeClientStyle(int client, int style, bool manual)
 		return;
 	}
 
-	CallOnStyleChanged(client, gBS_Style[client], style, manual);
-
 	if(manual)
 	{
 		Shavit_PrintToChat(client, "%T", "StyleSelection", client, gS_ChatStrings[sMessageStyle], gS_StyleStrings[style][sStyleName], gS_ChatStrings[sMessageText]);
@@ -792,6 +790,7 @@ void ChangeClientStyle(int client, int style, bool manual)
 		Shavit_PrintToChat(client, "%T", "NewAiraccelerate", client, aa_old, gS_ChatStrings[sMessageVariable], aa_new, gS_ChatStrings[sMessageText]);
 	}
 
+	CallOnStyleChanged(client, gBS_Style[client], style, manual);
 	gBS_Style[client] = style;
 
 	UpdateAutoBhop(client);
@@ -1175,6 +1174,11 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	any[] snapshot = new any[TIMERSNAPSHOT_SIZE];
 	GetNativeArray(2, snapshot, TIMERSNAPSHOT_SIZE);
 
+	if(gBS_Style[client] != snapshot[bsStyle])
+	{
+		CallOnStyleChanged(client, gBS_Style[client], snapshot[bsStyle], false);
+	}
+
 	gB_TimerEnabled[client] = view_as<bool>(snapshot[bTimerEnabled]);
 	gF_PauseStartTime[client] = view_as<float>(snapshot[fPauseStartTime]);
 	gF_PauseTotalTime[client] = view_as<float>(snapshot[fPauseTotalTime]);
@@ -1358,8 +1362,8 @@ public void OnClientCookiesCached(int client)
 		style = StringToInt(sCookie);
 	}
 
-	gBS_Style[client] = (style >= 0 && style < gI_Styles)? style:0;
 	CallOnStyleChanged(client, 0, gBS_Style[client], false);
+	gBS_Style[client] = (style >= 0 && style < gI_Styles)? style:0;
 
 	UpdateAutoBhop(client);
 	UpdateAiraccelerate(client);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -743,31 +743,26 @@ void UpdateHUD(int client)
 
 			if(style == -1)
 			{
-				return;
-			}
-
-			track = Shavit_GetReplayBotTrack(target);
-
-			float start = 0.0;
-			Shavit_GetReplayBotFirstFrame(style, start);
-
-			float time = (GetEngineTime() - start);
-
-			float fWR = 0.0;
-			Shavit_GetWRTime(style, fWR, track);
-
-			if(time > fWR || !Shavit_IsReplayDataLoaded(style, track))
-			{
 				PrintHintText(client, "%T", "NoReplayData", client);
 
 				return;
 			}
 
-			char[] sTime = new char[32];
-			FormatSeconds(time, sTime, 32, false);
+			track = Shavit_GetReplayBotTrack(target);
 
-			char[] sWR = new char[32];
-			FormatSeconds(fWR, sWR, 32, false);
+			float fReplayTime = Shavit_GetReplayTime(style, track);
+			float fReplayLength = Shavit_GetReplayLength(style, track);
+
+			if(fReplayTime < 0.0 || fReplayTime > fReplayLength || !Shavit_IsReplayDataLoaded(style, track))
+			{
+				return;
+			}
+
+			char[] sReplayTime = new char[32];
+			FormatSeconds(fReplayTime, sReplayTime, 32, false);
+
+			char[] sReplayLength = new char[32];
+			FormatSeconds(fReplayLength, sReplayLength, 32, false);
 
 			char[] sTrack = new char[32];
 
@@ -781,15 +776,19 @@ void UpdateHUD(int client)
 			{
 				FormatEx(sHintText, 512, "<font face='Stratum2'>");
 				Format(sHintText, 512, "%s\t<u><font color='#%s'>%s %T</font></u>", sHintText, gS_StyleStrings[style][sHTMLColor], gS_StyleStrings[style][sStyleName], "ReplayText", client);
-				Format(sHintText, 512, "%s\n\t%T: <font color='#00FF00'>%s</font> / %s", sHintText, "HudTimeText", client, sTime, sWR);
+				Format(sHintText, 512, "%s\n\t%T: <font color='#00FF00'>%s</font> / %s", sHintText, "HudTimeText", client, sReplayTime, sReplayLength);
 				Format(sHintText, 512, "%s\n\t%T: %d", sHintText, "HudSpeedText", client, iSpeed);
 				Format(sHintText, 512, "%s</font>", sHintText);
 			}
 
 			else
 			{
-				FormatEx(sHintText, 512, "%s %sReplay", gS_StyleStrings[style][sStyleName], sTrack);
-				Format(sHintText, 512, "%s\n%T: %s/%s", sHintText, "HudTimeText", client, sTime, sWR);
+				char[] sPlayerName = new char[MAX_NAME_LENGTH];
+				Shavit_GetReplayName(style, track, sPlayerName, MAX_NAME_LENGTH);
+
+				FormatEx(sHintText, 512, "%s %s%T", gS_StyleStrings[style][sStyleName], sTrack, "ReplayText", client);
+				Format(sHintText, 512, "%s\n%s", sHintText, sPlayerName);
+				Format(sHintText, 512, "%s\n%T: %s/%s", sHintText, "HudTimeText", client, sReplayTime, sReplayLength);
 				Format(sHintText, 512, "%s\n%T: %d", sHintText, "HudSpeedText", client, iSpeed);
 			}
 

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -38,8 +38,8 @@ EngineVersion gEV_Type = Engine_Unknown;
 // modules
 bool gB_Replay = false;
 bool gB_Zones = false;
-bool gB_BhopStats = false;
 bool gB_Sounds = false;
+bool gB_BhopStats = false;
 
 // cache
 int gI_Cycle = 0;
@@ -114,6 +114,7 @@ public void OnPluginStart()
 	// prevent errors in case the replay bot isn't loaded
 	gB_Replay = LibraryExists("shavit-replay");
 	gB_Zones = LibraryExists("shavit-zones");
+	gB_Sounds = LibraryExists("shavit-sounds");
 	gB_BhopStats = LibraryExists("bhopstats");
 
 	// HUD handle
@@ -121,7 +122,6 @@ public void OnPluginStart()
 
 	// plugin convars
 	gCV_GradientStepSize = CreateConVar("shavit_hud_gradientstepsize", "15", "How fast should the start/end HUD gradient be?\nThe number is the amount of color change per 0.1 seconds.\nThe higher the number the faster the gradient.", 0, true, 1.0, true, 255.0);
-
 	gCV_GradientStepSize.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -107,7 +107,7 @@ ConVar gCV_HideTeamChanges = null;
 ConVar gCV_RespawnOnTeam = null;
 ConVar gCV_RespawnOnRestart = null;
 ConVar gCV_StartOnSpawn = null;
-ConVar gCV_PrespeedLimit = null;
+ConVar gCV_PrestrafeLimit = null;
 ConVar gCV_HideRadar = null;
 ConVar gCV_TeleportCommands = null;
 ConVar gCV_NoWeaponDrops = null;
@@ -131,19 +131,19 @@ ConVar gCV_RestoreStates = null;
 
 // cached cvars
 int gI_GodMode = 3;
-int gI_PreSpeed = 3;
+int gI_PreSpeed = 1;
 bool gB_HideTeamChanges = true;
 bool gB_RespawnOnTeam = true;
 bool gB_RespawnOnRestart = true;
 bool gB_StartOnSpawn = true;
-float gF_PrespeedLimit = 280.00;
+float gF_PrestrafeLimit = 30.00;
 bool gB_HideRadar = true;
 bool gB_TeleportCommands = true;
 bool gB_NoWeaponDrops = true;
 bool gB_NoBlock = true;
 bool gB_NoBlood = false;
 float gF_AutoRespawn = 1.5;
-int gI_CreateSpawnPoints = 32;
+int gI_CreateSpawnPoints = 6;
 bool gB_DisableRadio = false;
 bool gB_Scoreboard = true;
 int gI_WeaponCommands = 2;
@@ -272,19 +272,19 @@ public void OnPluginStart()
 
 	// cvars and stuff
 	gCV_GodMode = CreateConVar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.", 0, true, 0.0, true, 3.0);
-	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "3", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit to shavit_misc_prespeedlimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to shavit_misc_prespeedlimit and block bunnyhopping.", 0, true, 0.0, true, 3.0);
+	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "1", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to shavit_misc_prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to shavit_misc_prestrafelimit and block bunnyhopping.", 0, true, 0.0, true, 3.0);
 	gCV_HideTeamChanges = CreateConVar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = CreateConVar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnRestart = CreateConVar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if they use the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_StartOnSpawn = CreateConVar("shavit_misc_startonspawn", "1", "Restart the timer for a player after they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_PrespeedLimit = CreateConVar("shavit_misc_prespeedlimit", "280.00", "Prespeed limitation in startzone.", 0, true, 10.0, false);
+	gCV_PrestrafeLimit = CreateConVar("shavit_misc_prestrafelimit", "30", "Prestrafe limitation in startzone.\nThe value used internally is style run speed + this.\ni.e. run speed of 250 can prestrafe up to 278 (+28) with regular settings.", 0, true, 0.0, false);
 	gCV_HideRadar = CreateConVar("shavit_misc_hideradar", "1", "Should the plugin hide the in-game radar?", 0, true, 0.0, true, 1.0);
 	gCV_TeleportCommands = CreateConVar("shavit_misc_tpcmds", "1", "Enable teleport-related commands? (sm_goto/sm_tpto)\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_NoWeaponDrops = CreateConVar("shavit_misc_noweapondrops", "1", "Remove every dropped weapon.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_NoBlock = CreateConVar("shavit_misc_noblock", "1", "Disable player collision?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_NoBlood = CreateConVar("shavit_misc_noblood", "0", "Hide blood decals and particles?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_AutoRespawn = CreateConVar("shavit_misc_autorespawn", "1.5", "Seconds to wait before respawning player?\n0 - Disabled", 0, true, 0.0, true, 10.0);
-	gCV_CreateSpawnPoints = CreateConVar("shavit_misc_createspawnpoints", "32", "Amount of spawn points to add for each team.\n0 - Disabled", 0, true, 0.0, true, 32.0);
+	gCV_CreateSpawnPoints = CreateConVar("shavit_misc_createspawnpoints", "6", "Amount of spawn points to add for each team.\n0 - Disabled", 0, true, 0.0, true, 32.0);
 	gCV_DisableRadio = CreateConVar("shavit_misc_disableradio", "0", "Block radio commands.\n0 - Disabled (radio commands work)\n1 - Enabled (radio commands are blocked)", 0, true, 0.0, true, 1.0);
 	gCV_Scoreboard = CreateConVar("shavit_misc_scoreboard", "1", "Manipulate scoreboard so score is -{time} and deaths are {rank})?\nDeaths part requires shavit-rankings.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_WeaponCommands = CreateConVar("shavit_misc_weaponcommands", "2", "Enable sm_usp, sm_glock and sm_knife?\n0 - Disabled\n1 - Enabled\n2 - Also give infinite reserved ammo.", 0, true, 0.0, true, 2.0);
@@ -305,7 +305,7 @@ public void OnPluginStart()
 	gCV_RespawnOnTeam.AddChangeHook(OnConVarChanged);
 	gCV_RespawnOnRestart.AddChangeHook(OnConVarChanged);
 	gCV_StartOnSpawn.AddChangeHook(OnConVarChanged);
-	gCV_PrespeedLimit.AddChangeHook(OnConVarChanged);
+	gCV_PrestrafeLimit.AddChangeHook(OnConVarChanged);
 	gCV_HideRadar.AddChangeHook(OnConVarChanged);
 	gCV_TeleportCommands.AddChangeHook(OnConVarChanged);
 	gCV_NoWeaponDrops.AddChangeHook(OnConVarChanged);
@@ -457,7 +457,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_RespawnOnTeam = gCV_RespawnOnTeam.BoolValue;
 	gB_RespawnOnRestart = gCV_RespawnOnRestart.BoolValue;
 	gB_StartOnSpawn = gCV_StartOnSpawn.BoolValue;
-	gF_PrespeedLimit = gCV_PrespeedLimit.FloatValue;
+	gF_PrestrafeLimit = gCV_PrestrafeLimit.FloatValue;
 	gB_HideRadar = gCV_HideRadar.BoolValue;
 	gB_TeleportCommands = gCV_TeleportCommands.BoolValue;
 	gB_NoWeaponDrops = gCV_NoWeaponDrops.BoolValue;
@@ -849,8 +849,9 @@ void RemoveRagdoll(int client)
 
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track)
 {
-	bool bNoclip = (GetEntityMoveType(client) == MOVETYPE_NOCLIP);
+	bool bNoclip = GetEntityMoveType(client) == MOVETYPE_NOCLIP;
 
+	// i will not be adding a setting to toggle this off
 	if(bNoclip && status == Timer_Running)
 	{
 		Shavit_StopTimer(client);
@@ -859,7 +860,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 	int iGroundEntity = GetEntPropEnt(client, Prop_Send, "m_hGroundEntity");
 
 	// prespeed
-	if(!gA_StyleSettings[gBS_Style[client]][bPrespeed] && Shavit_InsideZone(client, Zone_Start, track))
+	if(!bNoclip && !gA_StyleSettings[gBS_Style[client]][bPrespeed] && Shavit_InsideZone(client, Zone_Start, track))
 	{
 		if((gI_PreSpeed == 2 || gI_PreSpeed == 3) && gI_GroundEntity[client] == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
 		{
@@ -873,23 +874,27 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 		if(gI_PreSpeed == 1 || gI_PreSpeed == 3)
 		{
-			float speed[3];
-			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", speed);
+			float fSpeed[3];
+			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
-			float speed_New = (SquareRoot(Pow(speed[0], 2.0) + Pow(speed[1], 2.0)));
-			float fScale = (gF_PrespeedLimit / speed_New);
+			float fLimit = view_as<float>(gA_StyleSettings[gBS_Style[client]][fRunspeed]) + gF_PrestrafeLimit;
 
-			if(bNoclip)
+			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
+			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
+			if(fSpeed[2] > 0.0)
 			{
-				speed[2] = 0.0;
+				fLimit /= 3.0;
 			}
 
-			else if(fScale < 1.0)
+			float fSpeedXY = (SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0)));
+			float fScale = (fLimit / fSpeedXY);
+
+			if(fScale < 1.0)
 			{
-				ScaleVector(speed, fScale);
+				ScaleVector(fSpeed, fScale);
 			}
 
-			TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, speed);
+			TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, fSpeed);
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2342,7 +2342,9 @@ void UpdateFootsteps(int client)
 	}
 }
 
+#if SOURCEMOD_V_MAJOR == 1 && SOURCEMOD_V_MINOR < 9
 bool IsNullVector(float vec[3])
 {
 	return (vec[0] == NULL_VECTOR[0] && vec[1] == NULL_VECTOR[1] && vec[2] == NULL_VECTOR[2]);
 }
+#endif

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1641,6 +1641,11 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 
 	bool bInStart = Shavit_InsideZone(client, Zone_Start, -1);
 
+	if(bInStart)
+	{
+		Shavit_StopTimer(client);
+	}
+
 	Shavit_SetPracticeMode(client, true, !bInStart);
 	Shavit_LoadSnapshot(client, gA_CheckpointsSnapshots[client][index]);
 
@@ -1653,11 +1658,6 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPSpeed]));
 	SetEntPropFloat(client, Prop_Send, "m_flStamina", view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPStamina]));
 	DispatchKeyValue(client, "targetname", gS_CheckpointsTargetname[client][index]);
-
-	if(bInStart)
-	{
-		Shavit_StopTimer(client);
-	}
 	
 	if(!suppressMessage)
 	{

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -736,19 +736,19 @@ void RecalculateMap(const char[] map, const int track, const int style, const in
 	#endif
 }
 
-public void SQL_Recalculate_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_Recalculate_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	ResetPack(view_as<DataPack>(data));
-	int serial = ReadPackCell(data);
-	int size = ReadPackCell(data);
+	data.Reset();
+	int serial = data.ReadCell();
+	int size = data.ReadCell();
 
 	char[] sMap = new char[size + 1];
 	ReadPackString(data, sMap, size + 1);
 
-	int track = ReadPackCell(data);
-	int style = ReadPackCell(data);
-	bool print = view_as<bool>(ReadPackCell(data));
-	delete view_as<DataPack>(data);
+	int track = data.ReadCell();
+	int style = data.ReadCell();
+	bool print = view_as<bool>(data.ReadCell());
+	delete data;
 
 	if(results == null)
 	{

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -409,7 +409,7 @@ public void OnMapStart()
 
 	char[] sQuery = new char[256];
 	FormatEx(sQuery, 256, "SELECT tier FROM %smaptiers WHERE map = '%s';", gS_MySQLPrefix, gS_Map);
-	gH_SQL.Query(SQL_GetMapTier_Callback, sQuery, 0, DBPrio_High);
+	gH_SQL.Query(SQL_GetMapTier_Callback, sQuery, 0, DBPrio_Low);
 }
 
 public void SQL_GetMapTier_Callback(Database db, DBResultSet results, const char[] error, any data)

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -268,8 +268,16 @@ void SQL_DBConnect()
 {
 	if(gH_SQL != null)
 	{
+		char[] sDriver = new char[8];
+		gH_SQL.Driver.GetIdentifier(sDriver, 8);
+
+		if(!StrEqual(sDriver, "mysql", false))
+		{
+			SetFailState("MySQL is the only supported database engine for shavit-rankings.");
+		}
+
 		char[] sQuery = new char[256];
-		FormatEx(sQuery, 256, "CREATE TABLE IF NOT EXISTS `%smaptiers` (`map` CHAR(128), `tier` INT NOT NULL DEFAULT 1, PRIMARY KEY (`map`));", gS_MySQLPrefix);
+		FormatEx(sQuery, 256, "CREATE TABLE IF NOT EXISTS `%smaptiers` (`map` CHAR(128), `tier` INT NOT NULL DEFAULT 1, PRIMARY KEY (`map`)) ENGINE=INNODB;", gS_MySQLPrefix);
 
 		gH_SQL.Query(SQL_CreateTable_Callback, sQuery, 0);
 	}

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -330,23 +330,24 @@ public void SQL_CreateTable_Callback(Database db, DBResultSet results, const cha
 	LogError("%s", sQuery);
 	#endif
 
+	bool bSuccess = true;
+
 	if(!SQL_FastQuery(gH_SQL, sQuery))
 	{
 		char[] sError = new char[255];
 		SQL_GetError(gH_SQL, sError, 255);
 		LogError("Timer (rankings, create procedure) error! Reason: %s", sError);
 
-		SQL_UnlockDatabase(gH_SQL);
+		bSuccess = false;
+	}
 
+	SQL_FastQuery(gH_SQL, "DELIMITER ;");
+	SQL_UnlockDatabase(gH_SQL);
+
+	if(!bSuccess)
+	{
 		return;
 	}
-
-	else
-	{
-		SQL_FastQuery(gH_SQL, "DELIMITER ;");
-	}
-
-	SQL_UnlockDatabase(gH_SQL);
 
 	OnMapStart();
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -394,13 +394,13 @@ public int Native_GetReplayTime(Handle handler, int numParams)
 	{
 		if(gA_CentralCache[iCentralReplayStatus] == Replay_End)
 		{
-			return view_as<int>(gA_FrameCache[style][track][1]);
+			return view_as<int>(GetReplayLength(style, track));
 		}
 	}
 
 	else if(gRS_ReplayStatus[style] == Replay_End)
 	{
-		return view_as<int>(gA_FrameCache[style][Track_Main][1]);
+		return view_as<int>(GetReplayLength(Track_Main, track));
 	}
 
 	return view_as<int>(float(gI_ReplayTick[style]) / gF_Tickrate);
@@ -888,9 +888,9 @@ bool SaveReplay(int style, int track, float time, char[] authid, char[] name)
 
 	delete fFile;
 
-	gA_FrameCache[style][track][0] = view_as<int>(iSize);
-	gA_FrameCache[style][track][1] = view_as<float>(time);
-	gA_FrameCache[style][track][2] = view_as<bool>(true);
+	gA_FrameCache[style][track][0] = iSize;
+	gA_FrameCache[style][track][1] = time;
+	gA_FrameCache[style][track][2] = true;
 	strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, name);
 
 	return true;
@@ -915,9 +915,9 @@ bool DeleteReplay(int style, int track)
 	}
 
 	gA_Frames[style][track].Clear();
-	gA_FrameCache[style][track][0] = view_as<int>(0);
-	gA_FrameCache[style][track][1] = view_as<float>(0.0);
-	gA_FrameCache[style][track][2] = view_as<bool>(false);
+	gA_FrameCache[style][track][0] = 0;
+	gA_FrameCache[style][track][1] = 0.0;
+	gA_FrameCache[style][track][2] = false;
 	strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 	gI_ReplayTick[style] = -1;
 
@@ -1171,7 +1171,7 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	else
 	{
-		float fReplayTime = view_as<float>(gA_FrameCache[style][track][1]);
+		float fReplayTime = GetReplayLength(style, track);
 
 		if(fReplayTime != 0.0 && time >= fReplayTime)
 		{
@@ -1552,7 +1552,7 @@ public void Shavit_OnWRDeleted(int style, int id, int track)
 	float time = 0.0;
 	Shavit_GetWRTime(style, time, track);
 
-	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) - 0.1 <= time) // -0.1 to fix rounding issues
+	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && GetReplayLength(style, track) - gF_Tickrate <= time) // -0.1 to fix rounding issues
 	{
 		DeleteReplay(style, track);
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1547,7 +1547,10 @@ void ClearFrames(int client)
 
 public void Shavit_OnWRDeleted(int style, int id, int track)
 {
-	if(view_as<int>(gA_FrameCache[style][track][0]) > 0)
+	float time = 0.0;
+	Shavit_GetWRTime(style, time, track);
+
+	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) == time)
 	{
 		DeleteReplay(style, track);
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1519,6 +1519,7 @@ public Action Hook_SayText2(UserMsg msg_id, any msg, const int[] players, int pl
 	{
 		Protobuf pbmsg = msg;
 		pbmsg.ReadString("msg_name", sMessage, 24);
+		delete pbmsg;
 	}
 
 	else
@@ -1527,6 +1528,7 @@ public Action Hook_SayText2(UserMsg msg_id, any msg, const int[] players, int pl
 		bfmsg.ReadByte();
 		bfmsg.ReadByte();
 		bfmsg.ReadString(sMessage, 24, false);
+		delete bfmsg;
 	}
 
 	if(StrEqual(sMessage, "#Cstrike_Name_Change"))

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1552,7 +1552,7 @@ public void Shavit_OnWRDeleted(int style, int id, int track)
 	float time = 0.0;
 	Shavit_GetWRTime(style, time, track);
 
-	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) + 0.1 <= time) // + 0.1 to fix rounding issues
+	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) - 0.1 <= time) // -0.1 to fix rounding issues
 	{
 		DeleteReplay(style, track);
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1171,7 +1171,7 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	else
 	{
-		float fReplayTime = GetReplayLength(style, track);
+		float fReplayTime = view_as<float>(gA_FrameCache[style][track][1]);
 
 		if(fReplayTime != 0.0 && time >= fReplayTime)
 		{

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -377,7 +377,7 @@ public int Native_GetReplayFrameCount(Handle handler, int numParams)
 
 public int Native_GetReplayLength(Handle handler, int numParams)
 {
-	return view_as<int>(gA_FrameCache[GetNativeCell(1)][GetNativeCell(2)][1]);
+	return view_as<int>(GetReplayLength(GetNativeCell(1), GetNativeCell(2)));
 }
 
 public int Native_GetReplayName(Handle handler, int numParams)
@@ -750,7 +750,7 @@ bool LoadReplay(int style, int track, const char[] path)
 
 			int iTemp = 0;
 			fFile.ReadInt32(iTemp);
-			gA_FrameCache[style][track][0] = view_as<int>(iTemp);
+			gA_FrameCache[style][track][0] = iTemp;
 
 			if(gA_Frames[style][track] == null)
 			{
@@ -760,7 +760,7 @@ bool LoadReplay(int style, int track, const char[] path)
 			gA_Frames[style][track].Resize(iTemp);
 
 			fFile.ReadInt32(iTemp);
-			gA_FrameCache[style][track][1] = view_as<float>(iTemp);
+			gA_FrameCache[style][track][1] = iTemp;
 
 			char[] sAuthID = new char[32];
 			fFile.ReadString(sAuthID, 32);
@@ -792,7 +792,7 @@ bool LoadReplay(int style, int track, const char[] path)
 				}
 			}
 
-			gA_FrameCache[style][track][2] = view_as<bool>(true); // not wr-based
+			gA_FrameCache[style][track][2] = true; // not wr-based
 		}
 
 		else if(StrEqual(sExplodedHeader[1], REPLAY_FORMAT_V2))
@@ -800,7 +800,7 @@ bool LoadReplay(int style, int track, const char[] path)
 			int iReplaySize = gA_FrameCache[style][track][0] = StringToInt(sExplodedHeader[0]);
 			gA_Frames[style][track].Resize(iReplaySize);
 
-			gA_FrameCache[style][track][1] = view_as<float>(0.0); // N/A at this version
+			gA_FrameCache[style][track][1] = 0.0; // N/A at this version
 
 			any[] aReplayData = new any[6];
 
@@ -817,7 +817,7 @@ bool LoadReplay(int style, int track, const char[] path)
 				}
 			}
 
-			gA_FrameCache[style][track][2] = view_as<bool>(false);
+			gA_FrameCache[style][track][2] = false;
 			strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 		}
 
@@ -840,9 +840,9 @@ bool LoadReplay(int style, int track, const char[] path)
 				gA_Frames[style][track].Set(i, (iStrings == 6)? StringToInt(sExplodedLine[5]):0, 5);
 			}
 
-			gA_FrameCache[style][track][0] = view_as<int>(gA_Frames[style][track].Length);
-			gA_FrameCache[style][track][1] = view_as<float>(0.0); // N/A at this version
-			gA_FrameCache[style][track][2] = view_as<bool>(false); // wr-based
+			gA_FrameCache[style][track][0] = gA_Frames[style][track].Length;
+			gA_FrameCache[style][track][1] = 0.0; // N/A at this version
+			gA_FrameCache[style][track][2] = false; // wr-based
 			strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 		}
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1550,7 +1550,7 @@ public void Shavit_OnWRDeleted(int style, int id, int track)
 	float time = 0.0;
 	Shavit_GetWRTime(style, time, track);
 
-	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) == time)
+	if(view_as<int>(gA_FrameCache[style][track][0]) > 0 && view_as<float>(gA_FrameCache[style][track][1]) + 0.1 <= time) // + 0.1 to fix rounding issues
 	{
 		DeleteReplay(style, track);
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -27,6 +27,10 @@
 #include <shavit>
 
 #define REPLAY_FORMAT_V2 "{SHAVITREPLAYFORMAT}{V2}"
+#define REPLAY_FORMAT_FINAL "{SHAVITREPLAYFORMAT}{FINAL}"
+#define REPLAY_FORMAT_SUBVERSION 0x01 // for compatibility, if i ever update this code again
+#define CELLS_PER_FRAME 6 // origin[3], angles[2], buttons
+
 // #define DEBUG
 
 #pragma newdecls required
@@ -62,7 +66,8 @@ int gI_ReplayBotClient[STYLE_LIMIT];
 ArrayList gA_Frames[STYLE_LIMIT][TRACKS_SIZE];
 float gF_StartTick[STYLE_LIMIT];
 ReplayStatus gRS_ReplayStatus[STYLE_LIMIT];
-int gI_FrameCount[STYLE_LIMIT][TRACKS_SIZE];
+any gA_FrameCache[STYLE_LIMIT][TRACKS_SIZE][3]; // int frame_count, float, time, bool new_format
+char gS_ReplayNames[STYLE_LIMIT][TRACKS_SIZE][MAX_NAME_LENGTH];
 bool gB_ForciblyStopped = false;
 
 bool gB_Button[MAXPLAYERS+1];
@@ -110,6 +115,10 @@ char gS_ChatStrings[CHATSETTINGS_SIZE][128];
 // replay settings
 char gS_ReplayStrings[REPLAYSTRINGS_SIZE][MAX_NAME_LENGTH];
 
+// database related things
+Database gH_SQL = null;
+char gS_MySQLPrefix[32];
+
 public Plugin myinfo =
 {
 	name = "[shavit] Replay Bot",
@@ -138,6 +147,19 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	gB_Late = late;
 
 	return APLRes_Success;
+}
+
+public void OnAllPluginsLoaded()
+{
+	if(!LibraryExists("shavit-wr"))
+	{
+		SetFailState("shavit-wr is required for the plugin to work.");
+	}
+
+	if(gH_SQL == null)
+	{
+		Shavit_OnDatabaseLoaded();
+	}
 }
 
 public void OnPluginStart()
@@ -187,6 +209,9 @@ public void OnPluginStart()
 	// commands
 	RegAdminCmd("sm_deletereplay", Command_DeleteReplay, ADMFLAG_RCON, "Open replay deletion menu.");
 	RegConsoleCmd("sm_replay", Command_Replay, "Opens the central bot menu. For admins: 'sm_replay stop' to stop the playback.");
+
+	// database
+	SQL_SetPrefix();
 }
 
 public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] newValue)
@@ -225,10 +250,10 @@ public int Native_IsReplayDataLoaded(Handle handler, int numParams)
 
 	if(gB_CentralBot)
 	{
-		return (gA_CentralCache[iCentralClient] != -1 && gA_CentralCache[iCentralClient] != Replay_Idle && gI_FrameCount[style][track] > 0);
+		return (gA_CentralCache[iCentralClient] != -1 && gA_CentralCache[iCentralClient] != Replay_Idle && gA_FrameCache[style][track][0] > 0);
 	}
 
-	return view_as<int>(ReplayEnabled(style) && gI_FrameCount[style][Track_Main] > 0);
+	return view_as<int>(ReplayEnabled(style) && gA_FrameCache[style][Track_Main][0] > 0);
 }
 
 public int Native_ReloadReplay(Handle handler, int numParams)
@@ -246,8 +271,11 @@ public int Native_ReloadReplay(Handle handler, int numParams)
 	GetNativeString(4, path, PLATFORM_MAX_PATH);
 
 	delete gA_Frames[style][track];
-	gA_Frames[style][track] = new ArrayList(6);
-	gI_FrameCount[style][track] = 0;
+	gA_Frames[style][track] = new ArrayList(CELLS_PER_FRAME);
+	gA_FrameCache[style][track][0] = 0;
+	gA_FrameCache[style][track][1] = 0.0;
+	gA_FrameCache[style][track][2] = false;
+	strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 
 	bool loaded = false;
 
@@ -348,6 +376,59 @@ public int Native_GetReplayBotTrack(Handle handler, int numParams)
 	return GetReplayTrack(GetNativeCell(1));
 }
 
+public void Shavit_OnDatabaseLoaded()
+{
+	gH_SQL = Shavit_GetDatabase();
+	SetSQLInfo();
+}
+
+public Action CheckForSQLInfo(Handle Timer)
+{
+	return SetSQLInfo();
+}
+
+Action SetSQLInfo()
+{
+	if(gH_SQL == null)
+	{
+		gH_SQL = Shavit_GetDatabase();
+
+		CreateTimer(0.5, CheckForSQLInfo);
+	}
+
+	else
+	{
+		return Plugin_Stop;
+	}
+
+	return Plugin_Continue;
+}
+
+void SQL_SetPrefix()
+{
+	char[] sFile = new char[PLATFORM_MAX_PATH];
+	BuildPath(Path_SM, sFile, PLATFORM_MAX_PATH, "configs/shavit-prefix.txt");
+
+	File fFile = OpenFile(sFile, "r");
+
+	if(fFile == null)
+	{
+		SetFailState("Cannot open \"configs/shavit-prefix.txt\". Make sure this file exists and that the server has read permissions to it.");
+	}
+	
+	char[] sLine = new char[PLATFORM_MAX_PATH*2];
+
+	while(fFile.ReadLine(sLine, PLATFORM_MAX_PATH*2))
+	{
+		TrimString(sLine);
+		strcopy(gS_MySQLPrefix, 32, sLine);
+
+		break;
+	}
+
+	delete fFile;
+}
+
 public Action Cron(Handle Timer)
 {
 	if(!gB_Enabled)
@@ -363,19 +444,13 @@ public Action Cron(Handle Timer)
 		bot_quota.IntValue = gI_ExpectedBots;
 	}
 
-	// clear player cache if time is worse than wr
-	// might cause issues if WR time is removed and someone else gets a new WR
-	float[][] fWRTimes = new float[gI_Styles][TRACKS_SIZE];
-
 	for(int i = 0; i < gI_Styles; i++)
 	{
 		for(int j = 0; j < ((gB_CentralBot)? TRACKS_SIZE:1); j++)
 		{
-			Shavit_GetWRTime(i, fWRTimes[i][j], j);
-
 			if(!gB_CentralBot && gI_ReplayBotClient[i] != 0)
 			{
-				UpdateReplayInfo(gI_ReplayBotClient[i], i, fWRTimes[i][j], j);
+				UpdateReplayInfo(gI_ReplayBotClient[i], i, GetReplayLength(i, j), j);
 			}
 		}
 	}
@@ -390,23 +465,6 @@ public Action Cron(Handle Timer)
 		else
 		{
 			UpdateReplayInfo(gA_CentralCache[iCentralClient], 0, 0.0, 0);
-		}
-	}
-
-	for(int i = 1; i <= MaxClients; i++)
-	{
-		if(gI_PlayerFrames[i] == 0 || !IsValidClient(i, true) || IsFakeClient(i))
-		{
-			continue;
-		}
-
-		int style = Shavit_GetBhopStyle(i);
-		int track = Shavit_GetClientTrack(i);
-
-		if(!ReplayEnabled(style) || (fWRTimes[style][track] > 0.0 && Shavit_GetClientTime(i) > fWRTimes[style][track]))
-		{
-			ClearFrames(i);
-			gB_Record[i] = false;
 		}
 	}
 
@@ -560,8 +618,12 @@ public void OnMapStart()
 		for(int j = 0; j < ((gB_CentralBot)? TRACKS_SIZE:1); j++)
 		{
 			delete gA_Frames[i][j];
-			gA_Frames[i][j] = new ArrayList(6);
-			gI_FrameCount[i][j] = 0;
+			gA_Frames[i][j] = new ArrayList(CELLS_PER_FRAME);
+			gA_FrameCache[i][j][0] = 0;
+			gA_FrameCache[i][j][1] = 0.0;
+			gA_FrameCache[i][j][2] = false;
+			strcopy(gS_ReplayNames[i][j], MAX_NAME_LENGTH, "invalid");
+
 			loaded = DefaultLoadReplay(i, j);
 		}
 
@@ -641,10 +703,65 @@ bool LoadReplay(int style, int track, const char[] path)
 		char[][] sExplodedHeader = new char[2][64];
 		ExplodeString(sHeader, ":", sExplodedHeader, 2, 64);
 
-		if(StrEqual(sExplodedHeader[1], REPLAY_FORMAT_V2)) // new replay format, fast!
+		if(StrEqual(sExplodedHeader[1], REPLAY_FORMAT_FINAL)) // hopefully, the last of them
 		{
-			int iReplaySize = StringToInt(sExplodedHeader[0]);
+			// uncomment if ever needed
+			// int iSubVersion = StringToInt(sExplodedHeader[0]);
+
+			int iTemp = 0;
+			fFile.ReadInt32(iTemp);
+			gA_FrameCache[style][track][0] = view_as<int>(iTemp);
+
+			if(gA_Frames[style][track] == null)
+			{
+				gA_Frames[style][track] = new ArrayList(CELLS_PER_FRAME);
+			}
+
+			gA_Frames[style][track].Resize(iTemp);
+
+			fFile.ReadInt32(iTemp);
+			gA_FrameCache[style][track][1] = view_as<float>(iTemp);
+
+			char[] sAuthID = new char[32];
+			fFile.ReadString(sAuthID, 32);
+
+			if(gH_SQL != null)
+			{
+				// TODO: query database with above steamid and store name into `gS_ReplayNames[style][track]`
+				char[] sQuery = new char[192];
+				FormatEx(sQuery, 192, "SELECT name FROM %susers WHERE auth = '%s';", gS_MySQLPrefix, sAuthID);
+
+				DataPack pack = new DataPack();
+				pack.WriteCell(style);
+				pack.WriteCell(track);
+
+				gH_SQL.Query(SQL_GetUserName_Callback, sQuery, pack, DBPrio_High);
+			}
+
+			any[] aReplayData = new any[CELLS_PER_FRAME];
+
+			for(int i = 0; i < gA_FrameCache[style][track][0]; i++)
+			{
+				if(fFile.Read(aReplayData, CELLS_PER_FRAME, 4) >= 0)
+				{
+					gA_Frames[style][track].Set(i, view_as<float>(aReplayData[0]), 0);
+					gA_Frames[style][track].Set(i, view_as<float>(aReplayData[1]), 1);
+					gA_Frames[style][track].Set(i, view_as<float>(aReplayData[2]), 2);
+					gA_Frames[style][track].Set(i, view_as<float>(aReplayData[3]), 3);
+					gA_Frames[style][track].Set(i, view_as<float>(aReplayData[4]), 4);
+					gA_Frames[style][track].Set(i, view_as<int>(aReplayData[5]), 5);
+				}
+			}
+
+			gA_FrameCache[style][track][2] = view_as<bool>(true); // not wr-based
+		}
+
+		else if(StrEqual(sExplodedHeader[1], REPLAY_FORMAT_V2))
+		{
+			int iReplaySize = gA_FrameCache[style][track][0] = StringToInt(sExplodedHeader[0]);
 			gA_Frames[style][track].Resize(iReplaySize);
+
+			gA_FrameCache[style][track][1] = view_as<float>(0.0); // N/A at this version
 
 			any[] aReplayData = new any[6];
 
@@ -660,6 +777,9 @@ bool LoadReplay(int style, int track, const char[] path)
 					gA_Frames[style][track].Set(i, view_as<int>(aReplayData[5]), 5);
 				}
 			}
+
+			gA_FrameCache[style][track][2] = view_as<bool>(false);
+			strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 		}
 
 		else // old, outdated and slow - only used for ancient replays
@@ -680,9 +800,12 @@ bool LoadReplay(int style, int track, const char[] path)
 				gA_Frames[style][track].Set(i, StringToFloat(sExplodedLine[4]), 4);
 				gA_Frames[style][track].Set(i, (iStrings == 6)? StringToInt(sExplodedLine[5]):0, 5);
 			}
-		}
 
-		gI_FrameCount[style][track] = gA_Frames[style][track].Length;
+			gA_FrameCache[style][track][0] = view_as<int>(gA_Frames[style][track].Length);
+			gA_FrameCache[style][track][1] = view_as<float>(0.0); // N/A at this version
+			gA_FrameCache[style][track][2] = view_as<bool>(false); // wr-based
+			strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
+		}
 
 		delete fFile;
 
@@ -692,7 +815,7 @@ bool LoadReplay(int style, int track, const char[] path)
 	return false;
 }
 
-bool SaveReplay(int style, int track)
+bool SaveReplay(int style, int track, float time, char[] authid, char[] name)
 {
 	char[] sTrack = new char[4];
 	FormatEx(sTrack, 4, "_%d", track);
@@ -705,36 +828,31 @@ bool SaveReplay(int style, int track)
 		DeleteFile(sPath);
 	}
 
+	File fFile = OpenFile(sPath, "wb");
+	fFile.WriteLine("%d:" ... REPLAY_FORMAT_FINAL, REPLAY_FORMAT_SUBVERSION);
+
 	int iSize = gA_Frames[style][track].Length;
 
-	File fFile = OpenFile(sPath, "wb");
-	fFile.WriteLine("%d:%s", iSize, REPLAY_FORMAT_V2);
+	fFile.WriteInt32(iSize);
+	fFile.WriteInt32(view_as<int>(time));
+	fFile.WriteString(authid, true);
 
-	int iTickrate = RoundToZero(gF_Tickrate);
-	int iArraySize = (iTickrate * 6);
-	any[] aReplayData = new any[iArraySize];
-	any[] aFrameData = new any[6];
+	// if REPLAY_FORMAT_SUBVERSION is over 0x01 i'll add variables here
 
-	int iQueuedFrames = 0;
+	any[] aFrameData = new any[CELLS_PER_FRAME];
 
-	for(int i = 0; i < iSize; iQueuedFrames = (++i % iTickrate))
+	for(int i = 0; i < iSize; i++)
 	{
-		gA_Frames[style][track].GetArray(i, aFrameData, 6);
-
-		for(int x = 0; x < 6; x++)
-		{
-			aReplayData[((iQueuedFrames * 6) + x)] = aFrameData[x];
-		}
-
-		if(i == (iSize - 1) || (iQueuedFrames + 1) == iTickrate)
-		{
-			fFile.Write(aReplayData, (iQueuedFrames * 6), 4);
-		}
+		gA_Frames[style][track].GetArray(i, aFrameData, CELLS_PER_FRAME);
+		fFile.Write(aFrameData, CELLS_PER_FRAME, 4);
 	}
 
 	delete fFile;
 
-	gI_FrameCount[style][track] = iSize;
+	gA_FrameCache[style][track][0] = view_as<int>(iSize);
+	gA_FrameCache[style][track][1] = view_as<float>(time);
+	gA_FrameCache[style][track][2] = view_as<bool>(true);
+	strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, name);
 
 	return true;
 }
@@ -758,7 +876,10 @@ bool DeleteReplay(int style, int track)
 	}
 
 	gA_Frames[style][track].Clear();
-	gI_FrameCount[style][track] = 0;
+	gA_FrameCache[style][track][0] = view_as<int>(0);
+	gA_FrameCache[style][track][1] = view_as<float>(0.0);
+	gA_FrameCache[style][track][2] = view_as<bool>(false);
+	strcopy(gS_ReplayNames[style][track], MAX_NAME_LENGTH, "invalid");
 	gI_ReplayTick[style] = -1;
 
 	if(gI_ReplayBotClient[style] != 0)
@@ -767,6 +888,26 @@ bool DeleteReplay(int style, int track)
 	}
 
 	return true;
+}
+
+public void SQL_GetUserName_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
+{
+	data.Reset();
+	int style = data.ReadCell();
+	int track = data.ReadCell();
+	delete data;
+
+	if(results == null)
+	{
+		LogError("Timer error! Get user name (replay) failed. Reason: %s", error);
+
+		return;
+	}
+
+	if(results.FetchRow())
+	{
+		results.FetchString(0, gS_ReplayNames[style][track], MAX_NAME_LENGTH);
+	}
 }
 
 public void OnClientPutInServer(int client)
@@ -778,7 +919,8 @@ public void OnClientPutInServer(int client)
 
 	if(!IsFakeClient(client))
 	{
-		gA_PlayerFrames[client] = new ArrayList(6);
+		delete gA_PlayerFrames[client];
+		gA_PlayerFrames[client] = new ArrayList(CELLS_PER_FRAME);
 	}
 
 	else
@@ -808,14 +950,13 @@ public void OnClientPutInServer(int client)
 
 void FormatStyle(const char[] source, int style, bool central, float time, int track, char[] dest, int size)
 {
-	float fWRTime = 0.0;
-	Shavit_GetWRTime(style, fWRTime, track);
+	float fWRTime = GetReplayLength(style, track);
 
 	char[] sTime = new char[16];
 	FormatSeconds((time == -1.0)? fWRTime:time, sTime, 16);
 
 	char[] sName = new char[MAX_NAME_LENGTH];
-	Shavit_GetWRName(style, sName, MAX_NAME_LENGTH, track);
+	GetReplayName(style, track, sName, MAX_NAME_LENGTH);
 	
 	char[] temp = new char[size];
 	strcopy(temp, size, source);
@@ -862,8 +1003,9 @@ void UpdateReplayInfo(int client, int style, float time, int track)
 	CS_SetClientClanTag(client, sTag);
 
 	char[] sName = new char[MAX_NAME_LENGTH];
+	int iFrameCount = view_as<int>(gA_FrameCache[style][track][0]);
 	
-	if(central || gI_FrameCount[style][track] > 0)
+	if(central || iFrameCount > 0)
 	{
 		FormatStyle(gS_ReplayStrings[(idle)? sReplayCentralName:sReplayNameStyle], style, central, time, track, sName, MAX_NAME_LENGTH);
 	}
@@ -876,7 +1018,7 @@ void UpdateReplayInfo(int client, int style, float time, int track)
 	gB_HideNameChange = true;
 	SetClientName(client, sName);
 
-	int iScore = (gI_FrameCount[style][track] > 0 || client == gA_CentralCache[iCentralClient])? 2000:-2000;
+	int iScore = (iFrameCount > 0 || client == gA_CentralCache[iCentralClient])? 2000:-2000;
 
 	if(gEV_Type == Engine_CSGO)
 	{
@@ -892,7 +1034,7 @@ void UpdateReplayInfo(int client, int style, float time, int track)
 
 	gB_DontCallTimer = true;
 
-	if(!gB_CentralBot && gI_FrameCount[style][track] == 0)
+	if(!gB_CentralBot && iFrameCount == 0)
 	{
 		if(IsPlayerAlive(client))
 		{
@@ -934,6 +1076,11 @@ public void OnClientDisconnect(int client)
 {
 	if(!IsFakeClient(client))
 	{
+		if(gA_PlayerFrames[client] != null)
+		{
+			delete gA_PlayerFrames[client];
+		}
+
 		return;
 	}
 
@@ -968,22 +1115,32 @@ public void Shavit_OnStop(int client)
 	ClearFrames(client);
 }
 
-public void Shavit_OnFinish_Post(int client, int style, float time, int jumps, int strafes, float sync, int rank, int overwrite, int track)
+public void Shavit_OnFinish(int client, int style, float time, int jumps, int strafes, float sync, int track)
 {
-	float fWRTime = 0.0;
-	Shavit_GetWRTime(style, fWRTime, track);
+	gB_Record[client] = false;
 
-	if(!gB_Enabled || !ReplayEnabled(style) || (fWRTime > 0.0 && time > fWRTime))
+	float fWR = 0.0;
+	Shavit_GetWRTime(style, fWR, track);
+
+	if(!view_as<bool>(gA_FrameCache[style][track][2]) && view_as<int>(gA_FrameCache[style][track][0] != 0))
 	{
-		ClearFrames(client);
+		if(time >= fWR)
+		{
+			return;
+		}
 	}
 
-	gB_Record[client] = false;
-}
+	else
+	{
+		float fReplayTime = view_as<float>(gA_FrameCache[style][track][1]);
 
-public void Shavit_OnWorldRecord(int client, int style, float time, int jumps, int strafes, float sync, int track)
-{
-	if(gI_PlayerFrames[client] == 0 || !gB_Record[client])
+		if(fReplayTime != 0.0 && time >= fReplayTime)
+		{
+			return;
+		}
+	}
+
+	if(gI_PlayerFrames[client] == 0)
 	{
 		return;
 	}
@@ -996,7 +1153,15 @@ public void Shavit_OnWorldRecord(int client, int style, float time, int jumps, i
 	}
 
 	gA_Frames[style][track] = gA_PlayerFrames[client].Clone();
-	SaveReplay(style, track);
+
+	char[] sAuthID = new char[32];
+	GetClientAuthId(client, AuthId_Steam3, sAuthID, 32);
+
+	char[] sName = new char[MAX_NAME_LENGTH];
+	GetClientName(client, sName, MAX_NAME_LENGTH);
+	ReplaceString(sName, MAX_NAME_LENGTH, "#", "?");
+
+	SaveReplay(style, track, time, sAuthID, sName);
 
 	if(ReplayEnabled(style))
 	{
@@ -1075,14 +1240,15 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 		vel[0] = 0.0;
 		vel[1] = 0.0;
-		// vel[2] = 0.0; // i doubt this is needed
 
-		if(gA_Frames[style][track] == null || gI_FrameCount[style][track] <= 0) // if no replay is loaded
+		int iFrameCount = view_as<int>(gA_FrameCache[style][track][0]);
+
+		if(gA_Frames[style][track] == null || iFrameCount <= 0) // if no replay is loaded
 		{
 			return Plugin_Changed;
 		}
 
-		if(gI_ReplayTick[style] != -1 && gI_FrameCount[style][track] >= 1)
+		if(gI_ReplayTick[style] != -1 && iFrameCount >= 1)
 		{
 			float vecPosition[3];
 			float vecAngles[3];
@@ -1091,7 +1257,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 			{
 				bool bStart = (gRS_ReplayStatus[style] == Replay_Start);
 
-				int iFrame = (bStart)? 0:(gI_FrameCount[style][track] - 1);
+				int iFrame = (bStart)? 0:(iFrameCount - 1);
 
 				vecPosition[0] = gA_Frames[style][track].Get(iFrame, 0);
 				vecPosition[1] = gA_Frames[style][track].Get(iFrame, 1);
@@ -1116,7 +1282,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				return Plugin_Changed;
 			}
 
-			if(++gI_ReplayTick[style] >= gI_FrameCount[style][track])
+			if(++gI_ReplayTick[style] >= iFrameCount)
 			{
 				gI_ReplayTick[style] = 0;
 				gRS_ReplayStatus[style] = gA_CentralCache[iCentralReplayStatus] = Replay_End;
@@ -1248,11 +1414,6 @@ public void Player_Event(Event event, const char[] name, bool dontBroadcast)
 
 		gB_DontCallTimer = false;
 	}
-
-	else
-	{
-		ClearFrames(client);
-	}
 }
 
 public Action DelayedUpdate(Handle Timer, any data)
@@ -1347,7 +1508,7 @@ void ClearFrames(int client)
 
 public void Shavit_OnWRDeleted(int style, int id, int track)
 {
-	if(gI_FrameCount[style][track] > 0)
+	if(view_as<int>(gA_FrameCache[style][track][0]) > 0)
 	{
 		DeleteReplay(style, track);
 	}
@@ -1372,7 +1533,7 @@ public Action Command_DeleteReplay(int client, int args)
 
 		for(int j = 0; j < TRACKS_SIZE; j++)
 		{
-			if(gI_FrameCount[i][j] == 0)
+			if(view_as<int>(gA_FrameCache[i][j][0]) == 0)
 			{
 				continue;
 			}
@@ -1380,8 +1541,7 @@ public Action Command_DeleteReplay(int client, int args)
 			char[] sInfo = new char[8];
 			FormatEx(sInfo, 8, "%d;%d", i, j);
 
-			float time = 0.0;
-			Shavit_GetWRTime(i, time, j);
+			float time = GetReplayLength(i, j);
 
 			char[] sTrack = new char[32];
 			GetTrackName(client, j, sTrack, 32);
@@ -1393,7 +1553,7 @@ public Action Command_DeleteReplay(int client, int args)
 				char[] sTime = new char[32];
 				FormatSeconds(time, sTime, 32, false);
 
-				FormatEx(sDisplay, 64, "%s (%s) - WR: %s", gS_StyleStrings[i][sStyleName], sTrack, sTime);
+				FormatEx(sDisplay, 64, "%s (%s) - %s", gS_StyleStrings[i][sStyleName], sTrack, sTime);
 			}
 
 			else
@@ -1542,7 +1702,7 @@ Action OpenReplayMenu(int client)
 
 		for(int j = 0; j < gI_Styles; j++)
 		{
-			if(gI_FrameCount[j][i] > 0)
+			if(view_as<int>(gA_FrameCache[j][i][0]) > 0)
 			{
 				records = true;
 
@@ -1612,8 +1772,7 @@ void OpenReplaySubMenu(int client, int track)
 		char[] sInfo = new char[8];
 		IntToString(i, sInfo, 8);
 
-		float time = 0.0;
-		Shavit_GetWRTime(i, time, track);
+		float time = GetReplayLength(i, track);
 
 		char[] sDisplay = new char[64];
 
@@ -1622,7 +1781,7 @@ void OpenReplaySubMenu(int client, int track)
 			char[] sTime = new char[32];
 			FormatSeconds(time, sTime, 32, false);
 
-			FormatEx(sDisplay, 64, "%s - WR: %s", gS_StyleStrings[i][sStyleName], sTime);
+			FormatEx(sDisplay, 64, "%s - %s", gS_StyleStrings[i][sStyleName], sTime);
 		}
 
 		else
@@ -1630,7 +1789,7 @@ void OpenReplaySubMenu(int client, int track)
 			strcopy(sDisplay, 64, gS_StyleStrings[i][sStyleName]);
 		}
 
-		menu.AddItem(sInfo, sDisplay, (gI_FrameCount[i][track] > 0)? ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+		menu.AddItem(sInfo, sDisplay, (view_as<int>(gA_FrameCache[i][track][0]) > 0)? ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 	}
 
 	if(menu.ItemCount == 0)
@@ -1664,7 +1823,7 @@ public int MenuHandler_ReplaySubmenu(Menu menu, MenuAction action, int param1, i
 
 		int style = StringToInt(info);
 
-		if(style == -1 || !ReplayEnabled(style) || gI_FrameCount[style][gI_Track[param1]] == 0 || gA_CentralCache[iCentralClient] <= 0)
+		if(style == -1 || !ReplayEnabled(style) || view_as<int>(gA_FrameCache[style][gI_Track[param1]][0]) == 0 || gA_CentralCache[iCentralClient] <= 0)
 		{
 			return 0;
 		}
@@ -1686,8 +1845,7 @@ public int MenuHandler_ReplaySubmenu(Menu menu, MenuAction action, int param1, i
 			TeleportToStart(gA_CentralCache[iCentralClient], style, gI_Track[param1]);
 			gB_ForciblyStopped = false;
 
-			float time = 0.0;
-			Shavit_GetWRTime(gA_CentralCache[iCentralStyle], time, gI_Track[param1]);
+			float time = GetReplayLength(gA_CentralCache[iCentralStyle], gI_Track[param1]);
 
 			UpdateReplayInfo(gA_CentralCache[iCentralClient], style, time, gI_Track[param1]);
 
@@ -1710,7 +1868,7 @@ public int MenuHandler_ReplaySubmenu(Menu menu, MenuAction action, int param1, i
 
 void TeleportToStart(int client, int style, int track)
 {
-	if(gI_FrameCount[style][track] == 0)
+	if(view_as<int>(gA_FrameCache[style][track][0]) == 0)
 	{
 		return;
 	}
@@ -1819,6 +1977,31 @@ void GetTrackName(int client, int track, char[] output, int size)
 	static char sTrack[16];
 	FormatEx(sTrack, 16, "Track_%d", track);
 	FormatEx(output, size, "%T", sTrack, client);
+}
+
+float GetReplayLength(int style, int track)
+{
+	if(view_as<bool>(gA_FrameCache[style][track][2]))
+	{
+		return view_as<float>(gA_FrameCache[style][track][1]);
+	}
+
+	float fWRTime = 0.0;
+	Shavit_GetWRTime(style, fWRTime, track);
+
+	return fWRTime;
+}
+
+void GetReplayName(int style, int track, char[] buffer, int length)
+{
+	if(view_as<bool>(gA_FrameCache[style][track][2]))
+	{
+		strcopy(buffer, length, gS_ReplayNames[style][track]);
+
+		return;
+	}
+
+	Shavit_GetWRName(style, buffer, length, track);
 }
 
 /*

--- a/addons/sourcemod/scripting/shavit-timelimit.sp
+++ b/addons/sourcemod/scripting/shavit-timelimit.sp
@@ -260,7 +260,7 @@ void StartCalculating()
 		PrintToServer("%s", sQuery);
 		#endif
 
-		gH_SQL.Query(SQL_GetMapTimes, sQuery, 0, DBPrio_High);
+		gH_SQL.Query(SQL_GetMapTimes, sQuery, 0, DBPrio_Low);
 	}
 }
 

--- a/addons/sourcemod/scripting/shavit-timelimit.sp
+++ b/addons/sourcemod/scripting/shavit-timelimit.sp
@@ -346,6 +346,11 @@ public Action Timer_PrintToChat(Handle Timer)
 	int timeleft = 0;
 	GetMapTimeLeft(timeleft);
 
+	if(timeleft <= -1 || timeleft >= -3)
+	{
+		Shavit_StopChatSound();
+	}
+
 	switch(timeleft)
 	{
 		case 3600: Shavit_PrintToChatAll("%T", "Minutes", LANG_SERVER, "60");
@@ -360,26 +365,23 @@ public Action Timer_PrintToChat(Handle Timer)
 		
 		case -1:
 		{
-			Shavit_StopChatSound();
 			Shavit_PrintToChatAll("3..");
 		}
 		
 		case -2:
 		{
-			Shavit_StopChatSound();
 			Shavit_PrintToChatAll("2..");
 		}
 		
 		case -3:
 		{
-			Shavit_StopChatSound();
 			Shavit_PrintToChatAll("1..");
 		}
-	}
-	
-	if(timeleft == -4)
-	{
-		CS_TerminateRound(0.0, CSRoundEnd_Draw, true);
+
+		case -4:
+		{
+			CS_TerminateRound(0.0, CSRoundEnd_Draw, true);
+		}
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1513,7 +1513,12 @@ public Action Command_RecentRecords(int client, int args)
 	}
 
 	char[] sQuery = new char[512];
-	FormatEx(sQuery, 512, "SELECT p.id, p.map, u.name, MIN(p.time), p.jumps, p.style, p.points, p.track FROM %splayertimes p JOIN %susers u ON p.auth = u.auth GROUP BY p.map, p.style, p.track ORDER BY date DESC LIMIT %d;", gS_MySQLPrefix, gS_MySQLPrefix, gI_RecentLimit);
+
+	FormatEx(sQuery, 512,
+		"SELECT a.id, a.map, u.name, a.time, a.jumps, a.style, a.points, a.track FROM %splayertimes a " ...
+		"JOIN (SELECT MIN(time) time, map, style, track FROM %splayertimes GROUP by map, style, track) b " ...
+		"JOIN %susers u ON a.time = b.time AND a.auth = u.auth AND a.map = b.map AND a.style = b.style AND a.track = b.track " ...
+		"ORDER BY date DESC LIMIT 100;", gS_MySQLPrefix, gS_MySQLPrefix, gS_MySQLPrefix);
 
 	gH_SQL.Query(SQL_RR_Callback, sQuery, GetClientSerial(client), DBPrio_Low);
 

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1891,7 +1891,7 @@ void SQL_DBConnect()
 
 		if(gB_MySQL)
 		{
-			FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` INT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), INDEX `auth` (`auth`), INDEX `points` (`points`), INDEX `time` (`time`), FULLTEXT INDEX `map` (`map`));", gS_MySQLPrefix);
+			FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` INT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), INDEX `auth` (`auth`), INDEX `points` (`points`), INDEX `time` (`time`), INDEX `style` (`style`), INDEX `track` (`track`), INDEX `date` (`date`), FULLTEXT INDEX `map` (`map`)) ENGINE=INNODB;", gS_MySQLPrefix);
 		}
 
 		else

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -925,12 +925,12 @@ public int MenuHandler_DeleteStyleRecords_Confirm(Menu menu, MenuAction action, 
 	return 0;
 }
 
-public void DeleteStyleRecords_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void DeleteStyleRecords_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	ResetPack(view_as<DataPack>(data));
-	int serial = ReadPackCell(data);
-	int style = ReadPackCell(data);
-	delete view_as<DataPack>(data);
+	data.Reset();
+	int serial = data.ReadCell();
+	int style = data.ReadCell();
+	delete data;
 
 	if(results == null)
 	{
@@ -988,12 +988,12 @@ void OpenDelete(int client, int style)
 	gH_SQL.Query(SQL_OpenDelete_Callback, sQuery, datapack, DBPrio_High);
 }
 
-public void SQL_OpenDelete_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_OpenDelete_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	ResetPack(data);
-	int client = GetClientFromSerial(ReadPackCell(data));
-	int style = ReadPackCell(data);
-	delete view_as<DataPack>(data);
+	data.Reset();
+	int client = GetClientFromSerial(data.ReadCell());
+	int style = data.ReadCell();
+	delete data;
 
 	if(results == null)
 	{
@@ -1363,17 +1363,16 @@ void StartWRMenu(int client, const char[] map, int style, int track)
 	return;
 }
 
-public void SQL_WR_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_WR_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	ResetPack(data);
-
-	int serial = ReadPackCell(data);
-	int track = ReadPackCell(data);
+	data.Reset();
+	int serial = data.ReadCell();
+	int track = data.ReadCell();
 
 	char[] sMap = new char[192];
-	ReadPackString(data, sMap, 192);
+	data.ReadString(sMap, 192);
 
-	delete view_as<DataPack>(data);
+	delete data;
 
 	if(results == null)
 	{
@@ -1649,19 +1648,19 @@ void OpenSubMenu(int client, int id)
 	gH_SQL.Query(SQL_SubMenu_Callback, sQuery, datapack, DBPrio_High);
 }
 
-public void SQL_SubMenu_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_SubMenu_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
+	data.Reset();
+	int client = GetClientFromSerial(data.ReadCell());
+	int id = data.ReadCell();
+	delete data;
+
 	if(results == null)
 	{
 		LogError("Timer (WR SUBMENU) SQL query failed. Reason: %s", error);
 
 		return;
 	}
-
-	ResetPack(data);
-	int client = GetClientFromSerial(ReadPackCell(data));
-	int id = ReadPackCell(data);
-	delete view_as<DataPack>(data);
 
 	if(client == 0)
 	{

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -463,8 +463,8 @@ bool LoadZonesConfig()
 
 	do
 	{
-		int track = (i <= 9)? Track_Main:Track_Bonus;
-		int index = (track == Track_Main)? i:i-10;
+		int track = (i / ZONETYPES_SIZE);
+		int index = (i % ZONETYPES_SIZE);
 
 		gA_ZoneSettings[index][track][bVisible] = view_as<bool>(kv.GetNum("visible", 1));
 		gA_ZoneSettings[index][track][iRed] = kv.GetNum("red", 255);

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -1148,13 +1148,13 @@ public int DeleteZone_MenuHandler(Menu menu, MenuAction action, int param1, int 
 	return 0;
 }
 
-public void SQL_DeleteZone_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_DeleteZone_Callback(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	ResetPack(data);
-	int client = GetClientFromSerial(ReadPackCell(data));
-	int type = ReadPackCell(data);
+	data.Reset();
+	int client = GetClientFromSerial(data.ReadCell());
+	int type = data.ReadCell();
 
-	delete view_as<DataPack>(data);
+	delete data;
 
 	if(results == null)
 	{

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -80,7 +80,6 @@ bool gB_CursorTracing[MAXPLAYERS+1];
 float gV_Point1[MAXPLAYERS+1][3];
 float gV_Point2[MAXPLAYERS+1][3];
 float gV_Teleport[MAXPLAYERS+1][3];
-float gV_OldPosition[MAXPLAYERS+1][3];
 float gV_WallSnap[MAXPLAYERS+1][3];
 bool gB_Button[MAXPLAYERS+1];
 bool gB_InsideZone[MAXPLAYERS+1][ZONETYPES_SIZE][TRACKS_SIZE];
@@ -1290,7 +1289,6 @@ void Reset(int client)
 		gV_Point1[client][i] = 0.0;
 		gV_Point2[client][i] = 0.0;
 		gV_Teleport[client][i] = 0.0;
-		gV_OldPosition[client][i] = 0.0;
 		gV_WallSnap[client][i] = 0.0;
 	}
 }
@@ -1395,13 +1393,6 @@ public int ZoneCreation_Handler(Menu menu, MenuAction action, int param1, int pa
 
 bool SnapToWall(float pos[3], int client, float final[3])
 {
-	if(AreVectorsEqual(pos, gV_OldPosition[client]))
-	{
-		final = gV_WallSnap[client];
-
-		return true;
-	}
-
 	bool hit = false;
 
 	float end[3];
@@ -1429,6 +1420,9 @@ bool SnapToWall(float pos[3], int client, float final[3])
 
 	if(hit && GetVectorDistance(prefinal, pos) <= gI_GridSnap[client])
 	{
+		prefinal[0] = float(RoundToNearest(prefinal[0] / gI_GridSnap[client]) * gI_GridSnap[client]);
+		prefinal[1] = float(RoundToNearest(prefinal[1] / gI_GridSnap[client]) * gI_GridSnap[client]);
+
 		final = prefinal;
 
 		return true;
@@ -1475,11 +1469,6 @@ public bool TraceFilter_World(int entity, int contentsMask)
 	return (entity == 0);
 }
 
-bool AreVectorsEqual(float vec1[3], float vec2[3])
-{
-	return (vec1[0] == vec2[0] && vec1[1] == vec2[1] && vec1[2] == vec2[2]);
-}
-
 public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status)
 {
 	if(!IsPlayerAlive(client) || IsFakeClient(client))
@@ -1512,7 +1501,6 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 				else
 				{
 					gV_WallSnap[client] = origin;
-					gV_OldPosition[client] = vPlayerOrigin;
 				}
 
 				origin[2] = vPlayerOrigin[2];
@@ -1919,7 +1907,6 @@ public Action Timer_Draw(Handle Timer, any data)
 	else
 	{
 		gV_WallSnap[client] = origin;
-		gV_OldPosition[client] = vPlayerOrigin;
 	}
 
 	if(gI_MapStep[client] == 1 || gV_Point2[client][0] == 0.0)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2423,8 +2423,8 @@ public void StartTouchPost(int entity, int other)
 		case Zone_Slay:
 		{
 			Shavit_StopTimer(other);
-
 			ForcePlayerSuicide(other);
+			Shavit_PrintToChat(other, "%T", "ZoneSlayEnter", other, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageVariable2], gS_ChatStrings[sMessageWarning]);
 		}
 
 		case Zone_Stop:
@@ -2432,6 +2432,7 @@ public void StartTouchPost(int entity, int other)
 			if(status != Timer_Stopped)
 			{
 				Shavit_StopTimer(other);
+				Shavit_PrintToChat(other, "%T", "ZoneStopEnter", other, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageVariable2], gS_ChatStrings[sMessageWarning]);
 			}
 		}
 

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2105,7 +2105,7 @@ void SQL_DBConnect()
 		gB_MySQL = StrEqual(sDriver, "mysql", false);
 
 		char[] sQuery = new char[1024];
-		FormatEx(sQuery, 1024, "CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` CHAR(128), `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`));", gS_MySQLPrefix);
+		FormatEx(sQuery, 1024, "CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` CHAR(128), `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`))%s;", gS_MySQLPrefix, (gB_MySQL)? " ENGINE=INNODB":"");
 
 		gH_SQL.Query(SQL_CreateTable_Callback, sQuery);
 	}

--- a/addons/sourcemod/translations/shavit-zones.phrases.txt
+++ b/addons/sourcemod/translations/shavit-zones.phrases.txt
@@ -214,4 +214,15 @@
 	{
 		"en"		"Refresh menu"
 	}
+	// ---------- Messages ---------- //
+	"ZoneSlayEnter"
+	{
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"{1}You have been slain for entering a {2}glitch zone{3}."
+	}
+	"ZoneStopEnter"
+	{
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"{1}Your timer has been stopped for entering a {2}glitch zone{3}."
+	}
 }


### PR DESCRIPTION
This pull request doesn't enable rankings-chat interoperability yet. I got distracted with other issues and there aren't many left to fix before everything is done, so expect TF2, chat and the triggers issue to be all be solved very soon!

Other changes:

* Allowed all movements on ladders, even if outside of a freestyle zone.
* Fixed !rr/!stats WR count/ownership issues.
* Fixed !rr menu breaking with nonstandard characters in names.
* Implemented new replay bot format and included backwards compatibility.
* Polished replay bot HUD.
* Fix HSW breaking for some players (thanks DoNotMiss).
* Default convar usage changes, see below: (copied from the commit's description)
* Fixed wall snapping not respecting grid snap. It should be cleaner now.
* Added zone track enforcing (`shavit_zones_enforcetracks`), so zone track will be respected for all zone types instead of just start/end!
* Added dynamic zone settings. Check the commit's (2f8be00) message for information.

> `shavit_misc_prespeedlimit`'s behavior was changed and is now `shavit_misc_prestrafelimit`. The value determines the maximum allowed prestrafe in the start zone *added* to the style's run speed. So i.e., Scroll can prestrafe up to 280 (in reality, 278) and Normal can up to 290.
> 
> The default settings for `shavit_core_blockprejump` and `shavit_misc_prespeed` were changed due to this commit.
> `shavit_misc_createspawnpoints`'s default setting was changed to 6 as 32 didn't make much sense.