### PR TITLE
Additions and fixes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,6 +17,8 @@ Zones are trigger based and are very lightweight.
 
 The zones plugin includes some less common features such as: Multiple tracks (main/bonus), zone editing (after setup), snapping zones to walls/corners/grid, zone setup using the cursor's position, configurable sprite/colors for zone types, zone tracks (main/bonus - can be extended), manual adjustments of coordinates before confirmations, teleport zones, glitch zones, no-limit zones (for styles like 400-velocity), flat/3D boxes for zone rendering, an API and more.
 
+It also contains support for built-in map timers (KZ) and the [Fly](https://github.com/3331/fly) zoning standard.
+
 #### shavit-chat
 The chat plugin manipulates chat messages sent by players.  
 It includes custom chat names, tags, colors and all can be defined by the players/admins.  

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -459,7 +459,7 @@ forward void Shavit_OnChatConfigLoaded();
  * @param client					Client index.
  * @param type						Zone type.
  * @param track						Zone track.
- * @param id						Zone ID.
+ * @param id						Zone ID. 0 for native zones.
  * @param entity					Zone entity iD.
  * @noreturn
  */
@@ -471,7 +471,7 @@ forward void Shavit_OnEnterZone(int client, int type, int track, int id, int ent
  * @param client					Client index.
  * @param type						Zone type.
  * @param track						Zone track.
- * @param id						Zone ID.
+ * @param id						Zone ID. 0 for native zones.
  * @param entity					Zone entity iD.
  * @noreturn
  */
@@ -1027,7 +1027,7 @@ native int Shavit_ReloadReplays(bool restart);
 native void Shavit_StopChatSound();
 
 /**
- * Marks a map as a KZ map.
+ * Marks a map as if it has built-in zones/buttons.
  *
  * @noreturn
  */
@@ -1035,6 +1035,8 @@ native void Shavit_MarkKZMap();
 
 /**
  * Lets us know if the map was marked as a KZ map.
+ * KZ map: a map with built-in zones/buttons.
+ * Does not necessarily mean that the map was designed for KZ gameplay.
  *
  * @return							Boolean value.
  */

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1249,7 +1249,7 @@ void StartTimer(int client, int track)
 	float fSpeed[3];
 	GetEntPropVector(client, Prop_Data, "m_vecVelocity", fSpeed);
 
-	if(!gB_NoZAxisSpeed || gA_StyleSettings[gBS_Style[client]][bPrespeed] || (fSpeed[2] == 0.0 && SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0)) <= 280.0))
+	if(!gB_NoZAxisSpeed || gA_StyleSettings[gBS_Style[client]][bPrespeed] || (fSpeed[2] == 0.0 && SquareRoot(Pow(fSpeed[0], 2.0) + Pow(fSpeed[1], 2.0)) <= 290.0))
 	{
 		gI_Strafes[client] = 0;
 		gI_Jumps[client] = 0;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -156,7 +156,6 @@ float gF_AdvertisementInterval = 600.0;
 bool gB_Checkpoints = true;
 int gI_RemoveRagdolls = 1;
 char gS_ClanTag[32] = "{styletag} :: {time}";
-bool gB_ClanTag = true;
 bool gB_DropAll = true;
 bool gB_ResetTargetname = false;
 bool gB_RestoreStates = false;
@@ -487,8 +486,6 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_DropAll = gCV_DropAll.BoolValue;
 	gB_ResetTargetname = gCV_ResetTargetname.BoolValue;
 	gB_RestoreStates = gCV_RestoreStates.BoolValue;
-
-	gB_ClanTag = !StrEqual(gS_ClanTag, "0");
 }
 
 public void OnConfigsExecuted()
@@ -737,10 +734,7 @@ public Action Timer_Scoreboard(Handle Timer)
 			UpdateScoreboard(i);
 		}
 
-		if(gB_ClanTag)
-		{
-			UpdateClanTag(i);
-		}
+		UpdateClanTag(i);
 	}
 
 	return Plugin_Continue;
@@ -830,7 +824,7 @@ void UpdateScoreboard(int client)
 void UpdateClanTag(int client)
 {
 	// no clan tags in tf2
-	if(gEV_Type == Engine_TF2)
+	if(gEV_Type == Engine_TF2 || StrEqual(gS_ClanTag, "0"))
 	{
 		return;
 	}
@@ -2043,10 +2037,7 @@ public void Player_Spawn(Event event, const char[] name, bool dontBroadcast)
 			UpdateScoreboard(client);
 		}
 
-		if(gB_ClanTag)
-		{
-			UpdateClanTag(client);
-		}
+		UpdateClanTag(client);
 	}
 
 	if(gB_NoBlock)

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -130,6 +130,7 @@ ConVar gCV_ClanTag = null;
 ConVar gCV_DropAll = null;
 ConVar gCV_ResetTargetname = null;
 ConVar gCV_RestoreStates = null;
+ConVar gCV_JointeamHook = null;
 
 // cached cvars
 int gI_GodMode = 3;
@@ -159,6 +160,7 @@ char gS_ClanTag[32] = "{styletag} :: {time}";
 bool gB_DropAll = true;
 bool gB_ResetTargetname = false;
 bool gB_RestoreStates = false;
+bool gB_JointeamHook = true;
 
 // dhooks
 Handle gH_GetPlayerMaxSpeed = null;
@@ -303,6 +305,7 @@ public void OnPluginStart()
 	gCV_DropAll = CreateConVar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_ResetTargetname = CreateConVar("shavit_misc_resettargetname", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RestoreStates = CreateConVar("shavit_misc_restorestates", "0", "Save the players' timer/position etc.. when they die/change teams,\nand load the data when they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_JointeamHook = CreateConVar("shavit_misc_jointeamhook", "1", "Hook `jointeam`?\n0 - Disabled\n1 - Enabled, players can instantly change teams.", 0, true, 0.0, true, 1.0);
 
 	gCV_GodMode.AddChangeHook(OnConVarChanged);
 	gCV_PreSpeed.AddChangeHook(OnConVarChanged);
@@ -331,6 +334,7 @@ public void OnPluginStart()
 	gCV_DropAll.AddChangeHook(OnConVarChanged);
 	gCV_ResetTargetname.AddChangeHook(OnConVarChanged);
 	gCV_RestoreStates.AddChangeHook(OnConVarChanged);
+	gCV_JointeamHook.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 
@@ -486,6 +490,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_DropAll = gCV_DropAll.BoolValue;
 	gB_ResetTargetname = gCV_ResetTargetname.BoolValue;
 	gB_RestoreStates = gCV_RestoreStates.BoolValue;
+	gB_JointeamHook = gCV_JointeamHook.BoolValue;
 }
 
 public void OnConfigsExecuted()
@@ -610,7 +615,7 @@ public void OnLibraryRemoved(const char[] name)
 
 public Action Command_Jointeam(int client, const char[] command, int args)
 {
-	if(!IsValidClient(client))
+	if(!IsValidClient(client) || !gB_JointeamHook)
 	{
 		return Plugin_Continue;
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1231,14 +1231,21 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 		return;
 	}
 
+	if(!gB_Enabled || (gF_TimeLimit > 0.0 && time > gF_TimeLimit))
+	{
+		ClearFrames(client);
+
+		return;
+	}
+
 	gB_Record[client] = false;
 
-	float fWR = 0.0;
-	Shavit_GetWRTime(style, fWR, track);
+	bool newformat = view_as<bool>(gA_FrameCache[style][track][2]);
+	float length = GetReplayLength(style, track);
 
-	if(!view_as<bool>(gA_FrameCache[style][track][2]))
+	if(newformat)
 	{
-		if(view_as<int>(gA_FrameCache[style][track][0]) != 0 && gI_PlayerFrames[client] > gA_FrameCache[style][track][0])
+		if(length > 0.0 && time > length)
 		{
 			return;
 		}
@@ -1246,9 +1253,10 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	else
 	{
-		float fReplayTime = view_as<float>(gA_FrameCache[style][track][1]);
+		float wrtime = 0.0;
+		Shavit_GetWRTime(style, wrtime, track);
 
-		if(fReplayTime != 0.0 && time >= fReplayTime)
+		if(wrtime != 0.0 && time > wrtime)
 		{
 			return;
 		}
@@ -1256,13 +1264,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	if(gI_PlayerFrames[client] == 0)
 	{
-		return;
-	}
-
-	if(!gB_Enabled || (gF_TimeLimit > 0.0 && time > gF_TimeLimit))
-	{
-		ClearFrames(client);
-
 		return;
 	}
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1236,9 +1236,9 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 	float fWR = 0.0;
 	Shavit_GetWRTime(style, fWR, track);
 
-	if(!view_as<bool>(gA_FrameCache[style][track][2]) && view_as<int>(gA_FrameCache[style][track][0] != 0))
+	if(!view_as<bool>(gA_FrameCache[style][track][2]))
 	{
-		if(time >= fWR)
+		if(view_as<int>(gA_FrameCache[style][track][0]) != 0 && gI_PlayerFrames[client] > gA_FrameCache[style][track][0])
 		{
 			return;
 		}

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2003,6 +2003,22 @@ public Action Timer_Draw(Handle Timer, any data)
 
 		TE_SetupBeamPoints(vPlayerOrigin, origin, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 230}, 0);
 		TE_SendToAll(0.0);
+
+		// visualize grid snap
+		float snap1[3];
+		float snap2[3];
+
+		for(int i = 0; i < 3; i++)
+		{
+			snap1 = origin;
+			snap1[i] -= (gI_GridSnap[client] / 2);
+
+			snap2 = origin;
+			snap2[i] += (gI_GridSnap[client] / 2);
+
+			TE_SetupBeamPoints(snap1, snap2, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 230}, 0);
+			TE_SendToAll(0.0);
+		}
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -1426,6 +1426,22 @@ public int ZoneCreation_Handler(Menu menu, MenuAction action, int param1, int pa
 	return 0;
 }
 
+float[] SnapToGrid(float pos[3], int grid, bool third)
+{
+	float origin[3];
+	origin = pos;
+
+	origin[0] = float(RoundToNearest(pos[0] / grid) * grid);
+	origin[1] = float(RoundToNearest(pos[1] / grid) * grid);
+	
+	if(third)
+	{
+		origin[2] = float(RoundToNearest(pos[2] / grid) * grid);
+	}
+
+	return origin;
+}
+
 bool SnapToWall(float pos[3], int client, float final[3])
 {
 	bool hit = false;
@@ -1455,10 +1471,7 @@ bool SnapToWall(float pos[3], int client, float final[3])
 
 	if(hit && GetVectorDistance(prefinal, pos) <= gI_GridSnap[client])
 	{
-		prefinal[0] = float(RoundToNearest(prefinal[0] / gI_GridSnap[client]) * gI_GridSnap[client]);
-		prefinal[1] = float(RoundToNearest(prefinal[1] / gI_GridSnap[client]) * gI_GridSnap[client]);
-
-		final = prefinal;
+		final = SnapToGrid(prefinal, gI_GridSnap[client], false);
 
 		return true;
 	}
@@ -1486,14 +1499,7 @@ float[] GetAimPosition(int client)
 		float end[3];
 		TR_GetEndPosition(end);
 
-		float final[3];
-		final = end;
-		
-		final[0] = float(RoundToNearest(end[0] / gI_GridSnap[client]) * gI_GridSnap[client]);
-		final[1] = float(RoundToNearest(end[1] / gI_GridSnap[client]) * gI_GridSnap[client]);
-		final[2] = float(RoundToNearest(end[2] / gI_GridSnap[client]) * gI_GridSnap[client]);
-
-		return final;
+		return SnapToGrid(end, gI_GridSnap[client], true);
 	}
 
 	return pos;
@@ -1526,8 +1532,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 				else if(!(gB_SnapToWall[client] && SnapToWall(vPlayerOrigin, client, origin)))
 				{
-					origin[0] = float(RoundToNearest(vPlayerOrigin[0] / gI_GridSnap[client]) * gI_GridSnap[client]);
-					origin[1] = float(RoundToNearest(vPlayerOrigin[1] / gI_GridSnap[client]) * gI_GridSnap[client]);
+					origin = SnapToGrid(vPlayerOrigin, gI_GridSnap[client], false);
 				}
 
 				else
@@ -1956,8 +1961,7 @@ public Action Timer_Draw(Handle Timer, any data)
 
 	else if(!(gB_SnapToWall[client] && SnapToWall(vPlayerOrigin, client, origin)))
 	{
-		origin[0] = float(RoundToNearest(vPlayerOrigin[0] / gI_GridSnap[client]) * gI_GridSnap[client]);
-		origin[1] = float(RoundToNearest(vPlayerOrigin[1] / gI_GridSnap[client]) * gI_GridSnap[client]);
+		origin = SnapToGrid(vPlayerOrigin, gI_GridSnap[client], false);
 	}
 
 	else

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -572,16 +572,14 @@ public void OnMapEnd()
 
 public void OnEntityCreated(int entity, const char[] classname)
 {
-	int ref = EntIndexToEntRef(entity);
-
 	if(StrEqual(classname, "func_button", false))
 	{
-		RequestFrame(Frame_HookButton, ref);
+		RequestFrame(Frame_HookButton, EntIndexToEntRef(entity));
 	}
 
 	else if(StrEqual(classname, "trigger_multiple", false))
 	{
-		RequestFrame(Frame_HookTrigger, ref);
+		RequestFrame(Frame_HookTrigger, EntIndexToEntRef(entity));
 	}
 }
 


### PR DESCRIPTION
* Fixed replay saving (for the most part) - if you happen to see an issue with them again, let me know. I can't guarantee this fix will 100% work for old-format replays, so excuse me if it doesn't.
* Fixed clan tag handling. When disabling the feature, you won't see players with "0" in their clan tag.
* Adjusted hardcoded prestrafe cap from 280 to 290, because standards.
* Made grid snap visualize some of the grid itself too.
* Added support for the [Fly gamemode's zoning standard](https://github.com/3331/fly/blob/master/README.md). If the map has built-in zones, you don't need to do it yourself.
* Added `shavit_misc_jointeamhook` to toggle team hooking. Disable this for servers with rounds.