### PR TITLE
Critical update

### DIFF
--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2591,7 +2591,7 @@ public void UsePost(int entity, int activator, int caller, UseType type, float v
 		Shavit_StartTimer(activator, track);
 	}
 
-	if(zone == Zone_End)
+	if(zone == Zone_End && Shavit_GetTimerStatus(activator) == Timer_Running && Shavit_GetClientTrack(activator) == track)
 	{
 		Shavit_FinishMap(activator, track);
 	}


### PR DESCRIPTION
* Fixes exploit with buttons in KZ maps.
* Fixes setups similar to [badges' "unbreakable boosts"](https://gamebanana.com/prefabs/4934) breaking in CS:GO. [@GeorgeRiley's prefab](https://gamebanana.com/prefabs/6677) should be unaffected by this glitch. This glitch also affected just about every booster in Serz's maps, including _bhop_cutekittenz_, _bhop_idiosyncrasy_ and _bhop_flocci_.