### PR TITLE
Added "Shavit_GetClientFrameCount" and "Shavit_GetReplayFrames"

### DIFF
--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1180,6 +1180,23 @@ native int Shavit_GetReplayBotCurrentFrame(int style);
 native int Shavit_GetReplayFrameCount(int style, int track);
 
 /**
+ * Retrieves the replay data for the given style and track.
+ *
+ * @param style						Style.
+ * @param track						Track.
+ * @return							ArrayList with proper replay data, or null if there is no recorded data.
+ */
+native ArrayList Shavit_GetReplayFrames(int style, int track);
+
+/**
+ * Retrieves a client's frame count.
+ *
+ * @param client					Client Index.
+ * @return							Current number of frames.
+ */
+native int Shavit_GetClientFrameCount(int client);
+
+/**
  * Retrieves a replay's total length in seconds.
  *
  * @param style						Style.
@@ -1560,6 +1577,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetRankForTime");
 	MarkNativeAsOptional("Shavit_GetRecordAmount");
 	MarkNativeAsOptional("Shavit_GetReplayBotCurrentFrame");
+	MarkNativeAsOptional("Shavit_GetClientFrameCount");
 	MarkNativeAsOptional("Shavit_GetReplayBotFirstFrame");
 	MarkNativeAsOptional("Shavit_GetReplayBotIndex");
 	MarkNativeAsOptional("Shavit_GetReplayBotStyle");
@@ -1567,6 +1585,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetReplayBotType");
 	MarkNativeAsOptional("Shavit_GetReplayData");
 	MarkNativeAsOptional("Shavit_GetReplayFrameCount");
+	MarkNativeAsOptional("Shavit_GetReplayFrames");
 	MarkNativeAsOptional("Shavit_GetReplayLength");
 	MarkNativeAsOptional("Shavit_GetReplayName");
 	MarkNativeAsOptional("Shavit_GetReplayTime");

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -179,12 +179,14 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 {
 	CreateNative("Shavit_DeleteReplay", Native_DeleteReplay);
 	CreateNative("Shavit_GetReplayBotCurrentFrame", Native_GetReplayBotIndex);
+	CreateNative("Shavit_GetClientFrameCount", Native_GetClientFrameCount);
 	CreateNative("Shavit_GetReplayBotFirstFrame", Native_GetReplayBotFirstFrame);
 	CreateNative("Shavit_GetReplayBotIndex", Native_GetReplayBotIndex);
 	CreateNative("Shavit_GetReplayBotStyle", Native_GetReplayBotStyle);
 	CreateNative("Shavit_GetReplayBotTrack", Native_GetReplayBotTrack);
 	CreateNative("Shavit_GetReplayBotType", Native_GetReplayBotType);
 	CreateNative("Shavit_GetReplayData", Native_GetReplayData);
+	CreateNative("Shavit_GetReplayFrames", Native_GetReplayFrames);
 	CreateNative("Shavit_GetReplayFrameCount", Native_GetReplayFrameCount);
 	CreateNative("Shavit_GetReplayLength", Native_GetReplayLength);
 	CreateNative("Shavit_GetReplayName", Native_GetReplayName);
@@ -587,9 +589,30 @@ public int Native_GetReplayData(Handle handler, int numParams)
 	return view_as<int>(frames);
 }
 
+public int Native_GetReplayFrames(Handle handler, int numParams)
+{
+	int track = GetNativeCell(1);
+	int style = GetNativeCell(2);
+	ArrayList frames = null;
+
+	if(gA_Frames[track][style] != null)
+	{
+		ArrayList temp = gA_Frames[track][style].Clone();
+		frames = view_as<ArrayList>(CloneHandle(temp, handler));
+		delete temp;
+	}
+
+	return view_as<int>(frames);
+}
+
 public int Native_GetReplayFrameCount(Handle handler, int numParams)
 {
 	return gA_FrameCache[GetNativeCell(1)][GetNativeCell(2)].iFrameCount;
+}
+
+public int Native_GetClientFrameCount(Handle handler, int numParams)
+{
+	return gA_PlayerFrames[GetNativeCell(1)].Length;
 }
 
 public int Native_GetReplayLength(Handle handler, int numParams)


### PR DESCRIPTION
Adds 2 new natives. Shavit_GetClientFrameCount to retrieve the number of frames a client has in their run. and Shavit_GetReplayFrames to retrieve a copy of the replay bot data for the given style and track.