### PR TITLE
Fix timescale being reset to styles default (fix #892)

### DIFF
--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1218,7 +1218,7 @@ void VelocityChanges(int data)
 
 	if(gA_Timers[client].fTimescale != -1.0)
 	{
-		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_StyleSettings[gA_Timers[client].iStyle].fTimescale));
+		SetEntPropFloat(client, Prop_Data, "m_flLaggedMovementValue", view_as<float>(gA_Timers[client].fTimescale));
 	}
 
 	else


### PR DESCRIPTION
This new line will fix the native Shavit_SetClientTimescale by not
resetting the timescale of the player to the style default after each
jump