### PR TITLE
Remove extra prerun frame, Add dynamic time difference

### DIFF
--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1740,6 +1740,15 @@ native int Shavit_GetPlayerPreFrame(int client);
  */
 native void Shavit_SetPlayerPreFrame(int client, int preframe);
 
+/*
+ * Get preframe length from specific replay
+ * @param stlye						Style
+ * @param track						Track 
+ *
+ * @return Replay preframe 
+ */
+native int Shavit_GetReplayPreFrameCount(int style, int track);
+
 // same as Shavit_PrintToChat() but loops through the whole server
 // code stolen from the base halflife.inc file
 stock void Shavit_PrintToChatAll(const char[] format, any ...)
@@ -1869,6 +1878,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_SetCurrentCheckpoint");
 	MarkNativeAsOptional("Shavit_GetPlayerPreFrame");
 	MarkNativeAsOptional("Shavit_GetPlayerTimerframe");
-	MarkNativeAsOptional("Shavit_SetPlayerPreFrame");  
+	MarkNativeAsOptional("Shavit_SetPlayerPreFrame");
+	MarkNativeAsOptional("Shavit_GetReplayPreFrameCount");
 }
 #endif

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1743,6 +1743,7 @@ native void Shavit_SetPlayerPreFrame(int client, int preframe);
 
 /*
  * Get preframe length from specific replay
+ *
  * @param stlye						Style
  * @param track						Track 
  *
@@ -1751,7 +1752,25 @@ native void Shavit_SetPlayerPreFrame(int client, int preframe);
 native int Shavit_GetReplayPreFrameCount(int style, int track);
 
 // I need a native English speaker to polish these two natives >_>  ---- deadwinter
+
+/* description here
+ * 
+ * @param clinet					Client index
+ * @param stlye						Style
+ * @param track						Track 
+ *
+ * @return Frame
+ */
 native int Shavit_GetClientCurrentFrame(int client, int style, int track);
+
+/* description here
+ * 
+ * @param clinet					Client index
+ * @param stlye						Style
+ * @param track						Track 
+ *
+ * @return Frame Time
+ */
 native float Shavit_GetClientCurrentFrameTime(int client, int style, int track);
 
 // same as Shavit_PrintToChat() but loops through the whole server

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1749,6 +1749,10 @@ native void Shavit_SetPlayerPreFrame(int client, int preframe);
  */
 native int Shavit_GetReplayPreFrameCount(int style, int track);
 
+// I need a native English speaker to polish these two natives >_>  ---- deadwinter
+native int Shavit_GetClientCurrentFrame(int client, int style, int track);
+native float Shavit_GetClientCurrentFrameTime(int client, int style, int track);
+
 // same as Shavit_PrintToChat() but loops through the whole server
 // code stolen from the base halflife.inc file
 stock void Shavit_PrintToChatAll(const char[] format, any ...)
@@ -1880,5 +1884,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetPlayerTimerframe");
 	MarkNativeAsOptional("Shavit_SetPlayerPreFrame");
 	MarkNativeAsOptional("Shavit_GetReplayPreFrameCount");
+	MarkNativeAsOptional("Shavit_GetClientCurrentFrame");
+	MarkNativeAsOptional("Shavit_GetClientCurrentFrameTime");
 }
 #endif

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -395,11 +395,12 @@ stock void FormatSeconds(float time, char[] newtime, int newtimesize, bool preci
 	float fSeconds = (iRounded % 60) + fTempTime - iRounded;
 
 	char sSeconds[8];
-	FormatEx(sSeconds, 8, precise? "%s%.03f":"%s%.01f", (time < 0.0)? "-":"", fSeconds);
+	FormatEx(sSeconds, 8, precise? "%.03f":"%.01f", fSeconds);
 
 	if(fTempTime < 60.0)
 	{
 		strcopy(newtime, newtimesize, sSeconds);
+		FormatEx(newtime, newtimesize, "%s%s", (fSeconds < 0.0) ? "-":"", sSeconds);
 	}
 
 	else

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -124,6 +124,7 @@ Convar gCV_GradientStepSize = null;
 Convar gCV_TicksPerUpdate = null;
 Convar gCV_SpectatorList = null;
 Convar gCV_UseHUDFix = null;
+Convar gCV_PrerunCountDown = null;
 
 // timer settings
 stylestrings_t gS_StyleStrings[STYLE_LIMIT];
@@ -197,6 +198,7 @@ public void OnPluginStart()
 	gCV_TicksPerUpdate = new Convar("shavit_hud_ticksperupdate", "5", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, (1.0 / GetTickInterval()));
 	gCV_SpectatorList = new Convar("shavit_hud_speclist", "1", "Who to show in the specators list?\n0 - everyone\n1 - all admins (admin_speclisthide override to bypass)\n2 - players you can target", 0, true, 0.0, true, 2.0);
 	gCV_UseHUDFix = new Convar("shavit_hud_csgofix", "1", "Apply the csgo color fix to the center hud?\nThis will add a dollar sign and block sourcemod hooks to hint message", 0, true, 0.0, true, 1.0);
+	gCV_PrerunCountDown = new Convar("shavit_hud_prerun_countdown", "1", "Display prerun countdown to the replay hud?", 0, true, 0.0, true, 1.0);
 
 	Convar.AutoExecConfig();
 
@@ -1162,6 +1164,11 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 			{	
 				char sTime[32];
 				FormatSeconds(data.fTime, sTime, 32, false);
+
+				if(data.fTime < 0.0 && gCV_PrerunCountDown.BoolValue)
+				{
+					Format(sTime, 32, "-%s", sTime);
+				}
 
 				char sWR[32];
 				FormatSeconds(data.fWR, sWR, 32, false);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1065,9 +1065,9 @@ int AddHUDToBuffer_Source2013(int client, huddata_t data, char[] buffer, int max
 			char sTimeDifference[32];
 			if((gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0)
 			{
-				if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+				if(Shavit_GetClientCurrentFrame(data.iTarget, data.iStyle, data.iTrack) != -1)
 				{
-					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack);
+					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(data.iTarget, data.iStyle, data.iTrack);
 					FormatSeconds(flDelta, sTimeDifference, 32, false);
 					Format(sTimeDifference, 32, " (%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
 				}

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -124,7 +124,6 @@ Convar gCV_GradientStepSize = null;
 Convar gCV_TicksPerUpdate = null;
 Convar gCV_SpectatorList = null;
 Convar gCV_UseHUDFix = null;
-Convar gCV_PrerunCountDown = null;
 
 // timer settings
 stylestrings_t gS_StyleStrings[STYLE_LIMIT];
@@ -198,7 +197,6 @@ public void OnPluginStart()
 	gCV_TicksPerUpdate = new Convar("shavit_hud_ticksperupdate", "5", "How often (in ticks) should the HUD update?\nPlay around with this value until you find the best for your server.\nThe maximum value is your tickrate.", 0, true, 1.0, true, (1.0 / GetTickInterval()));
 	gCV_SpectatorList = new Convar("shavit_hud_speclist", "1", "Who to show in the specators list?\n0 - everyone\n1 - all admins (admin_speclisthide override to bypass)\n2 - players you can target", 0, true, 0.0, true, 2.0);
 	gCV_UseHUDFix = new Convar("shavit_hud_csgofix", "1", "Apply the csgo color fix to the center hud?\nThis will add a dollar sign and block sourcemod hooks to hint message", 0, true, 0.0, true, 1.0);
-	gCV_PrerunCountDown = new Convar("shavit_hud_prerun_countdown", "1", "Display prerun countdown to the replay hud?", 0, true, 0.0, true, 1.0);
 
 	Convar.AutoExecConfig();
 
@@ -1164,11 +1162,6 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 			{	
 				char sTime[32];
 				FormatSeconds(data.fTime, sTime, 32, false);
-
-				if(data.fTime < 0.0 && gCV_PrerunCountDown.BoolValue)
-				{
-					Format(sTime, 32, "-%s", sTime);
-				}
 
 				char sWR[32];
 				FormatSeconds(data.fWR, sWR, 32, false);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1057,14 +1057,20 @@ int AddHUDToBuffer_Source2013(int client, huddata_t data, char[] buffer, int max
 			char sTime[32];
 			FormatSeconds(data.fTime, sTime, 32, false);
 
+			char sTimeDifference[32];
+			if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+			{
+				FormatSeconds(data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack), sTimeDifference, 32, false);
+			}
+
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "%T: %s (%d)", "HudTimeText", client, sTime, data.iRank);
+				FormatEx(sLine, 128, "%T: %s (%s) (%d)", "HudTimeText", client, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
 			{
-				FormatEx(sLine, 128, "%T: %s", "HudTimeText", client, sTime);
+				FormatEx(sLine, 128, "%T: %s (%s)", "HudTimeText", client, sTime, sTimeDifference);
 			}
 			
 			AddHUDLine(buffer, maxlen, sLine, iLines);
@@ -1260,14 +1266,21 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 			char sTime[32];
 			FormatSeconds(data.fTime, sTime, 32, false);
 
+			char sTimeDifference[32];
+			if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+			{
+				FormatSeconds(data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack), sTimeDifference, 32, false);
+			}
+			//PrintToConsole(client, "Difference: %.2f, ClosetFrame: %d", GetCurrentFrameTime(client, data), GetClosetFrameForPlayer(client, data));
+
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s</span> (#%d)", iColor, sTime, data.iRank);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s (%s)</span> (#%d)", iColor, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s</span>", iColor, sTime);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s (%s)</span>", iColor, sTime, sTimeDifference);
 			}
 			
 			AddHUDLine(buffer, maxlen, sLine, iLines);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -42,6 +42,7 @@
 #define HUD2_TRACK				(1 << 7)
 #define HUD2_SPLITPB			(1 << 8)
 #define HUD2_MAPTIER			(1 << 9)
+#define HUD2_TIMEDIFFERENCE		(1 << 10)
 
 #define HUD_DEFAULT				(HUD_MASTER|HUD_CENTER|HUD_ZONEHUD|HUD_OBSERVE|HUD_TOPLEFT|HUD_SYNC|HUD_TIMELEFT|HUD_2DVEL|HUD_SPECTATORS)
 #define HUD_DEFAULT2			0
@@ -685,6 +686,10 @@ Action ShowHUDMenu(int client, int item)
 		menu.AddItem(sInfo, sHudItem);
 	}
 
+	FormatEx(sInfo, 16, "@%d", HUD2_TIMEDIFFERENCE);
+	FormatEx(sHudItem, 64, "%T", "HudTimeDifference", client);
+	menu.AddItem(sInfo, sHudItem);
+
 	menu.ExitButton = true;
 	menu.DisplayAt(client, item, 60);
 
@@ -1058,14 +1063,19 @@ int AddHUDToBuffer_Source2013(int client, huddata_t data, char[] buffer, int max
 			FormatSeconds(data.fTime, sTime, 32, false);
 
 			char sTimeDifference[32];
-			if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+			if((gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0)
 			{
-				FormatSeconds(data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack), sTimeDifference, 32, false);
+				if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+				{
+					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack);
+					FormatSeconds(flDelta, sTimeDifference, 32, false);
+					Format(sTimeDifference, 32, "(%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
+				}
 			}
 
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "%T: %s (%s) (%d)", "HudTimeText", client, sTime, sTimeDifference, data.iRank);
+				FormatEx(sLine, 128, "%T: %s %s (%d)", "HudTimeText", client, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
@@ -1267,20 +1277,24 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 			FormatSeconds(data.fTime, sTime, 32, false);
 
 			char sTimeDifference[32];
-			if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+			if((gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0)
 			{
-				FormatSeconds(data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack), sTimeDifference, 32, false);
+				if(Shavit_GetClientCurrentFrame(client, data.iStyle, data.iTrack) != -1)
+				{
+					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack);
+					FormatSeconds(flDelta, sTimeDifference, 32, false);
+					Format(sTimeDifference, 32, "(%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
+				}
 			}
-			//PrintToConsole(client, "Difference: %.2f, ClosetFrame: %d", GetCurrentFrameTime(client, data), GetClosetFrameForPlayer(client, data));
 
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s (%s)</span> (#%d)", iColor, sTime, sTimeDifference, data.iRank);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s %s</span> (#%d)", iColor, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s (%s)</span>", iColor, sTime, sTimeDifference);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s %s</span>", iColor, sTime, sTimeDifference);
 			}
 			
 			AddHUDLine(buffer, maxlen, sLine, iLines);

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1069,18 +1069,18 @@ int AddHUDToBuffer_Source2013(int client, huddata_t data, char[] buffer, int max
 				{
 					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack);
 					FormatSeconds(flDelta, sTimeDifference, 32, false);
-					Format(sTimeDifference, 32, "(%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
+					Format(sTimeDifference, 32, " (%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
 				}
 			}
 
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "%T: %s %s (%d)", "HudTimeText", client, sTime, sTimeDifference, data.iRank);
+				FormatEx(sLine, 128, "%T: %s%s (%d)", "HudTimeText", client, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
 			{
-				FormatEx(sLine, 128, "%T: %s (%s)", "HudTimeText", client, sTime, sTimeDifference);
+				FormatEx(sLine, 128, "%T: %s%s", "HudTimeText", client, sTime, sTimeDifference);
 			}
 			
 			AddHUDLine(buffer, maxlen, sLine, iLines);
@@ -1283,18 +1283,18 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 				{
 					float flDelta = data.fTime - Shavit_GetClientCurrentFrameTime(client, data.iStyle, data.iTrack);
 					FormatSeconds(flDelta, sTimeDifference, 32, false);
-					Format(sTimeDifference, 32, "(%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
+					Format(sTimeDifference, 32, " (%s%s)", flDelta > 0 ? "+" : "", sTimeDifference);
 				}
 			}
 
 			if((gI_HUD2Settings[client] & HUD2_RANK) == 0)
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s %s</span> (#%d)", iColor, sTime, sTimeDifference, data.iRank);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s%s</span> (#%d)", iColor, sTime, sTimeDifference, data.iRank);
 			}
 
 			else
 			{
-				FormatEx(sLine, 128, "<span color='#%06X'>%s %s</span>", iColor, sTime, sTimeDifference);
+				FormatEx(sLine, 128, "<span color='#%06X'>%s%s</span>", iColor, sTime, sTimeDifference);
 			}
 			
 			AddHUDLine(buffer, maxlen, sLine, iLines);

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1627,16 +1627,14 @@ public Action Shavit_OnStart(int client)
 		
 		else
 		{
-			for(int i = 0; i < gA_PlayerFrames[client].Length - RoundToFloor(gCV_PlaybackPreRunTime.FloatValue * gF_Tickrate / gA_StyleSettings[Shavit_GetBhopStyle(client)].fTimescale); i++)
+			while(gA_PlayerFrames[client].Length > RoundToFloor(gCV_PlaybackPreRunTime.FloatValue * gF_Tickrate / gA_StyleSettings[Shavit_GetBhopStyle(client)].fTimescale))
 			{
 				gA_PlayerFrames[client].Erase(0);
 				gI_PlayerFrames[client]--;
 			}
 
-			if(gA_PlayerFrames[client].Length <= RoundToFloor(gCV_PlaybackPreRunTime.FloatValue * gF_Tickrate / gA_StyleSettings[Shavit_GetBhopStyle(client)].fTimescale))
-			{
-				gB_ClearFrame[client] = true;
-			}
+			gB_ClearFrame[client] = true;
+
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -156,6 +156,7 @@ Convar gCV_PlaybackCanStop = null;
 Convar gCV_PlaybackCooldown = null;
 Convar gCV_PlaybackPreRunTime = null;
 Convar gCV_ClearPreRun = null;
+ConVar gCV_PrerunCountdown = null;
 
 // timer settings
 int gI_Styles = 0;
@@ -249,6 +250,7 @@ public void OnPluginStart()
 
 	FindConVar((gEV_Type != Engine_TF2)? "bot_quota":"tf_bot_quota").Flags &= ~FCVAR_NOTIFY;
 	FindConVar("bot_stop").Flags &= ~FCVAR_CHEAT;
+	gCV_PrerunCountdown = FindConVar("shavit_hud_prerun_countdown");
 
 	for(int i = 0; i < sizeof(gS_ForcedCvars); i++)
 	{

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2765,14 +2765,25 @@ int GetClosetFrameForPlayer(int client, int style, int track)
 	}
 
 	if(iFrame > g_iLoopFrame[client])
+	{
 		g_iLoopFrame[client] += g_iLoopFrame[client];
+	}
 
 	if(g_iLoopFrame[client] > gA_Frames[style][track].Length)
+	{
 		g_iLoopFrame[client] = gA_Frames[style][track].Length;
+	}
 
 	if (iFrame > gA_Frames[style][track].Length)
+	{
 		iFrame = gA_Frames[style][track].Length;
+	}
 
+	if(iLastFrame < 0)
+	{
+		iLastFrame = 0;
+	}
+	
 	for(int i = iLastFrame; i < iFrame; i++)
 	{
 		vecFrameOrigin[0] = gA_Frames[style][track].Get(i, 0);

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1630,8 +1630,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 {
 	if(Shavit_IsPracticeMode(client))
 	{
-		ClearFrames(client);
-
 		return;
 	}
 
@@ -1646,8 +1644,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 	{
 		if(length > 0.0 && time > length)
 		{
-			ClearFrames(client);
-
 			return;
 		}
 	}
@@ -1658,16 +1654,12 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 		if(wrtime != 0.0 && time > wrtime)
 		{
-			ClearFrames(client);
-
 			return;
 		}
 	}
 
 	if(gI_PlayerFrames[client] == 0)
 	{
-		ClearFrames(client);
-
 		return;
 	}
 	

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2771,9 +2771,6 @@ float GetCurrentFrameTime(int client, int style, int track)
 	// TimerStartFrame = FrameAfterLeavingStartZone - PreFrames
 	// TotalTimerFrame = FrameCount - PreFrames
 	return float(GetClosetFrameForPlayer(client, style, track) - gA_FrameCache[style][track].iPreFrames) / float(gA_FrameCache[style][track].iFrameCount - gA_FrameCache[style][track].iPreFrames) * GetReplayLength(style, track);
-
-	//Kamay's 
-	//return (1 - (gA_FrameCache[style][track].iFrameCount - (GetClosetFrameForPlayer(client, style, track) + gA_FrameCache[style][track].iPreFrames)) / gA_FrameCache[style][track].iFrameCount) * GetReplayLength(style, track);
 }
 
 /*

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1630,6 +1630,8 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 {
 	if(Shavit_IsPracticeMode(client))
 	{
+		ClearFrames(client);
+
 		return;
 	}
 
@@ -1644,6 +1646,8 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 	{
 		if(length > 0.0 && time > length)
 		{
+			ClearFrames(client);
+
 			return;
 		}
 	}
@@ -1654,12 +1658,16 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 
 		if(wrtime != 0.0 && time > wrtime)
 		{
+			ClearFrames(client);
+
 			return;
 		}
 	}
 
 	if(gI_PlayerFrames[client] == 0)
 	{
+		ClearFrames(client);
+
 		return;
 	}
 	

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2739,7 +2739,7 @@ void GetReplayName(int style, int track, char[] buffer, int length)
 
 int GetClosetFrameForPlayer(int client, int style, int track)
 {
-	if(!gA_Frames[style][track])
+	if(!gA_Frames[style][track] || gA_Frames[style][track].Length == 0)
 	{
 		return -1;
 	}

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1606,9 +1606,16 @@ public void DeleteFrames(int client)
 	delete gA_PlayerFrames[client];
 }
 
+int g_iLoopFrame[MAXPLAYERS+1];
+
 public Action Shavit_OnStart(int client)
 {	
 	gI_PlayerPrerunFrames[client] = gA_PlayerFrames[client].Length;
+
+	if(gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length > RoundToFloor(gF_Tickrate * 60))
+		g_iLoopFrame[client] = gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length / 25;
+	else 
+		g_iLoopFrame[client] = gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length;
 
 	if(!gB_ClearFrame[client])
 	{
@@ -2742,13 +2749,38 @@ int GetClosetFrameForPlayer(int client, int style, int track)
 
 	float flLastDistance = 500.1;
 	int iFrame = -1;
+	int iLastFrame = -1;
 
-	for(int i = gA_FrameCache[style][track].iPreFrames; i < gA_Frames[style][track].Length; i++)
+	for(int i = gA_FrameCache[style][track].iPreFrames; i < g_iLoopFrame[client]; i++)
 	{
 		vecFrameOrigin[0] = gA_Frames[style][track].Get(i, 0);
 		vecFrameOrigin[1] = gA_Frames[style][track].Get(i, 1);
 		vecFrameOrigin[2] = gA_Frames[style][track].Get(i, 2);
 
+		float flDistance = GetVectorDistance(vecPlayerOrigin, vecFrameOrigin);
+		if(flDistance < flLastDistance && flDistance != 0.0)
+		{
+			flLastDistance = flDistance;
+			iFrame = i + 10;
+			iLastFrame = i - 10;
+		}
+	}
+
+	if(iFrame > g_iLoopFrame[client])
+		g_iLoopFrame[client] += g_iLoopFrame[client];
+
+	if(g_iLoopFrame[client] > gA_Frames[style][track].Length)
+		g_iLoopFrame[client] = gA_Frames[style][track].Length;
+
+	if (iFrame > gA_Frames[style][track].Length)
+		iFrame = gA_Frames[style][track].Length;
+
+	for(int i = iLastFrame; i < iFrame; i++)
+	{
+		vecFrameOrigin[0] = gA_Frames[style][track].Get(i, 0);
+		vecFrameOrigin[1] = gA_Frames[style][track].Get(i, 1);
+		vecFrameOrigin[2] = gA_Frames[style][track].Get(i, 2);
+	
 		float flDistance = GetVectorDistance(vecPlayerOrigin, vecFrameOrigin);
 		if(flDistance < flLastDistance && flDistance != 0.0)
 		{

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -1613,10 +1613,14 @@ public Action Shavit_OnStart(int client)
 	gI_PlayerPrerunFrames[client] = gA_PlayerFrames[client].Length;
 
 	if(gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length > RoundToFloor(gF_Tickrate * 60))
+	{
 		g_iLoopFrame[client] = gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length / 25;
-	else 
+	}
+	else
+	{ 
 		g_iLoopFrame[client] = gA_Frames[Shavit_GetBhopStyle(client)][Shavit_GetClientTrack(client)].Length;
-
+	}
+	
 	if(!gB_ClearFrame[client])
 	{
 		if(!gCV_ClearPreRun.BoolValue)
@@ -2783,7 +2787,7 @@ int GetClosetFrameForPlayer(int client, int style, int track)
 	{
 		iLastFrame = 0;
 	}
-	
+
 	for(int i = iLastFrame; i < iFrame; i++)
 	{
 		vecFrameOrigin[0] = gA_Frames[style][track].Get(i, 0);

--- a/addons/sourcemod/translations/shavit-hud.phrases.txt
+++ b/addons/sourcemod/translations/shavit-hud.phrases.txt
@@ -153,6 +153,10 @@
 	{
 		"en"		"Map tier"
 	}
+	"HudTimeDifference"
+	{
+		"en"		"Time Difference"
+	}
 	// ---------- Record Bots ---------- //
 	"ReplayText"
 	{


### PR DESCRIPTION
Thanks Kamay & ici & Promises & Nairda for help.

# Changes
- Fix an issue that prerun frame size is bigger than intended size when ``shavit_replay_prerun_always`` is 0
- Add dynamic time difference (#818)

# Something I can't do
- [ ] Polish native name and description