### PR TITLE
Begone bugs! (v2.0.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.dll
 *.so
 
-# Atom
+# editors
 *.atom-build.json
+.vscode/tasks.json

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -23,7 +23,7 @@
 #endif
 #define _shavit_included
 
-#define SHAVIT_VERSION "2.0.1"
+#define SHAVIT_VERSION "2.0.2"
 #define STYLE_LIMIT 256
 #define MAX_ZONES 64
 

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -204,7 +204,7 @@ bool LoadChatConfig()
 			float fRank = StringToFloat(sRanks);
 
 			aChatTitle[fCRFrom] = fRank;
-			aChatTitle[fCRTo] = (aChatTitle[iCRRangeType] != Rank_Points)? fRank:2147483648.0;
+			aChatTitle[fCRTo] = (aChatTitle[iCRRangeType] == Rank_Flat)? fRank:2147483648.0;
 		}
 		
 		aChatTitle[bCRFree] = view_as<bool>(kv.GetNum("free", false));

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -508,15 +508,15 @@ Action ShowChatRanksMenu(int client, int item)
 			continue;
 		}
 
-		char[] sInfo = new char[8];
-		IntToString(i, sInfo, 8);
-
 		any[] aCache = new any[CRCACHE_SIZE];
 		gA_ChatRanks.GetArray(i, aCache, view_as<int>(CRCACHE_SIZE));
 
 		strcopy(sDisplay, 192, aCache[sCRDisplay]);
 		ReplaceString(sDisplay, 192, "<n>", "\n");
 		StrCat(sDisplay, 192, "\n "); // to add spacing between each entry
+
+		char[] sInfo = new char[8];
+		IntToString(i, sInfo, 8);
 
 		menu.AddItem(sInfo, sDisplay, (gI_ChatSelection[client] == i)? ITEMDRAW_DISABLED:ITEMDRAW_DEFAULT);
 	}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -676,11 +676,16 @@ void UpdateHUD(int client)
 	else if((gI_HUDSettings[client] & HUD_CENTER) > 0)
 	{
 		int track = Shavit_GetClientTrack(target);
-		char[] sTrack = new char[32];
-		GetTrackName(client, track, sTrack, 32);
 
 		if(!IsFakeClient(target))
 		{
+			char[] sTrack = new char[32];
+
+			if(track != Track_Main)
+			{
+				GetTrackName(client, track, sTrack, 32);
+			}
+
 			float time = Shavit_GetClientTime(target);
 			int jumps = Shavit_GetClientJumps(target);
 			TimerStatus status = Shavit_GetTimerStatus(target);
@@ -826,6 +831,8 @@ void UpdateHUD(int client)
 
 			char[] sReplayLength = new char[32];
 			FormatSeconds(fReplayLength, sReplayLength, 32, false);
+
+			char[] sTrack = new char[32];
 
 			if(track != Track_Main)
 			{

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1682,10 +1682,14 @@ bool SaveCheckpoint(int client, int index)
 	cpcache[fCPStamina] = (gEV_Type != Engine_TF2)? GetEntPropFloat(target, Prop_Send, "m_flStamina"):0.0;
 	cpcache[iCPFlags] = GetEntityFlags(target);
 
-	if(gEV_Type == Engine_CSS)
+	if(gEV_Type != Engine_TF2)
 	{
 		cpcache[bCPDucked] = view_as<bool>(GetEntProp(target, Prop_Send, "m_bDucked"));
 		cpcache[bCPDucking] = view_as<bool>(GetEntProp(target, Prop_Send, "m_bDucking"));
+	}
+
+	if(gEV_Type == Engine_CSS)
+	{
 		cpcache[fCPDucktime] = GetEntPropFloat(target, Prop_Send, "m_flDucktime");
 	}
 
@@ -1804,12 +1808,12 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 	if(gEV_Type != Engine_TF2)
 	{
 		SetEntPropFloat(client, Prop_Send, "m_flStamina", cpcache[fCPStamina]);
+		SetEntProp(client, Prop_Send, "m_bDucked", cpcache[bCPDucked]);
+		SetEntProp(client, Prop_Send, "m_bDucking", cpcache[bCPDucking]);
 	}
 
 	if(gEV_Type == Engine_CSS)
 	{
-		SetEntProp(client, Prop_Send, "m_bDucked", cpcache[bCPDucked]);
-		SetEntProp(client, Prop_Send, "m_bDucking", cpcache[bCPDucking]);
 		SetEntPropFloat(client, Prop_Send, "m_flDucktime", cpcache[fCPDucktime]);
 	}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1592,12 +1592,8 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 			case 3:
 			{
 				CheckpointsCache cpcache[PCPCACHE_SIZE];
-				GetCheckpoint(param1, current, cpcache);
-
-				float pos[3];
-				CopyArray(cpcache[fCPPosition], pos, 3);
-
-				if(current < CP_MAX && !IsNullVector(pos))
+				
+				if(current < CP_MAX && GetCheckpoint(param1, current, cpcache))
 				{
 					gI_CheckpointsCache[param1][iCurrentCheckpoint]++;
 				}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -187,7 +187,7 @@ public Plugin myinfo =
 {
 	name = "[shavit] Miscellaneous",
 	author = "shavit",
-	description = "Miscellaneous stuff for shavit's bhop timer.",
+	description = "Miscellaneous features for shavit's bhop timer.",
 	version = SHAVIT_VERSION,
 	url = "https://github.com/shavitush/bhoptimer"
 }

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1544,8 +1544,8 @@ public void SQL_RR_Callback(Database db, DBResultSet results, const char[] error
 		return;
 	}
 
-	Menu m = new Menu(RRMenu_Handler);
-	m.SetTitle("%T:", "RecentRecords", client, gI_RecentLimit);
+	Menu menu = new Menu(RRMenu_Handler);
+	menu.SetTitle("%T:", "RecentRecords", client, gI_RecentLimit);
 
 	while(results.FetchRow())
 	{
@@ -1586,18 +1586,18 @@ public void SQL_RR_Callback(Database db, DBResultSet results, const char[] error
 		char[] sInfo = new char[192];
 		FormatEx(sInfo, 192, "%d;%s", results.FetchInt(0), sMap);
 
-		m.AddItem(sInfo, sDisplay);
+		menu.AddItem(sInfo, sDisplay);
 	}
 
-	if(m.ItemCount == 0)
+	if(menu.ItemCount == 0)
 	{
 		char[] sMenuItem = new char[64];
 		FormatEx(sMenuItem, 64, "%T", "WRMapNoRecords", client);
-		m.AddItem("-1", sMenuItem);
+		menu.AddItem("-1", sMenuItem);
 	}
 
-	m.ExitButton = true;
-	m.Display(client, 60);
+	menu.ExitButton = true;
+	menu.Display(client, 60);
 }
 
 public int RRMenu_Handler(Menu m, MenuAction action, int param1, int param2)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -989,6 +989,11 @@ public void SQL_DeleteCustom_Spawn_Callback(Database db, DBResultSet results, co
 
 void ClearCustomSpawn()
 {
+	if(Shavit_IsKZMap())
+	{
+		return;
+	}
+
 	for(int i = 0; i < TRACKS_SIZE; i++)
 	{
 		for(int j = 0; j < 3; j++)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -1310,7 +1310,6 @@ public Action Command_DeleteAllZones(int client, int args)
 	}
 
 	menu.ExitButton = true;
-
 	menu.Display(client, 20);
 
 	return Plugin_Handled;

--- a/addons/sourcemod/translations/shavit-misc.phrases.txt
+++ b/addons/sourcemod/translations/shavit-misc.phrases.txt
@@ -83,16 +83,6 @@
 		"#format"	"{1:d},{2:s},{3:s}"
 		"en"		"Checkpoint {1} is {2}empty{3}."
 	}
-	"MiscCheckpointsCrouchOn"
-	{
-		"#format"	"{1:s},{2:s}"
-		"en"		"You must {1}duck{2} while teleporting to this checkpoint."
-	}
-	"MiscCheckpointsCrouchOff"
-	{
-		"#format"	"{1:s},{2:s}"
-		"en"		"You must {1}stop ducking{2} while teleporting to this checkpoint."
-	}
 	// ---------- Menus ---------- //
 	"TeleportMenuTitle"
 	{


### PR DESCRIPTION
* Addressed CP menu bugs.
* Addressed an issue where donor plugins not always allowing players to use custom titles.
* Addressed an issue that caused chat titles to not always show.
* Fixed CS:S HUD not showing track properly.
* Fixed pre-zoned maps not saving spawn points if you just started the server.
* Removed duck/unduck requirement for checkpoints. Upon teleporting, the plugin will automatically adjust you to the state of the checkpoint.
* Fixed the 'to X rank' parameter when using percentile ranking in titles.
* Reworked gun shot muting. Now it supports TF2, and I've fixed the issue that caused others' gun shots to not play at all in CS:GO.
* Added `shavit_core_defaultstyle`. Usage: style ID. Add an exclamation mark as the prefix to ignore style cookies (i.e. "!3" to force everyone to play scroll when they join).