### PR TITLE
fix perf jump ratio measuring

### DIFF
--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -3057,12 +3057,14 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	else if(!bOnGround && gA_Timers[client].bOnGround && gA_Timers[client].bJumped)
 	{
 		int iDifference = (gI_TickCount - gA_Timers[client].iLandingTick);
-
-		if(1 <= iDifference <= 8)
+		// debug
+		// Shavit_PrintToChat(client, "Jump tick: %i", iDifference);
+		
+		if(0 <= iDifference <= 10)
 		{
 			gA_Timers[client].iMeasuredJumps++;
 
-			if(iDifference == 1)
+			if(iDifference <= 1)
 			{
 				gA_Timers[client].iPerfectJumps++;
 			}


### PR DESCRIPTION
Sometimes the jump can happen at 0 tick as well. Both 0 and 1 will result in a perf both on CSS and CSGO. I don't even know how 0 tick can occure, but it does, according to that "debug" line I made and that caused the perf ratio to be inaccurate.