### PR TITLE
Add forwards for topleft hud and clantag changes

### DIFF
--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -576,6 +576,37 @@ forward void Shavit_OnReplayStart(int client);
 forward void Shavit_OnReplayEnd(int client);
 
 /**
+ * Called when top left HUD updates.
+ *
+ * @param client					Client index that recieves the hud.
+ * @param target					Client index that recieves the hud.
+ * @param topleft					Reference to the HUD buffer.
+ * @param topleftlength				Max length of the topleft buffer.
+ * @return							Plugin_Handled or Plugin_Stop to block the HUD message from appearing. Anything else to pass along new values.
+ */
+forward Action Shavit_OnTopLeftHUD(int client, int target, char[] topleft, const int topleftlength);
+
+/**
+ * Called before clan tag variables are processed
+ *
+ * @param client					Client index.
+ * @param clantag					Reference to the clan tag buffer.
+ * @param clantaglength				Max length of the customtag buffer.
+ * @return							Plugin_Handled or Plugin_Stop to block the clan tag from changing. Anything else to pass along new values.
+ */
+forward Action Shavit_OnClanTagChangePre(int client, char[] clantag, int clantaglength);
+
+/**
+ * Called after clan tags are changed
+ *
+ * @param client					Client index.
+ * @param customtag					Reference to the custom clan tag buffer.
+ * @param customtaglength			Max length of the customtag buffer.
+ * @noreturn							
+ */
+forward void Shavit_OnClanTagChangePost(int client, char[] customtag, int customtaglength);
+
+/**
  * Returns the game type the server is running.
  *
  * @return							Game type. (See "enum ServerGame")

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -81,6 +81,9 @@ enum struct color_t
 // game type (CS:S/CS:GO/TF2)
 EngineVersion gEV_Type = Engine_Unknown;
 
+// forwards
+Handle gH_Forwards_OnTopLeftHUD = null;
+
 // modules
 bool gB_Replay = false;
 bool gB_Zones = false;
@@ -133,6 +136,10 @@ public Plugin myinfo =
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
+	// forwards
+	gH_Forwards_OnTopLeftHUD = CreateGlobalForward("Shavit_OnTopLeftHUD", ET_Event, Param_Cell, Param_Cell, Param_String, Param_Cell);
+
+
 	// natives
 	CreateNative("Shavit_ForceHUDUpdate", Native_ForceHUDUpdate);
 	CreateNative("Shavit_GetHUDSettings", Native_GetHUDSettings);
@@ -1583,6 +1590,19 @@ void UpdateTopLeftHUD(int client, bool wait)
 			else if(fSelfPB != 0.0)
 			{
 				Format(sTopLeft, 128, "%s\n%s (#%d)", sTopLeft, sSelfPB, Shavit_GetRankForTime(style, fSelfPB, track));
+			}
+
+			Action result = Plugin_Continue;
+			Call_StartForward(gH_Forwards_OnTopLeftHUD);
+			Call_PushCell(client);
+			Call_PushCell(target);
+			Call_PushStringEx(sTopLeft, 128, SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
+			Call_PushCell(128);
+			Call_Finish(result);
+			
+			if(result != Plugin_Continue && result != Plugin_Changed)
+			{
+				return;
 			}
 
 			SetHudTextParams(0.01, 0.01, 2.5, 255, 255, 255, 255, 0, 0.0, 0.0, 0.0);

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -147,6 +147,10 @@ ConVar gCV_SpectatorList = null;
 ConVar gCV_MaxCP = null;
 ConVar gCV_MaxCP_Segmented = null;
 
+// forwards
+Handle gH_Forwards_OnClanTagChangePre = null;
+Handle gH_Forwards_OnClanTagChangePost = null;
+
 // cached cvars
 int gI_HumanTeam = 0;
 
@@ -176,6 +180,10 @@ public Plugin myinfo =
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
+	// forwards
+	gH_Forwards_OnClanTagChangePre = CreateGlobalForward("Shavit_OnClanTagChangePre", ET_Event, Param_Cell, Param_String, Param_Cell);
+	gH_Forwards_OnClanTagChangePost = CreateGlobalForward("Shavit_OnClanTagChangePost", ET_Event, Param_Cell, Param_String, Param_Cell);
+
 	gB_Late = late;
 
 	return APLRes_Success;
@@ -888,7 +896,25 @@ void UpdateClanTag(int client)
 	ReplaceString(sCustomTag, 32, "{tr}", sTrack);
 	ReplaceString(sCustomTag, 32, "{rank}", sRank);
 
+	Action result = Plugin_Continue;
+	Call_StartForward(gH_Forwards_OnClanTagChangePre);
+	Call_PushCell(client);
+	Call_PushStringEx(sTag, 32, SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
+	Call_PushCell(32);
+	Call_Finish(result);
+	
+	if(result != Plugin_Continue && result != Plugin_Changed)
+	{
+		return;
+	}
+
 	CS_SetClientClanTag(client, sCustomTag);
+
+	Call_StartForward(gH_Forwards_OnClanTagChangePost);
+	Call_PushCell(client);
+	Call_PushStringEx(sCustomTag, 32, SM_PARAM_STRING_COPY, SM_PARAM_COPYBACK);
+	Call_PushCell(32);
+	Call_Finish();
 }
 
 void RemoveRagdoll(int client)


### PR DESCRIPTION
This adds 3 new forwards that will let people modify the topleft hud and clantags for individual clients.