### PR TITLE
Fixed a dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Includes a records system, map zones (start/end marks etc), bonuses, HUD with us
 * [SteamWorks](https://forums.alliedmods.net/showthread.php?t=229556)
 
 #  Installation:
-Refer to the [wiki page](https://github.com/shavitush/bhoptimer/wiki/1.-Installation).
+Refer to the [wiki page](https://github.com/shavitush/bhoptimer/wiki/1.-Installation-(from-source)).
 
 # Required plugins:
 `shavit-core` - completely required.  


### PR DESCRIPTION
The link for the installation wiki page was pointing to a dead link (what I assume was the old title of the page). It now points to the wiki again. I haven't gotten a chance to play much for a while but I still love what you're doing even if I can't experience it. I'm happy to help any way I can.