### PR TITLE
very good, yes... (2.3.0)

### DIFF
--- a/addons/sourcemod/configs/shavit-chat.cfg
+++ b/addons/sourcemod/configs/shavit-chat.cfg
@@ -4,6 +4,9 @@
 // "message" - a prefix to the message itself. Default: ""
 // "display" - display text in the !chatranks menu. "<n>" for a new line. Filling this is required.
 // "free" - is this title available for everyone to use? Default: "0"
+// "easteregg" - is this title an easter egg? Set to 1 to hide it from the !ranks menu. Default: "0"
+// "flag" - set to an admin flag to require privileges for this title. Can use an override instead of a flag.
+//          Combine with "free" "1" to instantly give access to privileged users. Default: ""
 // 
 // Global variables:
 // {default} - default color

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -26,6 +26,7 @@
 #define SHAVIT_VERSION "2.2.0"
 #define STYLE_LIMIT 256
 #define MAX_ZONES 64
+#define MAX_NAME_LENGTH_SQL 32
 
 // HUD
 #define HUD_NONE				(0)

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -23,7 +23,7 @@
 #endif
 #define _shavit_included
 
-#define SHAVIT_VERSION "2.2.0"
+#define SHAVIT_VERSION "2.3.0"
 #define STYLE_LIMIT 256
 #define MAX_ZONES 64
 #define MAX_NAME_LENGTH_SQL 32

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -1096,8 +1096,39 @@ bool HasRankAccess(int client, int rank)
 		return false;
 	}
 
-	static any aCache[view_as<int>(bCRFree)+1];
-	gA_ChatRanks.GetArray(rank, aCache[0], sizeof(aCache)); // a hack to only retrieve up to what we want
+	any[] aCache = new any[CRCACHE_SIZE];
+	gA_ChatRanks.GetArray(rank, aCache, view_as<int>(CRCACHE_SIZE));
+
+	char[] sFlag = new char[32];
+	strcopy(sFlag, 32, aCache[sCRAdminFlag]);
+
+	bool bFlagAccess = false;
+	int iSize = strlen(sFlag);
+
+	if(iSize == 0)
+	{
+		bFlagAccess = true;
+	}
+
+	else if(iSize == 1)
+	{
+		AdminFlag afFlag = view_as<AdminFlag>(0);
+		
+		if(FindFlagByChar(sFlag[0], afFlag))
+		{
+			bFlagAccess = GetAdminFlag(GetUserAdmin(client), afFlag);
+		}
+	}
+
+	else
+	{
+		bFlagAccess = CheckCommandAccess(client, sFlag, 0, true);
+	}
+
+	if(!bFlagAccess)
+	{
+		return false;
+	}
 
 	if(aCache[bCRFree])
 	{

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -44,6 +44,8 @@ enum ChatRanksCache
 	Float:fCRFrom,
 	Float:fCRTo,
 	bool:bCRFree,
+	bool:bCREasterEgg,
+	String:sCRAdminFlag[32],
 	String:sCRName[MAXLENGTH_NAME],
 	String:sCRMessage[MAXLENGTH_MESSAGE],
 	String:sCRDisplay[MAXLENGTH_DISPLAY],
@@ -237,10 +239,12 @@ bool LoadChatConfig()
 		}
 		
 		aChatTitle[bCRFree] = view_as<bool>(kv.GetNum("free", false));
-
+		aChatTitle[bCREasterEgg] = view_as<bool>(kv.GetNum("easteregg", false));
+		
 		kv.GetString("name", aChatTitle[sCRName], MAXLENGTH_NAME, "{name}");
 		kv.GetString("message", aChatTitle[sCRMessage], MAXLENGTH_MESSAGE, "");
 		kv.GetString("display", aChatTitle[sCRDisplay], MAXLENGTH_DISPLAY, "");
+		kv.GetString("flag", aChatTitle[sCRAdminFlag], 32, "");
 
 		if(strlen(aChatTitle[sCRDisplay]) > 0)
 		{
@@ -865,7 +869,36 @@ Action ShowRanksMenu(int client, int item)
 		any[] aCache = new any[CRCACHE_SIZE];
 		gA_ChatRanks.GetArray(i, aCache, view_as<int>(CRCACHE_SIZE));
 
-		// TODO: skip ranks with admin flags
+		char[] sFlag = new char[32];
+		strcopy(sFlag, 32, aCache[sCRAdminFlag]);
+
+		bool bFlagAccess = false;
+		int iSize = strlen(sFlag);
+
+		if(iSize == 0)
+		{
+			bFlagAccess = true;
+		}
+
+		else if(iSize == 1)
+		{
+			AdminFlag afFlag = view_as<AdminFlag>(0);
+			
+			if(FindFlagByChar(sFlag[0], afFlag))
+			{
+				bFlagAccess = GetAdminFlag(GetUserAdmin(client), afFlag);
+			}
+		}
+
+		else
+		{
+			bFlagAccess = CheckCommandAccess(client, sFlag, 0, true);
+		}
+
+		if(aCache[bCREasterEgg] || !bFlagAccess)
+		{
+			continue;
+		}
 
 		char[] sDisplay = new char[MAXLENGTH_DISPLAY];
 		strcopy(sDisplay, MAXLENGTH_DISPLAY, aCache[sCRDisplay]);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1400,9 +1400,9 @@ public void OnClientPutInServer(int client)
 		return;
 	}
 
-	char[] sName = new char[MAX_NAME_LENGTH];
-	GetClientName(client, sName, MAX_NAME_LENGTH);
-	ReplaceString(sName, MAX_NAME_LENGTH, "#", "?"); // to avoid this: https://user-images.githubusercontent.com/3672466/28637962-0d324952-724c-11e7-8b27-15ff021f0a59.png
+	char[] sName = new char[MAX_NAME_LENGTH_SQL];
+	GetClientName(client, sName, MAX_NAME_LENGTH_SQL);
+	ReplaceString(sName, MAX_NAME_LENGTH_SQL, "#", "?"); // to avoid this: https://user-images.githubusercontent.com/3672466/28637962-0d324952-724c-11e7-8b27-15ff021f0a59.png
 
 	int iLength = ((strlen(sName) * 2) + 1);
 	char[] sEscapedName = new char[iLength];

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -135,6 +135,7 @@ bool gB_StopChatSound = false;
 bool gB_HookedJump = false;
 char gS_LogPath[PLATFORM_MAX_PATH];
 int gI_GroundTicks[MAXPLAYERS+1];
+MoveType gMT_MoveType[MAXPLAYERS+1];
 
 // flags
 int gI_StyleFlag[STYLE_LIMIT];
@@ -795,11 +796,6 @@ void VelocityChanges(int data)
 	if(client == 0)
 	{
 		return;
-	}
-
-	if(view_as<float>(gA_StyleSettings[gI_Style[client]][fGravityMultiplier]) != 1.0)
-	{
-		SetEntityGravity(client, view_as<float>(gA_StyleSettings[gI_Style[client]][fGravityMultiplier]));
 	}
 
 	if(view_as<float>(gA_StyleSettings[gI_Style[client]][fSpeedMultiplier]) != 1.0)
@@ -1827,6 +1823,17 @@ public void PreThinkPost(int client)
 		{
 			sv_enablebunnyhopping.BoolValue = view_as<bool>(gA_StyleSettings[gI_Style[client]][bEnableBunnyhopping]);
 		}
+
+		MoveType mtMoveType = GetEntityMoveType(client);
+
+		if(view_as<float>(gA_StyleSettings[gI_Style[client]][fGravityMultiplier]) != 1.0 &&
+			(mtMoveType == MOVETYPE_WALK || mtMoveType == MOVETYPE_ISOMETRIC) &&
+			(gMT_MoveType[client] == MOVETYPE_LADDER || GetEntityGravity(client) == 1.0))
+		{
+			SetEntityGravity(client, view_as<float>(gA_StyleSettings[gI_Style[client]][fGravityMultiplier]));
+		}
+
+		gMT_MoveType[client] = mtMoveType;
 	}
 }
 
@@ -2272,4 +2279,6 @@ void UpdateStyleSettings(int client)
 	char[] sAiraccelerate = new char[8];
 	FloatToString(gA_StyleSettings[gI_Style[client]][fAiraccelerate], sAiraccelerate, 8);
 	sv_airaccelerate.ReplicateToClient(client, sAiraccelerate);
+
+	SetEntityGravity(client, view_as<float>(gA_StyleSettings[gI_Style[client]][fGravityMultiplier]));
 }

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -623,6 +623,14 @@ void TriggerHUDUpdate(int client, bool keysonly = false) // keysonly because CS:
 	}
 }
 
+void FixCSGOText(char[] buffer, int maxlen)
+{
+	if(gEV_Type == Engine_CSGO)
+	{
+		Format(buffer, maxlen, "<pre>%s</pre>", buffer);
+	}
+}
+
 void UpdateHUD(int client)
 {
 	int target = GetHUDTarget(client);
@@ -675,7 +683,8 @@ void UpdateHUD(int client)
 
 	if(strlen(sHintText) > 0)
 	{
-		PrintHintText(client, sHintText);
+		FixCSGOText(sHintText, 512);
+		PrintHintText(client, "%s", sHintText);
 	}
 
 	else if((gI_HUDSettings[client] & HUD_CENTER) > 0)
@@ -807,6 +816,7 @@ void UpdateHUD(int client)
 				}
 			}
 
+			FixCSGOText(sHintText, 512);
 			PrintHintText(client, "%s", sHintText);
 		}
 
@@ -816,6 +826,7 @@ void UpdateHUD(int client)
 
 			if(style == -1)
 			{
+				FixCSGOText(sHintText, 512);
 				PrintHintText(client, "%T", (gEV_Type != Engine_TF2)? "NoReplayData":"NoReplayDataTF2", client);
 
 				return;
@@ -864,6 +875,7 @@ void UpdateHUD(int client)
 				Format(sHintText, 512, "%s\n%T: %d", sHintText, "HudSpeedText", client, iSpeed);
 			}
 
+			FixCSGOText(sHintText, 512);
 			PrintHintText(client, "%s", sHintText);
 		}
 	}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -990,7 +990,7 @@ void UpdateSpectatorList(int client, Panel panel, bool &draw)
 
 	for(int i = 1; i <= MaxClients; i++)
 	{
-		if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetClientTeam(i) < 1 || GetHUDTarget(i) != client)
+		if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetClientTeam(i) < 1 || GetHUDTarget(i) != target)
 		{
 			continue;
 		}
@@ -1131,7 +1131,7 @@ void UpdateKeyHint(int client)
 
 				for(int i = 1; i <= MaxClients; i++)
 				{
-					if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetClientTeam(i) < 1 || GetHUDTarget(i) != client)
+					if(i == client || !IsValidClient(i) || IsFakeClient(i) || !IsClientObserver(i) || GetClientTeam(i) < 1 || GetHUDTarget(i) != target)
 					{
 						continue;
 					}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -832,6 +832,7 @@ void UpdateHUD(int client)
 				return;
 			}
 
+			iSpeed = RoundToNearest(float(iSpeed) / view_as<float>(gA_StyleSettings[style][fSpeedMultiplier]));			
 			track = Shavit_GetReplayBotTrack(target);
 
 			float fReplayTime = Shavit_GetReplayTime(style, track);

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1518,7 +1518,7 @@ public Action Command_Save(int client, int args)
 
 	int iMaxCPs = GetMaxCPs(client);
 	
-	if(gI_CheckpointsCache[client][iCheckpoints] >= iMaxCPs)
+	if(gI_CheckpointsCache[client][iCheckpoints] > iMaxCPs)
 	{
 		return Plugin_Handled;
 	}
@@ -1547,25 +1547,13 @@ public Action Command_Save(int client, int args)
 		}
 	}
 
-	bool bSegmenting = CanSegment(client);
-	bool bSaved = false;
+	bool bOverflow = index >= iMaxCPs;
 
-	if(!bSegmenting)
+	if(SaveCheckpoint(client, index, bOverflow))
 	{
-		bSaved = SaveCheckpoint(client, gI_CheckpointsCache[client][iCheckpoints]);
-		gI_CheckpointsCache[client][iCurrentCheckpoint] = ++gI_CheckpointsCache[client][iCheckpoints];
-	}
-	
-	else
-	{
-		bool bOverflow = gI_CheckpointsCache[client][iCheckpoints] >= iMaxCPs;
-		bSaved = SaveCheckpoint(client, gI_CheckpointsCache[client][iCheckpoints], bOverflow);
-		gI_CheckpointsCache[client][iCurrentCheckpoint] = (bOverflow)? iMaxCPs:++gI_CheckpointsCache[client][iCheckpoints];
-	}
+		gI_CheckpointsCache[client][iCurrentCheckpoint] = (bOverflow)? (iMaxCPs - 1):(index + 1);
 
-	if(bSaved)
-	{
-		Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+		Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gI_CheckpointsCache[client][iCurrentCheckpoint], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 	}
 
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1914,7 +1914,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 		cpcache[bCPSegmented] = false;
 	}
 
-	cpcache[bCPSpectated] = (client != target);
+	cpcache[bCPSpectated] = (client != target || bCPSegmented); // spoof a segmented cp to avoid abuse(? my brain is melting rn)
 
 	if(overflow)
 	{

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1984,16 +1984,9 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 		return;
 	}
 
-	bool bInStart = Shavit_InsideZone(client, Zone_Start, -1);
-
-	if(bInStart)
+	if(Shavit_InsideZone(client, Zone_Start, -1))
 	{
 		Shavit_StopTimer(client);
-	}
-	
-	if(!cpcache[bCPSegmented] || GetClientSerial(client) != cpcache[iCPSerial])
-	{
-		Shavit_SetPracticeMode(client, true, !bInStart);
 	}
 
 	any snapshot[TIMERSNAPSHOT_SIZE];
@@ -2018,6 +2011,11 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 	TeleportEntity(client, pos,
 		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0 || cpcache[bCPSegmented])? ang:NULL_VECTOR,
 		vel);
+
+	if(!cpcache[bCPSegmented] || GetClientSerial(client) != cpcache[iCPSerial])
+	{
+		Shavit_SetPracticeMode(client, true, true);
+	}
 
 	MoveType mt = cpcache[mtCPMoveType];
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -54,6 +54,7 @@ enum CheckpointsCache
 	ArrayList:aCPFrames,
 	bool:bCPSegmented,
 	iCPSerial,
+	bool:bCPPractice,
 	iCPGroundEntity,
 	PCPCACHE_SIZE
 }
@@ -1914,6 +1915,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 	}
 
 	cpcache[iCPSerial] = GetClientSerial(target);
+	cpcache[bCPPractice] = Shavit_IsPracticeMode(target);
 
 	if(overflow)
 	{
@@ -2012,7 +2014,7 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0 || cpcache[bCPSegmented])? ang:NULL_VECTOR,
 		vel);
 
-	if(!cpcache[bCPSegmented] || GetClientSerial(client) != cpcache[iCPSerial])
+	if(cpcache[bCPPractice] || !cpcache[bCPSegmented] || GetClientSerial(client) != cpcache[iCPSerial])
 	{
 		Shavit_SetPracticeMode(client, true, true);
 	}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1667,7 +1667,6 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 {
 	if(action == MenuAction_Select)
 	{
-		bool bSegmenting = CanSegment(param1);
 		int iMaxCPs = GetMaxCPs(param1);
 		int iCurrent = gI_CheckpointsCache[param1][iCurrentCheckpoint];
 
@@ -1675,6 +1674,7 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 		{
 			case 0:
 			{
+				bool bSegmenting = CanSegment(param1);
 				bool bOverflow = gI_CheckpointsCache[param1][iCheckpoints] >= iMaxCPs;
 
 				if(!bSegmenting)
@@ -1685,7 +1685,7 @@ public int MenuHandler_Checkpoints(Menu menu, MenuAction action, int param1, int
 						return 0;
 					}
 
-					SaveCheckpoint(param1, gI_CheckpointsCache[param1][iCheckpoints]);
+					SaveCheckpoint(param1, ++gI_CheckpointsCache[param1][iCheckpoints]);
 					gI_CheckpointsCache[param1][iCurrentCheckpoint] = gI_CheckpointsCache[param1][iCheckpoints];
 				}
 				
@@ -1956,7 +1956,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 
 void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 {
-	if(index < 0 || index >= gI_MaxCP || (!gB_Checkpoints && !CanSegment(client)))
+	if(index < 0 || index > gI_MaxCP || (!gB_Checkpoints && !CanSegment(client)))
 	{
 		return;
 	}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -39,7 +39,6 @@ enum CheckpointsCache
 	Float:fCPPosition[3],
 	Float:fCPAngles[3],
 	Float:fCPVelocity[3],
-	Float:fCPBaseVelocity[3],
 	MoveType:mtCPMoveType,
 	Float:fCPGravity,
 	Float:fCPSpeed,
@@ -1808,9 +1807,6 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 	GetEntPropVector(target, Prop_Data, "m_vecAbsVelocity", temp);
 	CopyArray(temp, cpcache[fCPVelocity], 3);
 
-	GetEntPropVector(target, Prop_Data, "m_vecBaseVelocity", temp);
-	CopyArray(temp, cpcache[fCPBaseVelocity], 3);
-
 	char[] sTargetname = new char[32];
 	GetEntPropString(target, Prop_Data, "m_iName", sTargetname, 32);
 
@@ -2002,20 +1998,21 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 	float ang[3];
 	CopyArray(cpcache[fCPAngles], ang, 3);
 
-	TeleportEntity(client, pos,
-		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0 || cpcache[bCPSegmented])? ang:NULL_VECTOR,
-		NULL_VECTOR);
+	float vel[3];
 
 	if((gI_CheckpointsSettings[client] & CP_VELOCITY) > 0 || cpcache[bCPSegmented])
 	{
-		float basevel[3];
-		CopyArray(cpcache[fCPBaseVelocity], basevel, 3);
-		SetEntPropVector(client, Prop_Data, "m_vecBaseVelocity", basevel);
-
-		float vel[3];
 		CopyArray(cpcache[fCPVelocity], vel, 3);
-		SetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", vel);
 	}
+
+	else
+	{
+		vel = NULL_VECTOR;
+	}
+
+	TeleportEntity(client, pos,
+		((gI_CheckpointsSettings[client] & CP_ANGLES) > 0 || cpcache[bCPSegmented])? ang:NULL_VECTOR,
+		vel);
 
 	MoveType mt = cpcache[mtCPMoveType];
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -301,7 +301,7 @@ public void OnPluginStart()
 
 	// cvars and stuff
 	gCV_GodMode = CreateConVar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.", 0, true, 0.0, true, 3.0);
-	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "1", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding.", 0, true, 0.0, true, 4.0);
+	gCV_PreSpeed = CreateConVar("shavit_misc_prespeed", "1", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.", 0, true, 0.0, true, 4.0);
 	gCV_HideTeamChanges = CreateConVar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = CreateConVar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnRestart = CreateConVar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if they use the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -1010,15 +1010,13 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 		if(gI_PreSpeed == 1 || gI_PreSpeed >= 3)
 		{
-			float fLimit = gF_PrestrafeLimit;
-
 			float fSpeed[3];
 			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
+			float fLimit = view_as<float>(gA_StyleSettings[gI_Style[client]][fRunspeed]) + gF_PrestrafeLimit;
+
 			if(gI_PreSpeed < 4)
 			{
-				fLimit = view_as<float>(gA_StyleSettings[gI_Style[client]][fRunspeed]) + gF_PrestrafeLimit;
-
 				// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 				// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
 				if(fSpeed[2] > 0.0)

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1525,17 +1525,16 @@ public Action Command_Save(int client, int args)
 		return Plugin_Handled;
 	}
 
-	int index = gI_CheckpointsCache[client][iCheckpoints] + 1;
-
-	if(index > iMaxCPs)
-	{
-		index = iMaxCPs;
-	}
-
 	bool bOverflow = gI_CheckpointsCache[client][iCheckpoints] >= iMaxCPs;
+	int index = gI_CheckpointsCache[client][iCheckpoints] + 1;
 
 	if(!bSegmenting)
 	{
+		if(index > iMaxCPs)
+		{
+			index = iMaxCPs;
+		}
+
 		if(bOverflow)
 		{
 			Shavit_PrintToChat(client, "%T", "MiscCheckpointsOverflow", client, index, gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
@@ -1550,10 +1549,13 @@ public Action Command_Save(int client, int args)
 		}
 	}
 	
-	else if(SaveCheckpoint(client, index, bOverflow))
+	else
 	{
-		gI_CheckpointsCache[client][iCurrentCheckpoint] = (bOverflow)? iMaxCPs:++gI_CheckpointsCache[client][iCheckpoints];
-		Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gI_CheckpointsCache[client][iCurrentCheckpoint], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+		if(SaveCheckpoint(client, index, bOverflow))
+		{
+			gI_CheckpointsCache[client][iCurrentCheckpoint] = (bOverflow)? iMaxCPs:++gI_CheckpointsCache[client][iCheckpoints];
+			Shavit_PrintToChat(client, "%T", "MiscCheckpointsSaved", client, gI_CheckpointsCache[client][iCurrentCheckpoint], gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
+		}
 	}
 
 	return Plugin_Handled;
@@ -1929,7 +1931,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 				continue; // ???
 			}
 
-			if(i == 0)
+			if(i == 1)
 			{
 				delete cpcacheold[aCPFrames];
 				gSM_Checkpoints.Remove(sKey);

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1549,7 +1549,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 				buttons &= ~IN_ATTACK2;
 			}
 
-			if(gB_BotPlusUse)
+			if(!gB_BotPlusUse)
 			{
 				buttons &= ~IN_USE;
 			}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1599,7 +1599,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 		}
 	}
 
-	else if(Shavit_GetTimerStatus(client) == Timer_Running && ReplayEnabled(Shavit_GetBhopStyle(client)) && Shavit_GetTimerStatus(client) == Timer_Running)
+	else if(ReplayEnabled(Shavit_GetBhopStyle(client)) && Shavit_GetTimerStatus(client) == Timer_Running)
 	{
 		gA_PlayerFrames[client].Resize(gI_PlayerFrames[client] + 1);
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -110,6 +110,7 @@ ConVar gCV_DefaultTeam = null;
 ConVar gCV_CentralBot = null;
 ConVar gCV_BotShooting = null;
 ConVar gCV_BotPlusUse = null;
+ConVar gCV_BotWeapon = null;
 
 // cached cvars
 bool gB_Enabled = true;
@@ -119,6 +120,7 @@ int gI_DefaultTeam = 3;
 bool gB_CentralBot = true;
 int gI_BotShooting = 3;
 bool gB_BotPlusUse = true;
+char gS_BotWeapon[32] = "";
 
 // timer settings
 int gI_Styles = 0;
@@ -214,6 +216,7 @@ public void OnPluginStart()
 	gCV_CentralBot = CreateConVar("shavit_replay_centralbot", "1", "Have one central bot instead of one bot per replay.\nTriggered with !replay.\nRestart the map for changes to take effect.\nThe disabled setting is not supported - use at your own risk.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_BotShooting = CreateConVar("shavit_replay_botshooting", "3", "Attacking buttons to allow for bots.\n0 - none\1 - +attack\n2 - +attack2\n3 - both", 0, true, 0.0, true, 3.0);
 	gCV_BotPlusUse = CreateConVar("shavit_replay_botplususe", "1", "Allow bots to use +use?", 0, true, 0.0, true, 1.0);
+	gCV_BotWeapon = CreateConVar("shavit_replay_botweapon", "", "Choose which weapon the bot will hold.\nLeave empty to use the default.\nSet to \"none\" to have none.\nExample: weapon_usp");
 
 	gCV_Enabled.AddChangeHook(OnConVarChanged);
 	gCV_ReplayDelay.AddChangeHook(OnConVarChanged);
@@ -222,6 +225,7 @@ public void OnPluginStart()
 	gCV_CentralBot.AddChangeHook(OnConVarChanged);
 	gCV_BotShooting.AddChangeHook(OnConVarChanged);
 	gCV_BotPlusUse.AddChangeHook(OnConVarChanged);
+	gCV_BotWeapon.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 
@@ -258,6 +262,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gB_CentralBot = gCV_CentralBot.BoolValue;
 	gI_BotShooting = gCV_BotShooting.IntValue;
 	gB_BotPlusUse = gCV_BotPlusUse.BoolValue;
+	gCV_BotWeapon.GetString(gS_BotWeapon, 32);
 
 	if(convar == gCV_CentralBot)
 	{
@@ -1269,10 +1274,39 @@ void UpdateReplayInfo(int client, int style, float time, int track)
 			}
 		}
 
-		// Spectating is laggy if the player has no weapons
-		if(gEV_Type != Engine_TF2 && GetPlayerWeaponSlot(client, CS_SLOT_KNIFE) == -1)
+		if(gEV_Type != Engine_TF2 && strlen(gS_BotWeapon) > 0)
 		{
-			GivePlayerItem(client, "weapon_knife");
+			int iWeapon = GetEntPropEnt(client, Prop_Data, "m_hActiveWeapon");
+
+			if(StrEqual(gS_BotWeapon, "none"))
+			{
+				if(iWeapon != -1 && IsValidEntity(iWeapon))
+				{
+					CS_DropWeapon(client, iWeapon, false);
+					AcceptEntityInput(iWeapon, "Kill");
+				}
+			}
+
+			else
+			{
+				char[] sClassname = new char[32];
+
+				if(iWeapon != -1 && IsValidEntity(iWeapon))
+				{
+					GetEntityClassname(iWeapon, sClassname, 32);
+
+					if(!StrEqual(gS_BotWeapon, sClassname))
+					{
+						CS_DropWeapon(client, iWeapon, false);
+						AcceptEntityInput(iWeapon, "Kill");
+					}
+				}
+
+				else
+				{
+					GivePlayerItem(client, gS_BotWeapon);
+				}
+			}
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -109,6 +109,7 @@ ConVar gCV_TimeLimit = null;
 ConVar gCV_DefaultTeam = null;
 ConVar gCV_CentralBot = null;
 ConVar gCV_BotShooting = null;
+ConVar gCV_BotPlusUse = null;
 
 // cached cvars
 bool gB_Enabled = true;
@@ -117,6 +118,7 @@ float gF_TimeLimit = 5400.0;
 int gI_DefaultTeam = 3;
 bool gB_CentralBot = true;
 int gI_BotShooting = 3;
+bool gB_BotPlusUse = true;
 
 // timer settings
 int gI_Styles = 0;
@@ -211,6 +213,7 @@ public void OnPluginStart()
 	gCV_DefaultTeam = CreateConVar("shavit_replay_defaultteam", "3", "Default team to make the bots join, if possible.\n2 - Terrorists/RED\n3 - Counter Terrorists/BLU", 0, true, 2.0, true, 3.0);
 	gCV_CentralBot = CreateConVar("shavit_replay_centralbot", "1", "Have one central bot instead of one bot per replay.\nTriggered with !replay.\nRestart the map for changes to take effect.\nThe disabled setting is not supported - use at your own risk.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_BotShooting = CreateConVar("shavit_replay_botshooting", "3", "Attacking buttons to allow for bots.\n0 - none\1 - +attack\n2 - +attack2\n3 - both", 0, true, 0.0, true, 3.0);
+	gCV_BotPlusUse = CreateConVar("shavit_replay_botplususe", "1", "Allow bots to use +use?", 0, true, 0.0, true, 1.0);
 
 	gCV_Enabled.AddChangeHook(OnConVarChanged);
 	gCV_ReplayDelay.AddChangeHook(OnConVarChanged);
@@ -218,6 +221,7 @@ public void OnPluginStart()
 	gCV_DefaultTeam.AddChangeHook(OnConVarChanged);
 	gCV_CentralBot.AddChangeHook(OnConVarChanged);
 	gCV_BotShooting.AddChangeHook(OnConVarChanged);
+	gCV_BotPlusUse.AddChangeHook(OnConVarChanged);
 
 	AutoExecConfig();
 
@@ -253,6 +257,7 @@ public void OnConVarChanged(ConVar convar, const char[] oldValue, const char[] n
 	gI_DefaultTeam = gCV_DefaultTeam.IntValue;
 	gB_CentralBot = gCV_CentralBot.BoolValue;
 	gI_BotShooting = gCV_BotShooting.IntValue;
+	gB_BotPlusUse = gCV_BotPlusUse.BoolValue;
 
 	if(convar == gCV_CentralBot)
 	{
@@ -1542,6 +1547,11 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 			if((gI_BotShooting & iBotShooting_Attack2) == 0)
 			{
 				buttons &= ~IN_ATTACK2;
+			}
+
+			if(gB_BotPlusUse)
+			{
+				buttons &= ~IN_USE;
 			}
 
 			MoveType mt = MOVETYPE_NOCLIP;

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -2308,7 +2308,7 @@ public void SQL_UpdateLeaderboards_Callback(Database db, DBResultSet results, co
 
 int GetRankForTime(int style, float time, int track)
 {
-	if(time < gF_WRTime[style][track] || gI_RecordAmount[style][track] <= 0)
+	if(time <= gF_WRTime[style][track] || gI_RecordAmount[style][track] <= 0)
 	{
 		return 1;
 	}

--- a/addons/sourcemod/translations/shavit-chat.phrases.txt
+++ b/addons/sourcemod/translations/shavit-chat.phrases.txt
@@ -59,4 +59,42 @@
 	{
 		"en"		"Custom\nUse custom chat settings. See !cchelp for more information."
 	}
+	"ChatRanksMenu"
+	{
+		"en"		"Obtainable chat ranks:\nSelect an entry to preview.\n"
+	}
+	"ChatRanksMenu_Unranked"
+	{
+		"en"		"Unranked"
+	}
+	"ChatRanksMenu_Points"
+	{
+		"#format"	"{1:d}"
+		"en"		"Have {1} points"
+	}
+	"ChatRanksMenu_Points_Ranged"
+	{
+		"#format"	"{1:d},{2:d}"
+		"en"		"Have between {1} and {2} points"
+	}
+	"ChatRanksMenu_Flat"
+	{
+		"#format"	"{1:d}"
+		"en"		"Ranked #{1} or better"
+	}
+	"ChatRanksMenu_Flat_Ranged"
+	{
+		"#format"	"{1:d},{2:d}"
+		"en"		"Ranked between #{1} and #{2}"
+	}
+	"ChatRanksMenu_Percentage"
+	{
+		"#format"	"{1:.1f},{2:c}"
+		"en"		"Top {1}{2}"
+	}
+	"ChatRanksMenu_Percentage_Ranged"
+	{
+		"#format"	"{1:.1f},{2:c},{3:.1f},{4:c}"
+		"en"		"Between top {1}{2} and {3}{4}"
+	}
 }

--- a/addons/sourcemod/translations/shavit-misc.phrases.txt
+++ b/addons/sourcemod/translations/shavit-misc.phrases.txt
@@ -83,6 +83,10 @@
 		"#format"	"{1:d},{2:s},{3:s}"
 		"en"		"Checkpoint {1} is {2}empty{3}."
 	}
+	"MiscCheckpointsOverflow"
+	{
+		"en"		"Unable to save due to checkpoint overflow."
+	}
 	"MiscSegmentedCommand"
 	{
 		"#format"	"{1:s},{2:s}"


### PR DESCRIPTION
* Fixed errors.
* Reworked checkpoints to not be so poopoo.
* Fixed memory leak with checkpoints.
* Fixed low gravity styles being trash with boosters.
* Fixed HUD showing wrong speeds for slower/faster styles.
* Fixed shavit_misc_prespeed 4. Set to 4 and combine with shavit_core_nozaxisspeed 1 to get the same behavior that SourceCode timer has.
* Added shavit_replay_botweapon. Choose whatever weapon you want the bots to have.
* Added shavit_replay_botplususe. You can disable bots from using +use.
* Added !ranks command in chat module. This shows a list with all* the visible chat titles. Select an entry in the menu to preview the chat rank!
  * Easter eggs and privileged titles are excluded from this menu.
* Added `"easteregg"` and `"flag"` settings to chat titles. The former decides on if it shows up in the !ranks menu. The latter limits this title to the flag/override you choose.