### PR TITLE
Copy missing style string in shavit-replay + docs

### DIFF
--- a/addons/sourcemod/configs/shavit-replay.cfg
+++ b/addons/sourcemod/configs/shavit-replay.cfg
@@ -17,7 +17,7 @@
 // Variables:
 // {map} - current map.
 // {style} - the style name.
-// {styletag} - the style's tag. See "styletag" in "shavit-styles.cfg".
+// {styletag} - the style's tag. See "clantag" in "shavit-styles.cfg".
 // {time} - formatted time for the WR currently being played.
 // {player} - the name of the player that holds the *record*, might be incorrect for replays from the beta version of bhoptimer.
 // {track} - track that the bot replays. Translated from the server's defined language.

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -848,6 +848,7 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 	for(int i = 0; i < styles; i++)
 	{
 		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
+		Shavit_GetStyleStrings(i, sClanTag, gS_StyleStrings[i][sClanTag], 128);
 		Shavit_GetStyleStrings(i, sStyleName, gS_StyleStrings[i][sStyleName], 128);
 		Shavit_GetStyleStrings(i, sShortName, gS_StyleStrings[i][sShortName], 128);
 	}


### PR DESCRIPTION
Currently the `{styletag}` variable in `shavit-replay.cfg` doesn't work as the style string is never copied to the buffer. This also makes the documentation a little clearer as the styles key is `clantag` not `styletag`.