### PR TITLE
Start zone HUD adjustments

### DIFF
--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1173,7 +1173,17 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 		{
 			if(gB_Rankings && (gI_HUD2Settings[client] & HUD2_MAPTIER) == 0)
 			{
-				FormatEx(sZoneHUD, 32, "%T\n\n", "HudZoneTier", client, Shavit_GetMapTier(gS_Map));
+				if(data.iTrack == Track_Main)
+				{
+					FormatEx(sZoneHUD, 32, "%T", "HudZoneTier", client, Shavit_GetMapTier(gS_Map));
+				}
+
+				else
+				{
+					GetTrackName(client, data.iTrack, sZoneHUD, 32);
+				}
+
+				Format(sZoneHUD, 32, "\t\t%s\n\n", sZoneHUD);
 				AddHUDLine(buffer, maxlen, sZoneHUD, iLines);
 				iLines++;
 			}


### PR DESCRIPTION
This replaces the tier text in non-main start zones with the track name, as well as indenting the first line to center it.

Preview:
![image](https://user-images.githubusercontent.com/15663890/54071685-3bdecd00-4268-11e9-952c-e0a9a24d66c0.png)
![image](https://user-images.githubusercontent.com/15663890/54071683-36818280-4268-11e9-9332-7ecc1c397c60.png)

Closes #748 