### PR TITLE
Some updates after a while with none

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-# i have no idea AT ALL on how to use travis,
-# stolen from splewis: https://raw.githubusercontent.com/splewis/csgo-pug-setup/master/.travis.yml
-# i'll fail anyways, right? :(
 sudo: false
 
 addons:
@@ -8,7 +5,7 @@ addons:
         - lib32stdc++6  # needed for spcomp
 
 env:
-    - SMVERSION=1.8
+    - SMVERSION=1.9
 
 before_script:
     # install smbuilder
@@ -26,7 +23,6 @@ before_script:
     - chmod +x spcomp
     - PATH+=":$PWD"
 
-    # - cp ../../../scripting/include/* include/ # i don't think this is necessary anymore
     - cd ../../..
 
 script:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Including a records system, map zones (start/end marks etc), bonuses, HUD with u
 
 # Requirements:
 * Steam version of Counter-Strike: Source or Counter-Strike: Global Offensive.
-* [SourceMod 1.8 or above](http://www.sourcemod.net/downloads.php)
+* [SourceMod 1.9 or above](http://www.sourcemod.net/downloads.php)
 
 # Optional requirements:
-* [DHooks](http://users.alliedmods.net/~drifter/builds/dhooks/2.0/) - required for 250/260 runspeed for all weapons.
+* [DHooks](http://users.alliedmods.net/~drifter/builds/dhooks/2.1/) - required for 250/260 runspeed for all weapons.
 * [Bunnyhop Statistics](https://forums.alliedmods.net/showthread.php?t=286135) - to show amount of scrolls for non-auto styles in the key display. Required for TF2 servers.
 * [SteamWorks](https://forums.alliedmods.net/showthread.php?t=229556) - for the `{serverip}` advertisement variable.
 * [Chat-Processor](https://github.com/Drixevel/Chat-Processor) - if you're enabling the `shavit-chat` module.

--- a/addons/sourcemod/configs/shavit-replay.cfg
+++ b/addons/sourcemod/configs/shavit-replay.cfg
@@ -30,4 +30,12 @@
 	"centralstyle" "!replay"
 	"centralstyletag" "!replay"
 	"unloaded" "{style} - N/A"
+
+	// Replay data folder. This is where replays are loaded from and saved to.
+	// Note: To use a path outside of the game directory, you will have to get out of it with "../".
+	// Edit at your own risk.
+	//
+	// Variables:
+	// {SM} - SourceMod folder. If this variable isn't included, you will have to specify the full path.
+	"replayfolder" "{SM}/data/replaybot"
 }

--- a/addons/sourcemod/configs/shavit-styles.cfg
+++ b/addons/sourcemod/configs/shavit-styles.cfg
@@ -40,7 +40,7 @@
 		"force_hsw"			"0" // Force half-sideways gameplay. 1 for regular HSW and 2 for surf-HSW.
 		"block_pleft"		"0" // Block +left (requires shavit_core_blockleftright 1).
 		"block_pright"		"0" // Block +right (requires shavit_core_blockleftright 1).
-		"block_pstrafe"		"0" // Stops timer on +strafe usage. May have false positives when players lag. Will prvent some strafe hacks too.
+		"block_pstrafe"		"0" // Prevent button inconsistencies (including +pstrafe). May have false positives when players lag. Will prevent some strafe hacks too. Set this to 2 to also stop the timer.
 
 		// Feature excluding
 		"unranked"			"0" // Unranked style. No ranking points and no records.

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -44,7 +44,7 @@
 
 // for reference, not used anymore
 // game types
-enum ServerGame(+=1)
+enum ServerGame
 {
 	Game_CSS = 0,
 	Game_CSGO,
@@ -52,19 +52,25 @@ enum ServerGame(+=1)
 };
 
 // status
-enum TimerStatus(+=1)
+enum TimerStatus
 {
 	Timer_Stopped = 0,
 	Timer_Running,
 	Timer_Paused
 };
 
-enum ReplayStatus(+=1)
+enum ReplayStatus
 {
 	Replay_Start = 0,
 	Replay_Running,
 	Replay_End,
 	Replay_Idle
+};
+
+enum ReplayBotType
+{
+	Replay_Central = 0,
+	Replay_Legacy
 };
 
 enum
@@ -787,6 +793,13 @@ native int Shavit_GetReplayBotStyle(int client);
 native int Shavit_GetReplayBotTrack(int client);
 
 /**
+ * Gets the replay bot type setting of the server.
+ *
+ * @return							See ReplayBotType enum.
+ */
+native ReplayBotType Shavit_GetReplayBotType();
+
+/**
  * Retrieve the replay bot's current played frame.
  *
  * @param style						Style.
@@ -1125,6 +1138,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetReplayBotIndex");
 	MarkNativeAsOptional("Shavit_GetReplayBotStyle");
 	MarkNativeAsOptional("Shavit_GetReplayBotTrack");
+	MarkNativeAsOptional("Shavit_GetReplayBotType");
 	MarkNativeAsOptional("Shavit_GetReplayData");
 	MarkNativeAsOptional("Shavit_GetReplayFrameCount");
 	MarkNativeAsOptional("Shavit_GetReplayLength");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -107,7 +107,7 @@ enum
 	iForceHSW,
 	bBlockPLeft,
 	bBlockPRight,
-	bBlockPStrafe,
+	iBlockPStrafe,
 	bUnranked,
 	bNoReplay,
 	bSync,

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -134,10 +134,7 @@ enum
 enum
 {
 	bTimerEnabled,
-	fStartTime,
 	fCurrentTime,
-	fPauseStartTime,
-	fPauseTotalTime,
 	bClientPaused,
 	iJumps,
 	bsStyle,
@@ -303,6 +300,32 @@ stock void FormatSeconds(float time, char[] newtime, int newtimesize, bool preci
  * @return							Plugin_Continue to let shavit-core keep doing what it does, Plugin_Changed to pass different values.
  */
 forward Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE]);
+
+/**
+ * Called just before shavit-core adds time to a player's timer.
+ * This is the forward you should use to modify the player's timer smoothly.
+ * A good example use case is timescaling.
+ *
+ * @param client					Client index.
+ * @param snapshot					A snapshot with the player's current timer. You cannot manipulate it here.
+ * @param time						The time to be added to the player's timer.
+ * @param stylesettings				An array that contains the player's bhop style's settings.
+ * @noreturn
+ */
+forward void Shavit_OnTimeIncrement(int client, any snapshot[TIMERSNAPSHOT_SIZE], float &time, any stylesettings[STYLESETTINGS_SIZE]);
+
+/**
+ * Called just before shavit-core adds time to a player's timer.
+ * This is the forward you should use to modify the player's timer smoothly.
+ * A good example use case is timescaling.
+ *
+ * @param client					Client index.
+ * @param snapshot					A snapshot with the player's current timer. Read above in shavit.inc for more information.
+ * @param time						The time to be added to the player's timer.
+ * @param stylesettings				An array that contains the player's bhop style's settings.
+ * @noreturn
+ */
+forward void Shavit_OnTimeIncrementPost(int client, float time, any stylesettings[STYLESETTINGS_SIZE]);
 
 /**
  * Called when a player's timer starts.

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -360,9 +360,10 @@ forward Action Shavit_OnFinishPre(int client, any snapshot[TIMERSNAPSHOT_SIZE]);
  * @param strafes					Amount of strafes.
  * @param sync						Sync percentage (0.0 to 100.0) or -1.0 when not measured.
  * @param track						Timer track.
+ * @param oldtime					The player's best time on the map before this finish.
  * @noreturn
  */
-forward void Shavit_OnFinish(int client, int style, float time, int jumps, int strafes, float sync, int track);
+forward void Shavit_OnFinish(int client, int style, float time, int jumps, int strafes, float sync, int track, float oldtime);
 
 /**
  * Like Shavit_OnFinish, but after the insertion query was called.

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -297,9 +297,10 @@ stock void FormatSeconds(float time, char[] newtime, int newtimesize, bool preci
  * @param track						The player's timer track.
  * @param style						The player's bhop style.
  * @param stylesettings				An array that contains the player's bhop style's settings.
+ * @param mouse						Mouse direction (x, y).
  * @return							Plugin_Continue to let shavit-core keep doing what it does, Plugin_Changed to pass different values.
  */
-forward Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE]);
+forward Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float vel[3], float angles[3], TimerStatus status, int track, int style, any stylesettings[STYLESETTINGS_SIZE], int mouse[2]);
 
 /**
  * Called just before shavit-core adds time to a player's timer.

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -363,6 +363,7 @@ public Action CP_OnChatMessage(int &author, ArrayList recipients, char[] flagstr
 		// proper colors with rtler
 		if(gB_RTLer && RTLify(sTemp, MAXLENGTH_MESSAGE, message) > 0)
 		{
+			TrimString(message);
 			Format(message, MAXLENGTH_MESSAGE, "%s%s", message, gS_CustomMessage[author]);
 		}
 

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1460,7 +1460,7 @@ bool LoadStyles()
 		gA_StyleSettings[i][iForceHSW] = kv.GetNum("force_hsw", 0);
 		gA_StyleSettings[i][bBlockPLeft] = view_as<bool>(kv.GetNum("block_pleft", 0));
 		gA_StyleSettings[i][bBlockPRight] = view_as<bool>(kv.GetNum("block_pright", 0));
-		gA_StyleSettings[i][bBlockPStrafe] = view_as<bool>(kv.GetNum("block_pstrafe", 0));
+		gA_StyleSettings[i][iBlockPStrafe] = kv.GetNum("block_pstrafe", 0);
 		gA_StyleSettings[i][bUnranked] = view_as<bool>(kv.GetNum("unranked", 0));
 		gA_StyleSettings[i][bNoReplay] = view_as<bool>(kv.GetNum("noreplay", 0));
 		gA_StyleSettings[i][bSync] = view_as<bool>(kv.GetNum("sync", 1));
@@ -1869,19 +1869,25 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		}
 
 		// +strafe block
-		if(gA_StyleSettings[gBS_Style[client]][bBlockPStrafe] &&
+		if(gA_StyleSettings[gBS_Style[client]][iBlockPStrafe] > 0 &&
 			((vel[0] > 0.0 && (buttons & IN_FORWARD) == 0) || (vel[0] < 0.0 && (buttons & IN_BACK) == 0) ||
 			(vel[1] > 0.0 && (buttons & IN_MOVERIGHT) == 0) || (vel[1] < 0.0 && (buttons & IN_MOVELEFT) == 0)))
 		{
-			float fTime = GetEngineTime();
-
-			if(gF_StrafeWarning[client] < fTime)
+			if(gF_StrafeWarning[client] < gF_PlayerTimer[client])
 			{
-				FormatEx(sCheatDetected, 64, "%T", "Inconsistencies", client);
-				StopTimer_Cheat(client, sCheatDetected);
+				if(gA_StyleSettings[gBS_Style[client]][iBlockPStrafe] >= 2)
+				{
+					FormatEx(sCheatDetected, 64, "%T", "Inconsistencies", client);
+					StopTimer_Cheat(client, sCheatDetected);
+				}
+
+				vel[0] = 0.0;
+				vel[1] = 0.0;
+
+				return Plugin_Changed;
 			}
 
-			gF_StrafeWarning[client] = fTime + 0.20;
+			gF_StrafeWarning[client] = gF_PlayerTimer[client] + 0.3;
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -760,7 +760,7 @@ void ChangeClientStyle(int client, int style, bool manual)
 
 	StopTimer(client);
 
-	if(gB_AllowTimerWithoutZone || (gB_Zones && Shavit_ZoneExists(Zone_Start, Track_Main)))
+	if(gB_AllowTimerWithoutZone || (gB_Zones && (Shavit_ZoneExists(Zone_Start, gI_Track[client]) || gB_KZMap)))
 	{
 		Call_StartForward(gH_Forwards_OnRestart);
 		Call_PushCell(client);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -561,13 +561,6 @@ public Action Command_TogglePause(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(gB_PracticeMode[client])
-	{
-		Shavit_PrintToChat(client, "%T", "PausePractice", client, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
-
-		return Plugin_Handled;
-	}
-
 	if(gB_ClientPaused[client])
 	{
 		TeleportEntity(client, gF_PausePosition[client][0], gF_PausePosition[client][1], gF_PausePosition[client][2]);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -193,7 +193,7 @@ public void OnPluginStart()
 	gH_Forwards_Start = CreateGlobalForward("Shavit_OnStart", ET_Event, Param_Cell, Param_Cell);
 	gH_Forwards_Stop = CreateGlobalForward("Shavit_OnStop", ET_Event, Param_Cell, Param_Cell);
 	gH_Forwards_FinishPre = CreateGlobalForward("Shavit_OnFinishPre", ET_Event, Param_Cell, Param_Array);
-	gH_Forwards_Finish = CreateGlobalForward("Shavit_OnFinish", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
+	gH_Forwards_Finish = CreateGlobalForward("Shavit_OnFinish", ET_Event, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	gH_Forwards_OnRestart = CreateGlobalForward("Shavit_OnRestart", ET_Event, Param_Cell, Param_Cell);
 	gH_Forwards_OnEnd = CreateGlobalForward("Shavit_OnEnd", ET_Event, Param_Cell, Param_Cell);
 	gH_Forwards_OnPause = CreateGlobalForward("Shavit_OnPause", ET_Event, Param_Cell, Param_Cell);
@@ -1035,25 +1035,37 @@ public int Native_FinishMap(Handle handler, int numParams)
 	Call_StartForward(gH_Forwards_Finish);
 	Call_PushCell(client);
 
+	int style = 0;
+	int track = Track_Main;
+
 	if(result == Plugin_Continue)
 	{
-		Call_PushCell(gBS_Style[client]);
+		Call_PushCell(style = gBS_Style[client]);
 		Call_PushCell(CalculateTime(client));
 		Call_PushCell(gI_Jumps[client]);
 		Call_PushCell(gI_Strafes[client]);
 		Call_PushCell((gA_StyleSettings[gBS_Style[client]][bSync])? (gI_GoodGains[client] == 0)? 0.0:(gI_GoodGains[client] / float(gI_TotalMeasures[client]) * 100.0):-1.0);
+		Call_PushCell(track = gI_Track[client]);
 	}
 
 	else
 	{
-		Call_PushCell(snapshot[bsStyle]);
+		Call_PushCell(style = snapshot[bsStyle]);
 		Call_PushCell(snapshot[fCurrentTime]);
 		Call_PushCell(snapshot[iJumps]);
 		Call_PushCell(snapshot[iStrafes]);
 		Call_PushCell((gA_StyleSettings[snapshot[bsStyle]][bSync])? (snapshot[iGoodGains] == 0)? 0.0:(snapshot[iGoodGains] / float(snapshot[iTotalMeasures]) * 100.0):-1.0);
+		Call_PushCell(track = snapshot[iTimerTrack]);
 	}
 
-	Call_PushCell(gI_Track[client]);
+	float oldtime = 0.0;
+
+	if(gB_WR)
+	{
+		Shavit_GetPlayerPB(client, style, oldtime, track);
+	}
+
+	Call_PushCell(oldtime);
 	Call_Finish();
 
 	StopTimer(client);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1180,6 +1180,7 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	gI_Strafes[client] = view_as<int>(snapshot[iStrafes]);
 	gI_TotalMeasures[client] = view_as<int>(snapshot[iTotalMeasures]);
 	gI_GoodGains[client] = view_as<int>(snapshot[iGoodGains]);
+	gF_PlayerTimer[client] = snapshot[fCurrentTime];
 	gI_SHSW_FirstCombination[client] = view_as<int>(snapshot[iSHSWCombination]);
 }
 
@@ -1232,6 +1233,7 @@ void StartTimer(int client, int track)
 			gB_TimerEnabled[client] = true;
 			gI_SHSW_FirstCombination[client] = -1;
 			gF_PlayerTimer[client] = 0.0;
+			gB_PracticeMode[client] = false;
 
 			SetEntityGravity(client, view_as<float>(gA_StyleSettings[gBS_Style[client]][fGravityMultiplier]));
 			SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_StyleSettings[gBS_Style[client]][fSpeedMultiplier]));

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -203,7 +203,7 @@ public void OnPluginStart()
 	gH_Forwards_OnStyleConfigLoaded = CreateGlobalForward("Shavit_OnStyleConfigLoaded", ET_Event, Param_Cell);
 	gH_Forwards_OnDatabaseLoaded = CreateGlobalForward("Shavit_OnDatabaseLoaded", ET_Event);
 	gH_Forwards_OnChatConfigLoaded = CreateGlobalForward("Shavit_OnChatConfigLoaded", ET_Event);
-	gH_Forwards_OnUserCmdPre = CreateGlobalForward("Shavit_OnUserCmdPre", ET_Event, Param_Cell, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell, Param_Cell, Param_Cell, Param_Array);
+	gH_Forwards_OnUserCmdPre = CreateGlobalForward("Shavit_OnUserCmdPre", ET_Event, Param_Cell, Param_CellByRef, Param_CellByRef, Param_Array, Param_Array, Param_Cell, Param_Cell, Param_Cell, Param_Array, Param_Array);
 	gH_Forwards_OnTimerIncrement = CreateGlobalForward("Shavit_OnTimeIncrement", ET_Event, Param_Cell, Param_Array, Param_CellByRef, Param_Array);
 	gH_Forwards_OnTimerIncrementPost = CreateGlobalForward("Shavit_OnTimeIncrementPost", ET_Event, Param_Cell, Param_Cell, Param_Array);
 
@@ -1814,7 +1814,7 @@ public void OnGameFrame()
 	}
 }
 
-public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3])
+public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
 	if(!IsPlayerAlive(client) || IsFakeClient(client))
 	{
@@ -1846,6 +1846,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	Call_PushCell(gI_Track[client]);
 	Call_PushCell(gBS_Style[client]);
 	Call_PushArray(gA_StyleSettings[gBS_Style[client]], STYLESETTINGS_SIZE);
+	Call_PushArrayEx(mouse, 2, SM_PARAM_COPYBACK);
 	Call_Finish(result);
 	
 	if(result != Plugin_Continue && result != Plugin_Changed)

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -679,7 +679,6 @@ void UpdateHUD(int client)
 	{
 		int track = Shavit_GetClientTrack(target);
 		char[] sTrack = new char[32];
-		GetTrackName(client, track, sTrack, 32);
 
 		if(!IsFakeClient(target))
 		{
@@ -731,6 +730,7 @@ void UpdateHUD(int client)
 
 					if(track != Track_Main)
 					{
+						GetTrackName(client, track, sTrack, 32);
 						Format(sHintText, 512, "%s[<font color='#FFFFFF'>%s</font>] ", sHintText, sTrack);
 					}
 
@@ -834,12 +834,13 @@ void UpdateHUD(int client)
 
 			if(track != Track_Main)
 			{
+				GetTrackName(client, track, sTrack, 32);
 				Format(sTrack, 32, "(%s) ", sTrack);
 			}
 
 			if(gEV_Type == Engine_CSGO)
 			{
-				FormatEx(sHintText, 512, "<font face='Stratum2'>");
+				FormatEx(sHintText, 512, "<font face=''>");
 				Format(sHintText, 512, "%s\t<u><font color='#%s'>%s %T</font></u>", sHintText, gS_StyleStrings[style][sHTMLColor], gS_StyleStrings[style][sStyleName], "ReplayText", client);
 				Format(sHintText, 512, "%s\n\t%T: <font color='#00FF00'>%s</font> / %s", sHintText, "HudTimeText", client, sReplayTime, sReplayLength);
 				Format(sHintText, 512, "%s\n\t%T: %d", sHintText, "HudSpeedText", client, iSpeed);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -67,7 +67,7 @@ ConVar gCV_TicksPerUpdate = null;
 
 // cached cvars
 int gI_GradientStepSize = 5;
-int gI_TicksPerUpdate = 20;
+int gI_TicksPerUpdate = 5;
 
 // timer settings
 char gS_StyleStrings[STYLE_LIMIT][STYLESTRINGS_SIZE][128];
@@ -132,7 +132,7 @@ public void OnPluginStart()
 
 	// plugin convars
 	gCV_GradientStepSize = CreateConVar("shavit_hud_gradientstepsize", "15", "How fast should the start/end HUD gradient be?\nThe number is the amount of color change per 0.1 seconds.\nThe higher the number the faster the gradient.", 0, true, 1.0, true, 255.0);
-	gCV_TicksPerUpdate = CreateConVar("shavit_hud_ticksperupdate", "20", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, (1.0 / GetTickInterval()));
+	gCV_TicksPerUpdate = CreateConVar("shavit_hud_ticksperupdate", "5", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, (1.0 / GetTickInterval()));
 
 	gCV_GradientStepSize.AddChangeHook(OnConVarChanged);
 	gCV_TicksPerUpdate.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -46,7 +46,6 @@ int gI_Cycle = 0;
 int gI_GradientColors[3];
 int gI_GradientDirection = -1;
 int gI_Styles = 0;
-int gI_Tickrate = 0;
 
 Handle gH_HUDCookie = null;
 int gI_HUDSettings[MAXPLAYERS+1];
@@ -104,7 +103,6 @@ public void OnPluginStart()
 
 	// game-specific
 	gEV_Type = GetEngineVersion();
-	gI_Tickrate = RoundToZero(1.0 / GetTickInterval());
 
 	if(IsSource2013(gEV_Type))
 	{
@@ -134,7 +132,7 @@ public void OnPluginStart()
 
 	// plugin convars
 	gCV_GradientStepSize = CreateConVar("shavit_hud_gradientstepsize", "15", "How fast should the start/end HUD gradient be?\nThe number is the amount of color change per 0.1 seconds.\nThe higher the number the faster the gradient.", 0, true, 1.0, true, 255.0);
-	gCV_TicksPerUpdate = CreateConVar("shavit_hud_ticksperupdate", "20", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, float(gI_Tickrate));
+	gCV_TicksPerUpdate = CreateConVar("shavit_hud_ticksperupdate", "20", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, (1.0 / GetTickInterval()));
 
 	gCV_GradientStepSize.AddChangeHook(OnConVarChanged);
 	gCV_TicksPerUpdate.AddChangeHook(OnConVarChanged);
@@ -483,7 +481,7 @@ public int MenuHandler_HUD(Menu menu, MenuAction action, int param1, int param2)
 
 public void OnGameFrame()
 {
-	if(GetGameTickCount() % (gI_Tickrate / gI_TicksPerUpdate) == 0)
+	if(GetGameTickCount() % gI_TicksPerUpdate == 0)
 	{
 		Cron();
 	}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1046,7 +1046,7 @@ void UpdateTopLeftHUD(int client, bool wait)
 				FormatEx(sTopLeft, 128, "WR: %s (%s)", sWRTime, sWRName);
 			}
 
-			SetHudTextParams(0.01, 0.01, 2.5, 255, 255, 255, 255);
+			SetHudTextParams(0.01, 0.01, 2.5, 255, 255, 255, 255, 0, 0.0, 0.0, 0.0);
 			ShowSyncHudText(client, gH_HUD, "%s", sTopLeft);
 		}
 	}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -772,22 +772,19 @@ void UpdateHUD(int client)
 			{
 				if(status != Timer_Stopped)
 				{
-					if(Shavit_GetTimerStatus(target) == Timer_Running)
+					char[] sFirstLine = new char[64];
+					strcopy(sFirstLine, 64, gS_StyleStrings[style][sStyleName]);
+
+					if(Shavit_IsPracticeMode(target))
 					{
-						char[] sFirstLine = new char[64];
-						strcopy(sFirstLine, 64, gS_StyleStrings[style][sStyleName]);
-
-						if(Shavit_IsPracticeMode(target))
-						{
-							Format(sFirstLine, 64, "%s %T", sFirstLine, "HudPracticeMode", client);
-						}
-
-						FormatEx(sHintText, 512, "%s\n%T: %s (%d)\n%T: %d\n%T: %d\n%T: %d%s", sFirstLine, "HudTimeText", client, sTime, rank, "HudJumpsText", client, jumps, "HudStrafeText", client, strafes, "HudSpeedText", client, iSpeed, (gA_StyleSettings[style][fVelocityLimit] > 0.0 && Shavit_InsideZone(target, Zone_NoVelLimit, -1))? "\nNo Speed Limit":"");
+						Format(sFirstLine, 64, "%s %T", sFirstLine, "HudPracticeMode", client);
 					}
 
-					else
+					FormatEx(sHintText, 512, "%s\n%T: %s (%d)\n%T: %d\n%T: %d\n%T: %d%s", sFirstLine, "HudTimeText", client, sTime, rank, "HudJumpsText", client, jumps, "HudStrafeText", client, strafes, "HudSpeedText", client, iSpeed, (gA_StyleSettings[style][fVelocityLimit] > 0.0 && Shavit_InsideZone(target, Zone_NoVelLimit, -1))? "\nNo Speed Limit":"");
+					
+					if(Shavit_GetTimerStatus(target) == Timer_Paused)
 					{
-						FormatEx(sHintText, 16, "%T", "HudPaused", client);
+						Format(sHintText, 512, "%s\n%T", sHintText, "HudPaused", client);
 					}
 
 					if(track != Track_Main)

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1022,20 +1022,20 @@ void UpdateTopLeftHUD(int client, bool wait)
 			char[] sPBTime = new char[16];
 			FormatSeconds(fPBTime, sPBTime, MAX_NAME_LENGTH);
 
-			char[] sTopLeft = new char[64];
+			char[] sTopLeft = new char[128];
 
 			if(fPBTime != 0.0)
 			{
-				FormatEx(sTopLeft, 64, "WR: %s (%s)\n%T: %s (#%d)", sWRTime, sWRName, "HudBestText", client, sPBTime, (Shavit_GetRankForTime(style, fPBTime, track) - 1));
+				FormatEx(sTopLeft, 128, "WR: %s (%s)\n%T: %s (#%d)", sWRTime, sWRName, "HudBestText", client, sPBTime, (Shavit_GetRankForTime(style, fPBTime, track) - 1));
 			}
 
 			else
 			{
-				FormatEx(sTopLeft, 64, "WR: %s (%s)", sWRTime, sWRName);
+				FormatEx(sTopLeft, 128, "WR: %s (%s)", sWRTime, sWRName);
 			}
 
 			SetHudTextParams(0.01, 0.01, 2.5, 255, 255, 255, 255);
-			ShowSyncHudText(client, gH_HUD, sTopLeft);
+			ShowSyncHudText(client, gH_HUD, "%s", sTopLeft);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -135,7 +135,7 @@ public void OnPluginStart()
 	AutoExecConfig();
 
 	// cron
-	CreateTimer(0.10, UpdateHUD_Timer, INVALID_HANDLE, TIMER_REPEAT);
+	CreateTimer(0.05, UpdateHUD_Timer, INVALID_HANDLE, TIMER_REPEAT);
 
 	// commands
 	RegConsoleCmd("sm_hud", Command_HUD, "Opens the HUD settings menu");
@@ -635,7 +635,7 @@ void UpdateHUD(int client)
 		{
 			if(gEV_Type == Engine_CSGO)
 			{
-				FormatEx(sHintText, 64, "<font size=\"38\" color=\"#%06X\">%T</font>\n\t%T: %d", ((gI_GradientColors[0] << 16) + (gI_GradientColors[1] << 8) + (gI_GradientColors[2])), "HudStartZone", client, "HudSpeedText", client, iSpeed);
+				FormatEx(sHintText, 128, "       <font size='34' color='#%06X'>%T</font>\n\t  %T: %d", ((gI_GradientColors[0] << 16) + (gI_GradientColors[1] << 8) + (gI_GradientColors[2])), "HudStartZone", client, "HudSpeedText", client, iSpeed);
 			}
 
 			else
@@ -649,7 +649,7 @@ void UpdateHUD(int client)
 		{
 			if(gEV_Type == Engine_CSGO)
 			{
-				FormatEx(sHintText, 64, "<font size=\"38\" color=\"#%06X\">%T</font>\n\t%T: %d", ((gI_GradientColors[0] << 16) + (gI_GradientColors[1] << 8) + (gI_GradientColors[2])), "HudEndZone", client, "HudSpeedText", client, iSpeed);
+				FormatEx(sHintText, 128, "       <font size='34' color='#%06X'>%T</font>\n\t  %T: %d", ((gI_GradientColors[0] << 16) + (gI_GradientColors[1] << 8) + (gI_GradientColors[2])), "HudEndZone", client, "HudSpeedText", client, iSpeed);
 			}
 
 			else
@@ -667,6 +667,8 @@ void UpdateHUD(int client)
 	else if((gI_HUDSettings[client] & HUD_CENTER) > 0)
 	{
 		int track = Shavit_GetClientTrack(target);
+		char[] sTrack = new char[32];
+		GetTrackName(client, track, sTrack, 32);
 
 		if(!IsFakeClient(target))
 		{
@@ -690,7 +692,7 @@ void UpdateHUD(int client)
 
 			if(gEV_Type == Engine_CSGO)
 			{
-				strcopy(sHintText, 512, "<font size=\"18\" face=\"Stratum2\">");
+				strcopy(sHintText, 512, "<font size='18' face=''>");
 
 				if(status >= Timer_Running)
 				{
@@ -698,7 +700,7 @@ void UpdateHUD(int client)
 
 					if(status == Timer_Paused)
 					{
-						strcopy(sColor, 8, "FF0000");
+						strcopy(sColor, 8, "A9C5E8");
 					}
 
 					else if(time < fWR || fWR == 0.0)
@@ -716,16 +718,15 @@ void UpdateHUD(int client)
 						strcopy(sColor, 8, "FF0000");
 					}
 
-					char[] sPauseItem = new char[64];
-					FormatEx(sPauseItem, 64, "%T\t</font>", "HudPaused", client);
+					if(track != Track_Main)
+					{
+						Format(sHintText, 512, "%s[<font color='#FFFFFF'>%s</font>] ", sHintText, sTrack);
+					}
 
-					char[] sUnpausedItem = new char[64];
-					FormatEx(sUnpausedItem, 64, "%s</font> (%d)\t", sTime, rank);
-					
-					Format(sHintText, 512, "%s%T: <font color='#%s'>%s", sHintText, "HudTimeText", client, sColor, (status == Timer_Paused)? sPauseItem:sUnpausedItem);
+					Format(sHintText, 512, "%s<font color='#%s'>%s</font> (%d)", sHintText, sColor, sTime, rank);
 				}
 
-				if(fPB > 0.0)
+				else if(fPB > 0.0)
 				{
 					Format(sHintText, 512, "%s%T: %s (#%d)", sHintText, "HudBestText", client, sPB, (Shavit_GetRankForTime(style, fPB, track) - 1));
 				}
@@ -754,8 +755,6 @@ void UpdateHUD(int client)
 						Format(sHintText, 512, "%s%s\t%T: %d", sHintText, (iSpeed < 1000)? "\t":"", "HudStrafeText", client, strafes);
 					}
 				}
-
-				Format(sHintText, 512, "%s</font>", sHintText);
 			}
 
 			else
@@ -782,9 +781,6 @@ void UpdateHUD(int client)
 
 					if(track != Track_Main)
 					{
-						char[] sTrack = new char[32];
-						GetTrackName(client, track, sTrack, 32);
-
 						Format(sHintText, 512, "%s\n%s", sHintText, sTrack);
 					}
 				}
@@ -825,11 +821,8 @@ void UpdateHUD(int client)
 			char[] sReplayLength = new char[32];
 			FormatSeconds(fReplayLength, sReplayLength, 32, false);
 
-			char[] sTrack = new char[32];
-
 			if(track != Track_Main)
 			{
-				GetTrackName(client, track, sTrack, 32);
 				Format(sTrack, 32, "(%s) ", sTrack);
 			}
 
@@ -839,7 +832,6 @@ void UpdateHUD(int client)
 				Format(sHintText, 512, "%s\t<u><font color='#%s'>%s %T</font></u>", sHintText, gS_StyleStrings[style][sHTMLColor], gS_StyleStrings[style][sStyleName], "ReplayText", client);
 				Format(sHintText, 512, "%s\n\t%T: <font color='#00FF00'>%s</font> / %s", sHintText, "HudTimeText", client, sReplayTime, sReplayLength);
 				Format(sHintText, 512, "%s\n\t%T: %d", sHintText, "HudSpeedText", client, iSpeed);
-				Format(sHintText, 512, "%s</font>", sHintText);
 			}
 
 			else

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -876,7 +876,20 @@ void UpdateKeyOverlay(int client, Panel panel, bool &draw)
 	int buttons = gI_Buttons[target];
 
 	char[] sPanelLine = new char[128];
-	FormatEx(sPanelLine, 128, "［%s］　［%s］\n　　 %s\n%s　 %s 　%s", 
+
+	int style = (IsFakeClient(target))? Shavit_GetReplayBotStyle(target):Shavit_GetBhopStyle(target);
+
+	if(style < 0 || style > gI_Styles)
+	{
+		style = 0;
+	}
+
+	if(gB_BhopStats && !gA_StyleSettings[style][bAutobhop])
+	{
+		FormatEx(sPanelLine, 64, " %d%s%d\n", gI_ScrollCount[target], (gI_ScrollCount[target] > 9)? "   ":"     ", gI_LastScrollCount[target]);
+	}
+
+	Format(sPanelLine, 128, "%s［%s］　［%s］\n　　 %s\n%s　 %s 　%s", sPanelLine,
 		(buttons & IN_JUMP) > 0? "Ｊ":"ｰ", (buttons & IN_DUCK) > 0? "Ｃ":"ｰ",
 		(buttons & IN_FORWARD) > 0? "Ｗ":"ｰ", (buttons & IN_MOVELEFT) > 0? "Ａ":"ｰ",
 		(buttons & IN_BACK) > 0? "Ｓ":"ｰ", (buttons & IN_MOVERIGHT) > 0? "Ｄ":"ｰ");

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1178,19 +1178,29 @@ public Action Command_Spec(int client, int args)
 
 	CleanSwitchTeam(client, 1, false);
 
+	int target = -1;
+
 	if(args > 0)
 	{
 		char[] sArgs = new char[MAX_TARGET_LENGTH];
 		GetCmdArgString(sArgs, MAX_TARGET_LENGTH);
 
-		int iTarget = FindTarget(client, sArgs, false, false);
+		target = FindTarget(client, sArgs, false, false);
 
-		if(iTarget == -1)
+		if(target == -1)
 		{
 			return Plugin_Handled;
 		}
+	}
 
-		SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", iTarget);
+	else if(gB_Replay)
+	{
+		target = Shavit_GetReplayBotIndex(0);
+	}
+
+	if(IsValidClient(target, true))
+	{
+		SetEntPropEnt(client, Prop_Send, "m_hObserverTarget", target);
 	}
 
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -515,17 +515,15 @@ public void OnMapStart()
 	GetCurrentMap(gS_CurrentMap, 192);
 	GetMapDisplayName(gS_CurrentMap, gS_CurrentMap, 192);
 
-	if(gI_CreateSpawnPoints > 0 && gEV_Type != Engine_TF2)
+	if(gI_CreateSpawnPoints > 0)
 	{
 		int iEntity = -1;
 		float fOrigin[3];
 
-		if((iEntity = FindEntityByClassname(iEntity, "info_player_terrorist")) != INVALID_ENT_REFERENCE)
-		{
-			GetEntPropVector(iEntity, Prop_Send, "m_vecOrigin", fOrigin);
-		}
-
-		else if((iEntity = FindEntityByClassname(iEntity, "info_player_counterterrorist")) != INVALID_ENT_REFERENCE)
+		if((iEntity = FindEntityByClassname(iEntity, "info_player_terrorist")) != INVALID_ENT_REFERENCE || // CS:S/CS:GO T
+			(iEntity = FindEntityByClassname(iEntity, "info_player_counterterrorist")) != INVALID_ENT_REFERENCE || // CS:S/CS:GO CT
+			(iEntity = FindEntityByClassname(iEntity, "info_player_teamspawn")) != INVALID_ENT_REFERENCE || // TF2 spawn point
+			(iEntity = FindEntityByClassname(iEntity, "info_player_start")) != INVALID_ENT_REFERENCE)
 		{
 			GetEntPropVector(iEntity, Prop_Send, "m_vecOrigin", fOrigin);
 		}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2172,6 +2172,14 @@ void RestoreState(any data)
 		return;
 	}
 
+	if(gA_SaveStates[client][bsStyle] != Shavit_GetBhopStyle(client) ||
+		gA_SaveStates[client][iTimerTrack] != Shavit_GetClientTrack(client))
+	{
+		gB_SaveStates[client] = false;
+
+		return;
+	}
+
 	LoadState(client);
 }
 
@@ -2451,17 +2459,12 @@ void LoadState(int client)
 
 	Shavit_LoadSnapshot(client, gA_SaveStates[client]);
 
-	if(gA_SaveFrames[client] != null)
+	if(gB_Replay && gA_SaveFrames[client] != null)
 	{
-		if(gB_Replay)
-		{
-			Shavit_SetReplayData(client, gA_SaveFrames[client]);
-		}
-
-		delete gA_SaveFrames[client];
-		gA_SaveFrames[client] = null;
+		Shavit_SetReplayData(client, gA_SaveFrames[client]);
 	}
 
+	delete gA_SaveFrames[client];
 	gB_SaveStates[client] = false;
 }
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2275,7 +2275,7 @@ public Action Shotgun_Shot(const char[] te_name, const int[] Players, int numCli
 	TE_WriteFloat("m_vecAngles[0]", TE_ReadFloat("m_vecAngles[0]"));
 	TE_WriteFloat("m_vecAngles[1]", TE_ReadFloat("m_vecAngles[1]"));
 	
-	if(gEV_Type == Engine_CSS)
+	if(IsSource2013(gEV_Type))
 	{
 		TE_WriteNum("m_iWeaponID", TE_ReadNum("m_iWeaponID"));
 	}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -33,15 +33,33 @@
 #undef REQUIRE_PLUGIN
 #include <shavit>
 
+// this one is here because enum structs don't work with new syntax
+enum CheckpointsCache
+{
+	Float:fCPPosition[3],
+	Float:fCPAngles[3],
+	Float:fCPVelocity[3],
+	MoveType:mtCPMoveType,
+	Float:fCPGravity,
+	Float:fCPSpeed,
+	Float:fCPStamina,
+	bool:bCPDucking,
+	iCPFlags,
+	any:aCPSnapshot[TIMERSNAPSHOT_SIZE],
+	String:sCPTargetname[32],
+	PCPCACHE_SIZE
+}
+
 #pragma newdecls required
 #pragma semicolon 1
+#pragma dynamic 131072
 
 #define CP_ANGLES				(1 << 0)
 #define CP_VELOCITY				(1 << 1)
 
 #define CP_DEFAULT				(CP_ANGLES|CP_VELOCITY)
 
-#define CP_MAX					64 // this is the amount i'm willing to go for
+#define CP_MAX					1000 // segmented runs shouldn't even reach 1k jumps on any map anyways
 
 // game specific
 EngineVersion gEV_Type = Engine_Unknown;
@@ -50,24 +68,6 @@ int gI_Ammo = -1;
 char gS_RadioCommands[][] = {"coverme", "takepoint", "holdpos", "regroup", "followme", "takingfire", "go", "fallback", "sticktog",
 	"getinpos", "stormfront", "report", "roger", "enemyspot", "needbackup", "sectorclear", "inposition", "reportingin",
 	"getout", "negative", "enemydown", "compliment", "thanks", "cheer"};
-
-// enums
-enum
-{
-	iCheckpoints,
-	iCurrentCheckpoint,
-	CHECKPOINTSCACHE_SIZE
-};
-
-enum
-{
-	iCPMoveType,
-	fCPGravity,
-	fCPSpeed,
-	fCPStamina,
-	bCPDucking,
-	PCHECKPOINTSCACHE_SIZE
-};
 
 // cache
 ConVar sv_disable_immunity_alpha = null;
@@ -84,12 +84,16 @@ int gI_AdvertisementsCycle = 0;
 char gS_CurrentMap[192];
 int gBS_Style[MAXPLAYERS+1];
 
-float gF_Checkpoints[MAXPLAYERS+1][CP_MAX][3][3]; // 3 - position, angles, velocity
+enum
+{
+	iCheckpoints,
+	iCurrentCheckpoint,
+	CPCACHE_SIZE
+};
+
+int gI_CheckpointsCache[MAXPLAYERS+1][CPCACHE_SIZE];
 int gI_CheckpointsSettings[MAXPLAYERS+1];
-any gA_PlayerCheckPointsCache[MAXPLAYERS+1][CP_MAX][PCHECKPOINTSCACHE_SIZE];
-any gA_CheckpointsSnapshots[MAXPLAYERS+1][CP_MAX][TIMERSNAPSHOT_SIZE];
-any gA_CheckpointsCache[MAXPLAYERS+1][CHECKPOINTSCACHE_SIZE];
-char gS_CheckpointsTargetname[MAXPLAYERS+1][CP_MAX][32];
+StringMap gSM_Checkpoints = null;
 
 // save states
 float gF_SaveStateData[MAXPLAYERS+1][3][3];
@@ -232,6 +236,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_save", Command_Save, "Saves checkpoint (default: 1). Usage: sm_save [number]");
 	RegConsoleCmd("sm_tele", Command_Tele, "Teleports to checkpoint (default: 1). Usage: sm_tele [number]");
 	gH_CheckpointsCookie = RegClientCookie("shavit_checkpoints", "Checkpoints settings", CookieAccess_Protected);
+	gSM_Checkpoints = new StringMap();
 
 	gI_Ammo = FindSendPropInfo("CCSPlayer", "m_iAmmo");
 
@@ -503,6 +508,8 @@ public void OnConfigsExecuted()
 
 public void OnMapStart()
 {
+	gSM_Checkpoints.Clear();
+
 	GetCurrentMap(gS_CurrentMap, 192);
 	GetMapDisplayName(gS_CurrentMap, gS_CurrentMap, 192);
 
@@ -987,42 +994,24 @@ public void OnClientPutInServer(int client)
 	}
 }
 
+public void OnClientDisconnect(int client)
+{
+	ResetCheckpoints(client);
+}
+
 void ResetCheckpoints(int client)
 {
-	for(int i = 0; i < sizeof(gF_Checkpoints[]); i++)
+	int serial = GetClientSerial(client);
+	char[] key = new char[32];
+
+	for(int i = 0; i < gI_CheckpointsCache[client][iCheckpoints]; i++)
 	{
-		for(int j = 0; j < sizeof(gF_Checkpoints[][]); j++)
-		{
-			gF_Checkpoints[client][i][j] = NULL_VECTOR;
-		}
+		FormatEx(key, 32, "%d_%d", serial, i);
+		gSM_Checkpoints.Remove(key);
 	}
 
-	for(int i = 0; i < CP_MAX; i++)
-	{
-		gA_CheckpointsSnapshots[client][i][bTimerEnabled] = false;
-		gA_CheckpointsSnapshots[client][i][fStartTime] = 0.0;
-		gA_CheckpointsSnapshots[client][i][fCurrentTime] = 0.0;
-		gA_CheckpointsSnapshots[client][i][fPauseStartTime] = 0.0;
-		gA_CheckpointsSnapshots[client][i][fPauseTotalTime] = 0.0;
-		gA_CheckpointsSnapshots[client][i][bClientPaused] = false;
-		gA_CheckpointsSnapshots[client][i][iJumps] = 0;
-		gA_CheckpointsSnapshots[client][i][bsStyle] = 0;
-		gA_CheckpointsSnapshots[client][i][iStrafes] = 0;
-		gA_CheckpointsSnapshots[client][i][iTotalMeasures] = 0;
-		gA_CheckpointsSnapshots[client][i][iGoodGains] = 0;
-		gA_CheckpointsSnapshots[client][i][iSHSWCombination] = -1;
-
-		gA_PlayerCheckPointsCache[client][i][iCPMoveType] = MOVETYPE_WALK;
-		gA_PlayerCheckPointsCache[client][i][fCPGravity] = 1.0;
-		gA_PlayerCheckPointsCache[client][i][fCPSpeed] = 1.0;
-		gA_PlayerCheckPointsCache[client][i][fCPStamina] = 1.0;
-		gA_PlayerCheckPointsCache[client][i][bCPDucking] = false;
-
-		strcopy(gS_CheckpointsTargetname[client][i], 32, "");
-	}
-
-	gA_CheckpointsCache[client][iCheckpoints] = 0;
-	gA_CheckpointsCache[client][iCurrentCheckpoint] = 1;
+	gI_CheckpointsCache[client][iCheckpoints] = 0;
+	gI_CheckpointsCache[client][iCurrentCheckpoint] = 1;
 }
 
 public Action OnTakeDamage(int victim, int attacker)
@@ -1444,11 +1433,11 @@ public Action Command_Save(int client, int args)
 	{
 		bool bSaved = false;
 
-		if(gA_CheckpointsCache[client][iCheckpoints] < CP_MAX)
+		if(gI_CheckpointsCache[client][iCheckpoints] < CP_MAX)
 		{
-			if((bSaved = SaveCheckpoint(client, gA_CheckpointsCache[client][iCheckpoints])))
+			if((bSaved = SaveCheckpoint(client, gI_CheckpointsCache[client][iCheckpoints])))
 			{
-				gA_CheckpointsCache[client][iCurrentCheckpoint] = ++gA_CheckpointsCache[client][iCheckpoints];
+				gI_CheckpointsCache[client][iCurrentCheckpoint] = ++gI_CheckpointsCache[client][iCheckpoints];
 			}
 		}
 
@@ -1456,13 +1445,13 @@ public Action Command_Save(int client, int args)
 		{
 			if((bSaved = SaveCheckpoint(client, (CP_MAX - 1))))
 			{
-				gA_CheckpointsCache[client][iCurrentCheckpoint] = CP_MAX;
+				gI_CheckpointsCache[client][iCurrentCheckpoint] = CP_MAX;
 			}
 		}
 
 		if(bSaved)
 		{
-			Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gA_CheckpointsCache[client][iCurrentCheckpoint],
+			Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gI_CheckpointsCache[client][iCurrentCheckpoint],
 				gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 		}
 	}
@@ -1486,7 +1475,7 @@ public Action Command_Tele(int client, int args)
 		return Plugin_Handled;
 	}
 
-	int index = (gA_CheckpointsCache[client][iCurrentCheckpoint] - 1);
+	int index = (gI_CheckpointsCache[client][iCurrentCheckpoint] - 1);
 
 	if(args > 0)
 	{
@@ -1501,7 +1490,13 @@ public Action Command_Tele(int client, int args)
 		}
 	}
 
-	if(IsNullVector(gF_Checkpoints[client][index][0]))
+	CheckpointsCache cpcache[PCPCACHE_SIZE];
+	GetCheckpoint(client, index, cpcache);
+
+	float pos[3];
+	CopyArray(cpcache[fCPPosition], pos, 3);
+
+	if(IsNullVector(pos))
 	{
 		Shavit_PrintToChat(client, "%T", "MiscCheckpointsEmpty", client, (index + 1), gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
 
@@ -1526,12 +1521,12 @@ public Action OpenCheckpointsMenu(int client, int item)
 	menu.SetTitle("%T\n%T\n ", "MiscCheckpointMenu", client, "MiscCheckpointWarning", client);
 
 	char[] sDisplay = new char[64];
-	FormatEx(sDisplay, 64, "%T", "MiscCheckpointSave", client, (gA_CheckpointsCache[client][iCheckpoints] + 1));
-	menu.AddItem("save", sDisplay, (gA_CheckpointsCache[client][iCheckpoints] < CP_MAX)? ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+	FormatEx(sDisplay, 64, "%T", "MiscCheckpointSave", client, (gI_CheckpointsCache[client][iCheckpoints] + 1));
+	menu.AddItem("save", sDisplay, (gI_CheckpointsCache[client][iCheckpoints] < CP_MAX)? ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 
-	if(gA_CheckpointsCache[client][iCheckpoints] > 0)
+	if(gI_CheckpointsCache[client][iCheckpoints] > 0)
 	{
-		FormatEx(sDisplay, 64, "%T", "MiscCheckpointTeleport", client, gA_CheckpointsCache[client][iCurrentCheckpoint]);
+		FormatEx(sDisplay, 64, "%T", "MiscCheckpointTeleport", client, gI_CheckpointsCache[client][iCurrentCheckpoint]);
 		menu.AddItem("tele", sDisplay, ITEMDRAW_DEFAULT);
 	}
 
@@ -1570,20 +1565,20 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 {
 	if(action == MenuAction_Select)
 	{
-		int current = gA_CheckpointsCache[param1][iCurrentCheckpoint];
+		int current = gI_CheckpointsCache[param1][iCurrentCheckpoint];
 
 		switch(param2)
 		{
 			case 0:
 			{
 				// fight an exploit
-				if(gA_CheckpointsCache[param1][iCheckpoints] >= CP_MAX)
+				if(gI_CheckpointsCache[param1][iCheckpoints] >= CP_MAX)
 				{
 					return 0;
 				}
 
-				SaveCheckpoint(param1, gA_CheckpointsCache[param1][iCheckpoints]);
-				gA_CheckpointsCache[param1][iCurrentCheckpoint] = ++gA_CheckpointsCache[param1][iCheckpoints];
+				SaveCheckpoint(param1, gI_CheckpointsCache[param1][iCheckpoints]);
+				gI_CheckpointsCache[param1][iCurrentCheckpoint] = ++gI_CheckpointsCache[param1][iCheckpoints];
 			}
 
 			case 1:
@@ -1595,15 +1590,21 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 			{
 				if(current > 1)
 				{
-					gA_CheckpointsCache[param1][iCurrentCheckpoint]--;
+					gI_CheckpointsCache[param1][iCurrentCheckpoint]--;
 				}
 			}
 
 			case 3:
 			{
-				if(current < CP_MAX && !IsNullVector(gF_Checkpoints[param1][current][0]))
+				CheckpointsCache cpcache[PCPCACHE_SIZE];
+				GetCheckpoint(param1, current, cpcache);
+
+				float pos[3];
+				CopyArray(cpcache[fCPPosition], pos, 3);
+
+				if(current < CP_MAX && !IsNullVector(pos))
 				{
-					gA_CheckpointsCache[param1][iCurrentCheckpoint]++;
+					gI_CheckpointsCache[param1][iCurrentCheckpoint]++;
 				}
 			}
 
@@ -1667,25 +1668,50 @@ bool SaveCheckpoint(int client, int index)
 		return false;
 	}
 
-	GetClientAbsOrigin(target, gF_Checkpoints[client][index][0]);
-	GetClientEyeAngles(target, gF_Checkpoints[client][index][1]);
-	GetEntPropVector(target, Prop_Data, "m_vecAbsVelocity", gF_Checkpoints[client][index][2]);
-	GetEntPropString(target, Prop_Data, "m_iName", gS_CheckpointsTargetname[client][index], 32);
+	CheckpointsCache cpcache[PCPCACHE_SIZE];
+	float temp[3];
 
-	gA_PlayerCheckPointsCache[client][index][iCPMoveType] = GetEntityMoveType(target);
-	gA_PlayerCheckPointsCache[client][index][fCPGravity] = GetEntityGravity(target);
-	gA_PlayerCheckPointsCache[client][index][fCPSpeed] = GetEntPropFloat(target, Prop_Send, "m_flLaggedMovementValue");
-	gA_PlayerCheckPointsCache[client][index][fCPStamina] = GetEntPropFloat(target, Prop_Send, "m_flStamina");
-	gA_PlayerCheckPointsCache[client][index][bCPDucking] = (GetClientButtons(target) & IN_DUCK) > 0;
+	GetClientAbsOrigin(target, temp);
+	CopyArray(temp, cpcache[fCPPosition], 3);
 
-	Shavit_SaveSnapshot(target, gA_CheckpointsSnapshots[client][index]);
+	GetClientEyeAngles(target, temp);
+	CopyArray(temp, cpcache[fCPAngles], 3);
+
+	GetEntPropVector(target, Prop_Data, "m_vecAbsVelocity", temp);
+	CopyArray(temp, cpcache[fCPVelocity], 3);
+
+	GetEntPropString(target, Prop_Data, "m_iName", cpcache[sCPTargetname], 32);
+
+	cpcache[mtCPMoveType] = GetEntityMoveType(target);
+	cpcache[fCPGravity] = GetEntityGravity(target);
+	cpcache[fCPSpeed] = GetEntPropFloat(target, Prop_Send, "m_flLaggedMovementValue");
+	cpcache[fCPStamina] = (gEV_Type != Engine_TF2)? GetEntPropFloat(target, Prop_Send, "m_flStamina"):0.0;
+	cpcache[bCPDucking] = (GetClientButtons(target) & IN_DUCK) > 0;
+	cpcache[iCPFlags] = GetEntityFlags(target);
+
+	any snapshot[TIMERSNAPSHOT_SIZE];
+	Shavit_SaveSnapshot(target, snapshot);
+	CopyArray(snapshot, cpcache[aCPSnapshot], TIMERSNAPSHOT_SIZE);
+
+	SetCheckpoint(client, index, cpcache);
 
 	return true;
 }
 
 void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 {
-	if(index < 0 || index >= CP_MAX || IsNullVector(gF_Checkpoints[client][index][0]))
+	if(index < 0 || index >= CP_MAX)
+	{
+		return;
+	}
+
+	CheckpointsCache cpcache[PCPCACHE_SIZE];
+	GetCheckpoint(client, index, cpcache);
+
+	float pos[3];
+	CopyArray(cpcache[fCPPosition], pos, 3);
+
+	if(IsNullVector(pos))
 	{
 		return;
 	}
@@ -1699,7 +1725,7 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 
 	bool bDucking = (GetClientButtons(client) & IN_DUCK) > 0;
 
-	if(gA_PlayerCheckPointsCache[client][index][bCPDucking] != bDucking)
+	if(cpcache[bCPDucking] != bDucking)
 	{
 		Shavit_PrintToChat(client, "%T", (bDucking)? "MiscCheckpointsCrouchOff":"MiscCheckpointsCrouchOn", client, gS_ChatStrings[sMessageWarning], gS_ChatStrings[sMessageText]);
 
@@ -1714,17 +1740,38 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 	}
 
 	Shavit_SetPracticeMode(client, true, !bInStart);
-	Shavit_LoadSnapshot(client, gA_CheckpointsSnapshots[client][index]);
 
-	TeleportEntity(client, gF_Checkpoints[client][index][0],
-		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0)? gF_Checkpoints[client][index][1]:NULL_VECTOR,
-		((gI_CheckpointsSettings[client] & CP_VELOCITY) > 0)? gF_Checkpoints[client][index][2]:NULL_VECTOR);
+	any snapshot[TIMERSNAPSHOT_SIZE];
+	CopyArray(cpcache[aCPSnapshot], snapshot, TIMERSNAPSHOT_SIZE);
+	Shavit_LoadSnapshot(client, snapshot);
 
-	SetEntityMoveType(client, view_as<MoveType>(gA_PlayerCheckPointsCache[client][index][iCPMoveType]));
-	SetEntityGravity(client, view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPGravity]));
-	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPSpeed]));
-	SetEntPropFloat(client, Prop_Send, "m_flStamina", view_as<float>(gA_PlayerCheckPointsCache[client][index][fCPStamina]));
-	DispatchKeyValue(client, "targetname", gS_CheckpointsTargetname[client][index]);
+	float ang[3];
+	CopyArray(cpcache[fCPAngles], ang, 3);
+
+	float vel[3];
+	CopyArray(cpcache[fCPVelocity], vel, 3);
+
+	TeleportEntity(client, pos,
+		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0)? ang:NULL_VECTOR,
+		((gI_CheckpointsSettings[client] & CP_VELOCITY) > 0)? vel:NULL_VECTOR);
+
+	MoveType mt = cpcache[mtCPMoveType];
+
+	if(mt == MOVETYPE_LADDER || mt == MOVETYPE_WALK)
+	{
+		SetEntityMoveType(client, mt);
+	}
+
+	SetEntityGravity(client, cpcache[fCPGravity]);
+	SetEntityFlags(client, cpcache[iCPFlags]);
+
+	SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", cpcache[fCPSpeed]);
+	DispatchKeyValue(client, "targetname", cpcache[sCPTargetname]);
+
+	if(gEV_Type != Engine_TF2)
+	{
+		SetEntPropFloat(client, Prop_Send, "m_flStamina", cpcache[fCPStamina]);
+	}
 	
 	if(!suppressMessage)
 	{
@@ -2223,7 +2270,7 @@ public Action Shotgun_Shot(const char[] te_name, const int[] Players, int numCli
 	{
 		TE_WriteNum("m_weapon", TE_ReadNum("m_weapon"));
 	}
-        
+		
 	TE_WriteNum("m_iMode", TE_ReadNum("m_iMode"));
 	TE_WriteNum("m_iSeed", TE_ReadNum("m_iSeed"));
 	TE_WriteNum("m_iPlayer", (client - 1));
@@ -2412,6 +2459,22 @@ void SaveState(int client)
 	gB_SaveStates[client] = true;
 }
 
+bool GetCheckpoint(int client, int index, CheckpointsCache cpcache[PCPCACHE_SIZE])
+{
+	char[] sKey = new char[32];
+	FormatEx(sKey, 32, "%d_%d", GetClientSerial(client), index);
+
+	return gSM_Checkpoints.GetArray(sKey, cpcache[0], view_as<int>(PCPCACHE_SIZE));
+}
+
+bool SetCheckpoint(int client, int index, CheckpointsCache cpcache[PCPCACHE_SIZE])
+{
+	char[] sKey = new char[32];
+	FormatEx(sKey, 32, "%d_%d", GetClientSerial(client), index);
+
+	return gSM_Checkpoints.SetArray(sKey, cpcache[0], view_as<int>(PCPCACHE_SIZE));
+}
+
 void UpdateFootsteps(int client)
 {
 	if(sv_footsteps != null)
@@ -2419,6 +2482,14 @@ void UpdateFootsteps(int client)
 		char[] sFootsteps = new char[4];
 		IntToString((gB_Hide[client])? 0:sv_footsteps.IntValue, sFootsteps, 4);
 		sv_footsteps.ReplicateToClient(client, sFootsteps);
+	}
+}
+
+void CopyArray(const any[] from, any[] to, int size)
+{
+	for(int i = 0; i < size; i++)
+	{
+		to[i] = from[i];
 	}
 }
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -160,7 +160,7 @@ int gI_NoclipMe = true;
 float gF_AdvertisementInterval = 600.0;
 bool gB_Checkpoints = true;
 int gI_RemoveRagdolls = 1;
-char gS_ClanTag[32] = "{styletag} :: {time}";
+char gS_ClanTag[32] = "{tr}{styletag} :: {time}";
 bool gB_DropAll = true;
 bool gB_ResetTargetname = false;
 bool gB_RestoreStates = false;
@@ -306,7 +306,7 @@ public void OnPluginStart()
 	gCV_AdvertisementInterval = CreateConVar("shavit_misc_advertisementinterval", "600.0", "Interval between each chat advertisement.\nConfiguration file for those is configs/shavit-advertisements.cfg.\nSet to 0.0 to disable.\nRequires server restart for changes to take effect.", 0, true, 0.0);
 	gCV_Checkpoints = CreateConVar("shavit_misc_checkpoints", "1", "Allow players to save and teleport to checkpoints.", 0, true, 0.0, true, 1.0);
 	gCV_RemoveRagdolls = CreateConVar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
-	gCV_ClanTag = CreateConVar("shavit_misc_clantag", "{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style settings from shavit-styles.cfg.\n{style} - style name.\n{time} - formatted time.", 0);
+	gCV_ClanTag = CreateConVar("shavit_misc_clantag", "{tr}{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style settings from shavit-styles.cfg.\n{style} - style name.\n{time} - formatted time.\n{tr} - first letter of track, if not default.", 0);
 	gCV_DropAll = CreateConVar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_ResetTargetname = CreateConVar("shavit_misc_resettargetname", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RestoreStates = CreateConVar("shavit_misc_restorestates", "0", "Save the players' timer/position etc.. when they die/change teams,\nand load the data when they spawn?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -878,11 +878,20 @@ void UpdateClanTag(int client)
 		}
 	}
 
+	int track = Shavit_GetClientTrack(client);
+	char[] sTrack = new char[3];
+
+	if(track != Track_Main)
+	{
+		GetTrackName(client, track, sTrack, 3);
+	}
+
 	char[] sCustomTag = new char[32];
 	strcopy(sCustomTag, 32, gS_ClanTag);
 	ReplaceString(sCustomTag, 32, "{style}", gS_StyleStrings[gBS_Style[client]][sStyleName]);
 	ReplaceString(sCustomTag, 32, "{styletag}", gS_StyleStrings[gBS_Style[client]][sClanTag]);
 	ReplaceString(sCustomTag, 32, "{time}", sTime);
+	ReplaceString(sCustomTag, 32, "{tr}", sTrack);
 
 	CS_SetClientClanTag(client, sCustomTag);
 }
@@ -2275,7 +2284,7 @@ public Action Shotgun_Shot(const char[] te_name, const int[] Players, int numCli
 	{
 		TE_WriteNum("m_weapon", TE_ReadNum("m_weapon"));
 	}
-		
+
 	TE_WriteNum("m_iMode", TE_ReadNum("m_iMode"));
 	TE_WriteNum("m_iSeed", TE_ReadNum("m_iSeed"));
 	TE_WriteNum("m_iPlayer", (client - 1));

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2047,18 +2047,34 @@ public void Shavit_OnRestart(int client, int track)
 			}
 		}
 
-		DataPack pack = null;
-		CreateDataTimer(0.1, Respawn, pack, TIMER_FLAG_NO_MAPCHANGE);
+		DataPack pack = new DataPack();
 		pack.WriteCell(GetClientSerial(client));
 		pack.WriteCell(track);
+		view_as<int>(pack) |= (1 << 24);
+
+		CreateTimer(0.1, Respawn, pack, TIMER_FLAG_NO_MAPCHANGE);
 	}
 }
 
-public Action Respawn(Handle Timer, DataPack pack)
+public Action Respawn(Handle Timer, any data)
 {
-	pack.Reset();
-	int client = GetClientFromSerial(pack.ReadCell());
-	int track = pack.ReadCell();
+	int track = Track_Main;
+	int client = 0;
+	
+	if(data & (1 << 24) > 0)
+	{
+		data &= ~(1 << 24);
+		DataPack pack = data;
+		pack.Reset();
+		client = GetClientFromSerial(pack.ReadCell());
+		track = pack.ReadCell();
+		delete pack;
+	}
+
+	else
+	{
+		client = GetClientFromSerial(data);
+	}
 
 	if(IsValidClient(client) && !IsPlayerAlive(client) && GetClientTeam(client) >= 2)
 	{

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2522,10 +2522,3 @@ void CopyArray(const any[] from, any[] to, int size)
 		to[i] = from[i];
 	}
 }
-
-#if SOURCEMOD_V_MAJOR == 1 && SOURCEMOD_V_MINOR < 9
-bool IsNullVector(float vec[3])
-{
-	return (vec[0] == NULL_VECTOR[0] && vec[1] == NULL_VECTOR[1] && vec[2] == NULL_VECTOR[2]);
-}
-#endif

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -172,6 +172,7 @@ Handle gH_GetPlayerMaxSpeed = null;
 // modules
 bool gB_Rankings = false;
 bool gB_Replay = false;
+bool gB_Zones = false;
 
 // timer settings
 char gS_StyleStrings[STYLE_LIMIT][STYLESTRINGS_SIZE][128];
@@ -391,6 +392,7 @@ public void OnPluginStart()
 	// modules
 	gB_Rankings = LibraryExists("shavit-rankings");
 	gB_Replay = LibraryExists("shavit-replay");
+	gB_Zones = LibraryExists("shavit-zones");
 }
 
 public void OnClientCookiesCached(int client)
@@ -605,6 +607,11 @@ public void OnLibraryAdded(const char[] name)
 	{
 		gB_Replay = true;
 	}
+
+	else if(StrEqual(name, "shavit-zones"))
+	{
+		gB_Zones = true;
+	}
 }
 
 public void OnLibraryRemoved(const char[] name)
@@ -617,6 +624,11 @@ public void OnLibraryRemoved(const char[] name)
 	else if(StrEqual(name, "shavit-replay"))
 	{
 		gB_Replay = false;
+	}
+
+	else if(StrEqual(name, "shavit-zones"))
+	{
+		gB_Zones = false;
 	}
 }
 
@@ -2071,7 +2083,7 @@ public Action Respawn(Handle Timer, DataPack pack)
 
 void RestartTimer(int client, int track)
 {
-	if(Shavit_ZoneExists(Zone_Start, track))
+	if((gB_Zones && Shavit_ZoneExists(Zone_Start, track)) || Shavit_IsKZMap())
 	{
 		Shavit_RestartTimer(client, track);
 	}

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -755,8 +755,8 @@ public void SQL_Recalculate_Callback(Database db, DBResultSet results, const cha
 	int serial = data.ReadCell();
 	int size = data.ReadCell();
 
-	char[] sMap = new char[size + 1];
-	ReadPackString(data, sMap, size + 1);
+	char[] sMap = new char[size+1];
+	data.ReadString(sMap, size+1);
 
 	int track = data.ReadCell();
 	int style = data.ReadCell();

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -20,7 +20,7 @@
 
 // Design idea:
 // Rank 1 per map/style/track gets ((points per tier * tier) * 1.5) + (rank 1 time in seconds / 15.0) points.
-// Records below rank 1 get points% relative to their time in comparison to rank 1 and a final multiplier of 85% to promote rank 1 hunting.
+// Records below rank 1 get points% relative to their time in comparison to rank 1.
 //
 // Bonus track gets a 0.25* final mutliplier for points and is treated as tier 1.
 //

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1231,14 +1231,21 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 		return;
 	}
 
+	if(!gB_Enabled || (gF_TimeLimit > 0.0 && time > gF_TimeLimit))
+	{
+		ClearFrames(client);
+
+		return;
+	}
+
 	gB_Record[client] = false;
 
-	float fWR = 0.0;
-	Shavit_GetWRTime(style, fWR, track);
+	bool newformat = view_as<bool>(gA_FrameCache[style][track][2]);
+	float length = GetReplayLength(style, track);
 
-	if(!view_as<bool>(gA_FrameCache[style][track][2]))
+	if(newformat)
 	{
-		if(view_as<int>(gA_FrameCache[style][track][0]) != 0 && gI_PlayerFrames[client] > gA_FrameCache[style][track][0])
+		if(length > 0.0 && time > length)
 		{
 			return;
 		}
@@ -1246,9 +1253,10 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	else
 	{
-		float fReplayTime = view_as<float>(gA_FrameCache[style][track][1]);
+		float wrtime = 0.0;
+		Shavit_GetWRTime(style, wrtime, track);
 
-		if(fReplayTime != 0.0 && time >= fReplayTime)
+		if(wrtime != 0.0 && time > wrtime)
 		{
 			return;
 		}
@@ -1256,13 +1264,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 	if(gI_PlayerFrames[client] == 0)
 	{
-		return;
-	}
-
-	if(!gB_Enabled || (gF_TimeLimit > 0.0 && time > gF_TimeLimit))
-	{
-		ClearFrames(client);
-
 		return;
 	}
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1359,6 +1359,19 @@ public void Shavit_OnResume(int client)
 	gB_Record[client] = true;
 }
 
+void ModifyFlags(int &flags, int flag, bool add)
+{
+	if(add)
+	{
+		flags |= flag;
+	}
+
+	else
+	{
+		flags &= flag;
+	}
+}
+
 // OnPlayerRunCmd instead of Shavit_OnUserCmdPre because bots are also used here.
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3])
 {
@@ -1465,22 +1478,29 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 			buttons = gA_Frames[style][track].Get(gI_ReplayTick[style], 5);
 
+			MoveType mt = MOVETYPE_NOCLIP;
+
 			if(gA_FrameCache[style][track][3] >= 0x02)
 			{
-				SetEntityFlags(client, gA_Frames[style][track].Get(gI_ReplayTick[style], 6));
+				int iReplayFlags = gA_Frames[style][track].Get(gI_ReplayTick[style], 6);
+				int iEntityFlags = GetEntityFlags(client);
+
+				ModifyFlags(iEntityFlags, FL_ONGROUND, (iReplayFlags & FL_ONGROUND) > 0);
+				ModifyFlags(iEntityFlags, FL_PARTIALGROUND, (iReplayFlags & FL_PARTIALGROUND) > 0);
+				ModifyFlags(iEntityFlags, FL_INWATER, (iReplayFlags & FL_INWATER) > 0);
+				ModifyFlags(iEntityFlags, FL_SWIM, (iReplayFlags & FL_SWIM) > 0);
+
+				SetEntityFlags(client, iEntityFlags);
 				
-				MoveType mt = gA_Frames[style][track].Get(gI_ReplayTick[style], 7);
+				MoveType movetype = gA_Frames[style][track].Get(gI_ReplayTick[style], 7);
 
-				if(mt == MOVETYPE_WALK || mt == MOVETYPE_LADDER)
+				if(movetype == MOVETYPE_WALK || movetype == MOVETYPE_LADDER)
 				{
-					SetEntityMoveType(client, mt);
-				}
-
-				else
-				{
-					SetEntityMoveType(client, MOVETYPE_NOCLIP);
+					mt = movetype;
 				}
 			}
+
+			SetEntityMoveType(client, mt);
 
 			float vecVelocity[3];
 			MakeVectorFromPoints(vecCurrentPosition, vecPosition, vecVelocity);

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -64,6 +64,8 @@ enum
 EngineVersion gEV_Type = Engine_Unknown;
 
 // cache
+char gS_ReplayFolder[PLATFORM_MAX_PATH];
+
 int gI_ReplayTick[STYLE_LIMIT];
 int gI_ReplayBotClient[STYLE_LIMIT];
 ArrayList gA_Frames[STYLE_LIMIT][TRACKS_SIZE];
@@ -557,7 +559,18 @@ bool LoadStyling()
 	kv.GetString("centralstyletag", gS_ReplayStrings[sReplayCentralStyleTag], MAX_NAME_LENGTH, "<EMPTY CENTRALSTYLETAG>");
 	kv.GetString("unloaded", gS_ReplayStrings[sReplayUnloaded], MAX_NAME_LENGTH, "<EMPTY UNLOADED>");
 
+	char[] sFolder = new char[PLATFORM_MAX_PATH];
+	kv.GetString("replayfolder", sFolder, PLATFORM_MAX_PATH, "{SM}/data/replaybot");
+
 	delete kv;
+
+	if(StrContains(sFolder, "{SM}") != -1)
+	{
+		ReplaceString(sFolder, PLATFORM_MAX_PATH, "{SM}/", "");
+		BuildPath(Path_SM, sFolder, PLATFORM_MAX_PATH, "%s", sFolder);
+	}
+	
+	strcopy(gS_ReplayFolder, PLATFORM_MAX_PATH, sFolder);
 
 	return true;
 }
@@ -678,12 +691,9 @@ public void OnMapStart()
 
 	gI_ExpectedBots = 0;
 
-	char[] sPath = new char[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot");
-
-	if(!DirExists(sPath))
+	if(!DirExists(gS_ReplayFolder))
 	{
-		CreateDirectory(sPath, 511);
+		CreateDirectory(gS_ReplayFolder, 511);
 	}
 
 	for(int i = 0; i < gI_Styles; i++)
@@ -697,7 +707,8 @@ public void OnMapStart()
 			continue;
 		}
 
-		BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot/%d", i);
+		char[] sPath = new char[PLATFORM_MAX_PATH];
+		FormatEx(sPath, PLATFORM_MAX_PATH, "%s/%d", gS_ReplayFolder, i);
 
 		if(!DirExists(sPath))
 		{
@@ -772,7 +783,7 @@ bool DefaultLoadReplay(int style, int track)
 	FormatEx(sTrack, 4, "_%d", track);
 
 	char[] sPath = new char[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot/%d/%s%s.replay", style, gS_Map, (track > 0)? sTrack:"");
+	FormatEx(sPath, PLATFORM_MAX_PATH, "%s/%d/%s%s.replay", gS_ReplayFolder, style, gS_Map, (track > 0)? sTrack:"");
 
 	return LoadReplay(style, track, sPath);
 }
@@ -911,7 +922,7 @@ bool SaveReplay(int style, int track, float time, char[] authid, char[] name)
 	FormatEx(sTrack, 4, "_%d", track);
 
 	char[] sPath = new char[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot/%d/%s%s.replay", style, gS_Map, (track > 0)? sTrack:"");
+	FormatEx(sPath, PLATFORM_MAX_PATH, "%s/%d/%s%s.replay", gS_ReplayFolder, style, gS_Map, (track > 0)? sTrack:"");
 
 	if(FileExists(sPath))
 	{
@@ -953,7 +964,7 @@ bool DeleteReplay(int style, int track)
 	FormatEx(sTrack, 4, "_%d", track);
 
 	char[] sPath = new char[PLATFORM_MAX_PATH];
-	BuildPath(Path_SM, sPath, PLATFORM_MAX_PATH, "data/replaybot/%d/%s%s.replay", style, gS_Map, (track > 0)? sTrack:"");
+	FormatEx(sPath, PLATFORM_MAX_PATH, "%s/%d/%s%s.replay", gS_ReplayFolder, style, gS_Map, (track > 0)? sTrack:"");
 
 	if(!FileExists(sPath) || !DeleteFile(sPath))
 	{

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -250,6 +250,11 @@ public int Native_GetReplayBotCurrentFrame(Handle handler, int numParams)
 
 public int Native_GetReplayBotIndex(Handle handler, int numParams)
 {
+	if(gB_CentralBot)
+	{
+		return gA_CentralCache[iCentralClient];
+	}
+
 	return gI_ReplayBotClient[GetNativeCell(1)];
 }
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -140,6 +140,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_GetReplayBotIndex", Native_GetReplayBotIndex);
 	CreateNative("Shavit_GetReplayBotStyle", Native_GetReplayBotStyle);
 	CreateNative("Shavit_GetReplayBotTrack", Native_GetReplayBotTrack);
+	CreateNative("Shavit_GetReplayBotType", Native_GetReplayBotType);
 	CreateNative("Shavit_GetReplayData", Native_GetReplayData);
 	CreateNative("Shavit_GetReplayFrameCount", Native_GetReplayFrameCount);
 	CreateNative("Shavit_GetReplayLength", Native_GetReplayLength);
@@ -419,6 +420,11 @@ public int Native_GetReplayBotStyle(Handle handler, int numParams)
 public int Native_GetReplayBotTrack(Handle handler, int numParams)
 {
 	return GetReplayTrack(GetNativeCell(1));
+}
+
+public int Native_GetReplayBotType(Handle handler, int numParams)
+{
+	return view_as<int>((gB_CentralBot)? Replay_Central:Replay_Legacy);
 }
 
 public void Shavit_OnDatabaseLoaded()

--- a/addons/sourcemod/scripting/shavit-stats.sp
+++ b/addons/sourcemod/scripting/shavit-stats.sp
@@ -84,7 +84,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 {
 	// natives
 	CreateNative("Shavit_OpenStatsMenu", Native_OpenStatsMenu);
-	CreateNative("Shavit_GetWRCount", Native_GetWRConut);
+	CreateNative("Shavit_GetWRCount", Native_GetWRCount);
 
 	RegPluginLibrary("shavit-stats");
 
@@ -843,7 +843,7 @@ public int Native_OpenStatsMenu(Handle handler, int numParams)
 	OpenStatsMenu(client, gS_TargetAuth[client]);
 }
 
-public int Native_GetWRConut(Handle handler, int numParams)
+public int Native_GetWRCount(Handle handler, int numParams)
 {
 	return gI_WRAmount[GetNativeCell(1)];
 }

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1880,12 +1880,12 @@ void SQL_DBConnect()
 
 	if(gB_MySQL)
 	{
-		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` INT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), INDEX `auth` (`auth`, `map`, `time`, `style`, `date`, `points`, `track`)) ENGINE=INNODB;", gS_MySQLPrefix);
+		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` TINYINT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, PRIMARY KEY (`id`), INDEX `map` (`map`, `style`, `track`), INDEX `auth` (`auth`, `date`, `points`), INDEX `time` (`time`)) ENGINE=INNODB;", gS_MySQLPrefix);
 	}
 
 	else
 	{
-		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INTEGER PRIMARY KEY, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` INT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0);", gS_MySQLPrefix);
+		FormatEx(sQuery, 512, "CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INTEGER PRIMARY KEY, `auth` CHAR(32), `map` CHAR(128), `time` FLOAT, `jumps` INT, `style` TINYINT, `date` CHAR(16), `strafes` INT, `sync` FLOAT, `points` FLOAT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0);", gS_MySQLPrefix);
 	}
 
 	gH_SQL.Query(SQL_CreateTable_Callback, sQuery, 0, DBPrio_High);

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1449,7 +1449,7 @@ public void SQL_WR_Callback(Database db, DBResultSet results, const char[] error
 
 		else
 		{
-			FormatEx(sRanks, 32, "(#%d/%d)", iMyRank, gI_RecordAmount[gBS_LastWR[client]]);
+			FormatEx(sRanks, 32, "(#%d/%d)", iMyRank, iRecords);
 		}
 
 		char[] sTrack = new char[32];

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2077,7 +2077,7 @@ public Action Timer_Draw(Handle Timer, any data)
 	{
 		origin[2] -= gF_Height;
 
-		TE_SetupBeamPoints(vPlayerOrigin, origin, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 230}, 0);
+		TE_SetupBeamPoints(vPlayerOrigin, origin, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 75}, 0);
 		TE_SendToAll(0.0);
 
 		// visualize grid snap
@@ -2092,7 +2092,7 @@ public Action Timer_Draw(Handle Timer, any data)
 			snap2 = origin;
 			snap2[i] += (gI_GridSnap[client] / 2);
 
-			TE_SetupBeamPoints(snap1, snap2, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 230}, 0);
+			TE_SetupBeamPoints(snap1, snap2, gI_BeamSprite, gI_HaloSprite, 0, 0, 0.1, 1.0, 1.0, 0, 0.0, {255, 255, 255, 75}, 0);
 			TE_SendToAll(0.0);
 		}
 	}

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -736,6 +736,14 @@ void KillZoneEntity(int index)
 			gB_InsideZoneID[i][index] = false;
 		}
 
+		char[] sTargetname = new char[32];
+		GetEntPropString(entity, Prop_Data, "m_iName", sTargetname, 32);
+
+		if(StrContains(sTargetname, "shavit_zones_") == -1)
+		{
+			return;
+		}
+
 		UnhookEntity(entity);
 		AcceptEntityInput(entity, "Kill");
 	}
@@ -769,21 +777,17 @@ void UnloadZones(int zone)
 		{
 			gB_ZonesCreated = false;
 
-			int iMaxEntities = GetMaxEntities();
-
-			char[] sClassname = new char[32];
 			char[] sTargetname = new char[32];
+			int iEntity = INVALID_ENT_REFERENCE;
 
-			for(int i = (MaxClients + 1); i < iMaxEntities; i++)
+			while((iEntity = FindEntityByClassname(iEntity, "trigger_multiple")) != INVALID_ENT_REFERENCE)
 			{
-				if(!IsValidEntity(i) 
-					|| !GetEntityClassname(i, sClassname, 32) || !StrEqual(sClassname, "trigger_multiple")
-					|| GetEntPropString(i, Prop_Data, "m_iName", sTargetname, 32) == 0 || StrContains(sTargetname, "shavit_zones_") == -1)
-				{
-					continue;
-				}
+				GetEntPropString(iEntity, Prop_Data, "m_iName", sTargetname, 32);
 
-				AcceptEntityInput(i, "Kill");
+				if(StrContains(sTargetname, "shavit_zones_") != -1)
+				{
+					AcceptEntityInput(iEntity, "Kill");
+				}
 			}
 		}
 

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2143,31 +2143,36 @@ void DrawZone(float points[8][3], int color[4], float life, float width, bool fl
 	}
 }
 
-// by blacky
+// original by blacky
 // creates 3d box from 2 points
 void CreateZonePoints(float point[8][3], float offset = 0.0)
 {
-	float center[2];
-	center[0] = ((point[0][0] + point[7][0]) / 2);
-	center[1] = ((point[0][1] + point[7][1]) / 2);
-
-	for(int i = 0; i < 8; i++)
+	// calculate all zone edges
+	for(int i = 1; i < 7; i++)
 	{
 		for(int j = 0; j < 3; j++)
 		{
-			if(i > 0 && i < 7)
-			{
-				point[i][j] = point[((i >> (2 - j)) & 1) * 7][j];
-			}
+			point[i][j] = point[((i >> (2 - j)) & 1) * 7][j];
+		}
+	}
 
-			if(offset != 0.0 && j < 2)
+	// apply beam offset
+	if(offset != 0.0)
+	{
+		float center[2];
+		center[0] = ((point[0][0] + point[7][0]) / 2);
+		center[1] = ((point[0][1] + point[7][1]) / 2);
+
+		for(int i = 0; i < 8; i++)
+		{
+			for(int j = 0; j < 2; j++)
 			{
 				if(point[i][j] < center[j])
 				{
 					point[i][j] += offset;
 				}
 
-				else
+				else if(point[i][j] > center[j])
 				{
 					point[i][j] -= offset;
 				}

--- a/addons/sourcemod/translations/shavit-core.phrases.txt
+++ b/addons/sourcemod/translations/shavit-core.phrases.txt
@@ -105,11 +105,6 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"Timer has been {1}paused{2}."
 	}
-	"PausePractice"
-	{
-		"#format"	"{1:s},{2:s}"
-		"en"		"You {1}are not{2} allowed to pause while in practice mode."
-	}
 	// ---------- Zones ---------- //
 	"StartZoneUndefined"
 	{


### PR DESCRIPTION
# * Removed support for SourceMod 1.8. Use 1.9 or above.
* Made it so that you can configure the replay data folder; fixes #570.
* Fixed a formatting issue with the top-left HUD. Players could previously cause formatting issues with control characters there.
* Fixed an issue where the total records count on other maps' WR menu is incorrect.
* Made the grid visualization less opaque than before.
* Added an extra native for the replay's API: `Shavit_GetReplayBotType`, also added the `ReplayBotType` type.
* Changed !spec to automatically forward you to the replay bot as long as arguments aren't supplied; fixes #574.
* Added `float oldtime` as a parameter to the `Shavit_OnFinish` forward.
* Reworked checkpoints. Now they're not actually 'capped' but rather soft-capped at 1,000 to avoid filling up the whole heap. You can change this manually by editing the `MAX_CPS` definition in `shavit-misc`, but you'll probably want to increase the `#pragma dynamic ...` directive too.
* Introduced replay bot format version `0x02`. It now records and plays back more data. Notably, movetype and entity flags.
* Added the `shavit_hud_ticksperupdate` cvar to allow server operators to change the amount of frequency of HUD updates.
* Tweaked the CS:GO HUD, see 9b5e4ad's message for information.
* Added `{tr}` as a parameter for `shavit_misc_clantag`. It's the first letter of the track you're on, and is only filled if your track isn't the default.
* Added the scroll pad to the CS:GO HUD's key display. Requires [Bunnyhop Statistics](https://github.com/shavitush/bhopstats).
* Fixed the issue where zone offsets were wrong! This isn't a thing anymore:
![image](https://user-images.githubusercontent.com/3672466/35231971-ee19ba98-ffa2-11e7-8721-a81620641f9e.png)
* Applied fixes for timer restarts with maps where the zones bundled into them.
* Made the CS:S HUD show your time even when you're paused.
* Made the resume command teleport you back to the position you were in while pausing. This fixes an exploit.
* Implemented #440. Please test this branch out and let me know if something is off, as this might be critical.
* Allowed pausing in practice mode.
* Fixed top-left HUD flickering.
* Revamped `block_pstrafe`. Option 1 will now just block inconsistencies with buttons. Option 2 will stop the timer. 1 stays the default.