### PR TITLE
New timer method, tick fractions & StartReplay native

### DIFF
--- a/addons/sourcemod/gamedata/shavit.games.txt
+++ b/addons/sourcemod/gamedata/shavit.games.txt
@@ -5,8 +5,6 @@
 		"Keys"
 		{
 			"IGameMovement"		"GameMovement001"
-
-			"IServerGameEnts"	"ServerGameEnts001"
 		}
 
 		"Signatures"
@@ -33,32 +31,6 @@
 	{
 		"Offsets"
 		{
-			// applies to trigger_vphysics_motion and trigger_wind
-			"CBaseVPhysicsTrigger::PassesTriggerFilters"
-			{
-				"windows"	"199"
-				"linux"		"200"
-			}
-
-			// applies to all other triggers
-			"CBaseTrigger::PassesTriggerFilters"
-			{
-				"windows"	"209"
-				"linux"		"210"
-			}
-
-			"IServerGameEnts::MarkEntitiesAsTouching"
-			{
-				"windows"	"1"
-				"linux"		"2"
-			}
-
-			"m_surfaceFriction"
-			{
-				"windows"	"4660"
-				"linux"		"4684"
-			}
-
 			"CCSPlayer::GetPlayerMaxSpeed"
 			{
 				"windows"	"505"
@@ -72,35 +44,11 @@
 	{
 		"Offsets"
 		{
-			// applies to trigger_vphysics_motion and trigger_wind
-			"CBaseVPhysicsTrigger::PassesTriggerFilters"
-			{
-				"windows"	"188"
-				"linux"		"189"
-			}
-
 			"CCSPlayer::GetPlayerMaxSpeed"
 			{
 				"windows"	"438"
 				"linux"		"439"
 				"mac"		"439"
-			}
-
-			// applies to all other triggers
-			"CBaseTrigger::PassesTriggerFilters"
-			{
-				"windows"	"197"
-				"linux"		"198"
-			}
-
-			"IServerGameEnts::MarkEntitiesAsTouching"
-			{
-				"windows"	"2"
-				"linux"		"3"
-			}
-			"m_surfaceFriction"
-			{
-				"linux"		"3852"
 			}
 		}
 	}

--- a/addons/sourcemod/gamedata/shavit.games.txt
+++ b/addons/sourcemod/gamedata/shavit.games.txt
@@ -1,14 +1,30 @@
 "Games"
 {
-	"cstrike"
+	"#default"
 	{
+		"Keys"
+		{
+			"IGameMovement"		"GameMovement001"
+
+			"IServerGameEnts"	"ServerGameEnts001"
+		}
+
+		"Signatures"
+		{
+			"CreateInterface"
+			{
+				"library"		"server"
+				"windows"		"@CreateInterface"
+				"linux"			"@CreateInterface"
+			}
+		}
+
 		"Offsets"
 		{
-			"CCSPlayer::GetPlayerMaxSpeed"
+			"ProcessMovement"
 			{
-				"windows"	"438"
-				"linux"		"439"
-				"mac"		"439"
+				"windows"		"1"
+				"linux"			"2"
 			}
 		}
 	}
@@ -17,11 +33,74 @@
 	{
 		"Offsets"
 		{
+			// applies to trigger_vphysics_motion and trigger_wind
+			"CBaseVPhysicsTrigger::PassesTriggerFilters"
+			{
+				"windows"	"199"
+				"linux"		"200"
+			}
+
+			// applies to all other triggers
+			"CBaseTrigger::PassesTriggerFilters"
+			{
+				"windows"	"209"
+				"linux"		"210"
+			}
+
+			"IServerGameEnts::MarkEntitiesAsTouching"
+			{
+				"windows"	"1"
+				"linux"		"2"
+			}
+
+			"m_surfaceFriction"
+			{
+				"windows"	"4660"
+				"linux"		"4684"
+			}
+
 			"CCSPlayer::GetPlayerMaxSpeed"
 			{
 				"windows"	"505"
 				"linux"		"506"
 				"mac"		"506"
+			}
+		}
+	}
+
+	"cstrike"
+	{
+		"Offsets"
+		{
+			// applies to trigger_vphysics_motion and trigger_wind
+			"CBaseVPhysicsTrigger::PassesTriggerFilters"
+			{
+				"windows"	"188"
+				"linux"		"189"
+			}
+
+			"CCSPlayer::GetPlayerMaxSpeed"
+			{
+				"windows"	"438"
+				"linux"		"439"
+				"mac"		"439"
+			}
+
+			// applies to all other triggers
+			"CBaseTrigger::PassesTriggerFilters"
+			{
+				"windows"	"197"
+				"linux"		"198"
+			}
+
+			"IServerGameEnts::MarkEntitiesAsTouching"
+			{
+				"windows"	"2"
+				"linux"		"3"
+			}
+			"m_surfaceFriction"
+			{
+				"linux"		"3852"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1389,9 +1389,10 @@ native int Shavit_GetWRCount(int client);
 *
 * @param style						Style index.
 * @param StyleSettings				Reference to the settings array.
+* @param size						Size of the StyleSettings buffer, e.g sizeof(stylesettings_t)
 * @return							SP_ERROR_NONE on success, anything else on failure.
 */
-native int Shavit_GetStyleSettings(int style, any StyleSettings[sizeof(stylesettings_t)]);
+native int Shavit_GetStyleSettings(int style, any[] StyleSettings, int size = sizeof(stylesettings_t));
 
 /**
  * Saves the style related strings on string references.
@@ -1465,18 +1466,20 @@ native bool Shavit_IsPracticeMode(int client);
  *
  * @param client					Client index.
  * @param snapshot					Full snapshot of the client's timer.
+ * @param size						Size of the snapshot buffer, e.g sizeof(timer_snapshot_t)
  * @noreturn
  */
-native void Shavit_SaveSnapshot(int client, any snapshot[sizeof(timer_snapshot_t)]);
+native void Shavit_SaveSnapshot(int client, any[] snapshot, int size = sizeof(timer_snapshot_t));
 
 /**
  * Restores the client's timer from a snapshot.
  *
  * @param client					Client index.
  * @param snapshot					Full snapshot of the client's timer.
+ * @param size						Size of the snapshot buffer, e.g sizeof(timer_snapshot_t)
  * @noreturn
  */
-native void Shavit_LoadSnapshot(int client, any snapshot[sizeof(timer_snapshot_t)]);
+native void Shavit_LoadSnapshot(int client, any[] snapshot, int size = sizeof(timer_snapshot_t));
 
 /**
  * Sets a player's replay recording frames from a provided ArrayList.
@@ -1630,22 +1633,25 @@ native void Shavit_LogMessage(const char[] format, any ...);
  *
  * @param client					Client index
  * @param index						Index of CP to get
- * @param cpcache					Buffer to store cp data in
+ * @param cpcache					Buffer to store cp data in sizeof(cp_cache_t)
+ * @param size						Size of the cpcache buffer, e.g sizeof(cp_cache_t)
  *
  * @noreturn
  */
-native bool Shavit_GetCheckpoint(int client, int index, any cpcache[sizeof(cp_cache_t)]);
+native bool Shavit_GetCheckpoint(int client, int index, any[] cpcache, int size = sizeof(cp_cache_t));
 
 /**
  * Sets checkpoint data at the given index for the given client
  *
  * @param client					Client index
  * @param index						Index of CP to set, or -1 to push cp as last
+ * @param cpcache					Buffer to store cp data in sizeof(cp_cache_t)
+ * @param size						Size of the cpcache buffer, e.g sizeof(cp_cache_t)
  * @param cpcache					Buffer with cp data
  *
  * @noreturn
  */
-native void Shavit_SetCheckpoint(int client, int index, any cpcache[sizeof(cp_cache_t)]);
+native void Shavit_SetCheckpoint(int client, int index, any[] cpcache, int size = sizeof(cp_cache_t));
 
 /**
  * Teleports client to the checkpoint at given index

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1755,7 +1755,7 @@ native int Shavit_GetPlayerPreFrame(int client);
  *
  * @return 							Timer preframe count
  */
- native int Shavit_GetPlayerTimerframe(int client);
+ native int Shavit_GetPlayerTimerFrame(int client);
 
 /*
  * Sets player's preframe length.
@@ -1776,7 +1776,7 @@ native void Shavit_SetPlayerPreFrame(int client, int PreFrame);
  *
  * @noreturn
  */
- native void Shavit_SetPlayerTimerPreFrame(int client, int TimerPreFrame);
+ native void Shavit_SetPlayerTimerFrame(int client, int TimerPreFrame);
 
 // same as Shavit_PrintToChat() but loops through the whole server
 // code stolen from the base halflife.inc file

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1501,6 +1501,15 @@ native void Shavit_SetReplayData(int client, ArrayList data);
 native ArrayList Shavit_GetReplayData(int client);
 
 /**
+ * Starts a replay given a style and track. 
+ * @param client					Client index.
+ * @param style						Bhop style.
+ * @param track						Timer track.
+ * @noreturn							
+ */
+native void Shavit_StartReplay(int style, int track, float delay, int client = 1);
+
+/**
  * Reloads a specific replay into the replay bot cache.
  * Note: Not guaranteed to work with legacy replay bots.
  *
@@ -1509,7 +1518,7 @@ native ArrayList Shavit_GetReplayData(int client);
  * @param restart					Restart the playback of the replay bot if it's playing?
  * @param path						Path to the replay file. Use `BuildPath(Path_SM, ...)` to generate one. Leave as empty to use default.
  * @return							Was the replay loaded?
- */
+ */ 
 native bool Shavit_ReloadReplay(int style, int track, bool restart, char[] path = "");
 
 /**
@@ -1888,6 +1897,7 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_SaveSnapshot");
 	MarkNativeAsOptional("Shavit_SetPracticeMode");
 	MarkNativeAsOptional("Shavit_SetReplayData");
+	MarkNativeAsOptional("Shavit_StartReplay");
 	MarkNativeAsOptional("Shavit_StartTimer");
 	MarkNativeAsOptional("Shavit_StopChatSound");
 	MarkNativeAsOptional("Shavit_StopTimer");

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -1906,8 +1906,9 @@ public void __pl_shavit_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetCurrentCheckpoint");
 	MarkNativeAsOptional("Shavit_SetCurrentCheckpoint");
 	MarkNativeAsOptional("Shavit_GetPlayerPreFrame");
-	MarkNativeAsOptional("Shavit_GetPlayerTimerframe");
+	MarkNativeAsOptional("Shavit_GetPlayerTimerFrame");
 	MarkNativeAsOptional("Shavit_SetPlayerPreFrame");
 	MarkNativeAsOptional("Shavit_GetClosestReplayTime");
+	MarkNativeAsOptional("Shavit_SetPlayerTimerFrame");
 }
 #endif

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -23,7 +23,7 @@
 #endif
 #define _shavit_included
 
-#define SHAVIT_VERSION "2.5.7a"
+#define SHAVIT_VERSION "2.6.0"
 #define STYLE_LIMIT 256
 #define MAX_ZONES 64
 #define MAX_NAME_LENGTH_SQL 32

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -2795,7 +2795,6 @@ public void Shavit_OnLeaveZone(int client, int type, int track, int id, int enti
 	{
 		if(gCV_UseOffsets.BoolValue)
 		{
-			PrintToChat(client, "track: %i", track);
 			float offset = CalculateTickIntervalOffset(client, type);
 			gA_Timers[client].fTimer += offset;
 			

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -1658,6 +1658,11 @@ public int Native_GetStyleCount(Handle handler, int numParams)
 
 public int Native_GetStyleSettings(Handle handler, int numParams)
 {
+	if(GetNativeCell(3) != sizeof(stylesettings_t))
+	{
+		return ThrowNativeError(200, "stylesettings_t does not match latest(got %i expected %i). Please update your includes and recompile your plugins",
+			GetNativeCell(3), sizeof(stylesettings_t));
+	}
 	return SetNativeArray(2, gA_StyleSettings[GetNativeCell(1)], sizeof(stylesettings_t));
 }
 
@@ -1725,6 +1730,12 @@ public int Native_IsPracticeMode(Handle handler, int numParams)
 
 public int Native_SaveSnapshot(Handle handler, int numParams)
 {
+	if(GetNativeCell(3) != sizeof(timer_snapshot_t))
+	{
+		return ThrowNativeError(200, "timer_snapshot_t does not match latest(got %i expected %i). Please update your includes and recompile your plugins",
+			GetNativeCell(3), sizeof(timer_snapshot_t));
+	}
+
 	int client = GetNativeCell(1);
 
 	timer_snapshot_t snapshot;
@@ -1747,6 +1758,11 @@ public int Native_SaveSnapshot(Handle handler, int numParams)
 
 public int Native_LoadSnapshot(Handle handler, int numParams)
 {
+	if(GetNativeCell(3) != sizeof(timer_snapshot_t))
+	{
+		return ThrowNativeError(200, "timer_snapshot_t does not match latest(got %i expected %i). Please update your includes and recompile your plugins",
+			GetNativeCell(3), sizeof(timer_snapshot_t));
+	}
 	int client = GetNativeCell(1);
 
 	timer_snapshot_t snapshot;
@@ -1775,6 +1791,8 @@ public int Native_LoadSnapshot(Handle handler, int numParams)
 	gA_Timers[client].iSHSWCombination = snapshot.iSHSWCombination;
 	gA_Timers[client].iMeasuredJumps = snapshot.iMeasuredJumps;
 	gA_Timers[client].iPerfectJumps = snapshot.iPerfectJumps;
+	
+	return 0;
 }
 
 public int Native_LogMessage(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -428,10 +428,10 @@ void LoadDHooks()
 		SetFailState("Failed to get ProcessMovement offset");
 	}
 
-	Handle processMovement = DHookCreate(offset, HookType_Raw, ReturnType_Void, ThisPointer_Ignore, DHook_ProcessMovement);
+	Handle processMovement = DHookCreate(offset, HookType_Raw, ReturnType_Void, ThisPointer_Ignore, DHook_ProcessMovementPost);
 	DHookAddParam(processMovement, HookParamType_CBaseEntity);
 	DHookAddParam(processMovement, HookParamType_ObjectPtr);
-	DHookRaw(processMovement, false, IGameMovement);
+	DHookRaw(processMovement, true, IGameMovement);
 
 	delete CreateInterface;
 	delete gamedataConf;
@@ -2849,7 +2849,7 @@ public void PostThink(int client)
 	gF_PreviousOrigin[client][0][2] += height; 
 }
 
-public MRESReturn DHook_ProcessMovement(Handle hParams)
+public MRESReturn DHook_ProcessMovementPost(Handle hParams)
 {
 	int client = DHookGetParam(hParams, 1);
 	

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1881,21 +1881,23 @@ void GetTrackName(int client, int track, char[] output, int size)
 
 void PrintCSGOHUDText(int client, const char[] format, any ...)
 {
-    char buff[MAX_HINT_SIZE];
-    VFormat(buff, sizeof(buff), format, 3);
-    Format(buff, sizeof(buff), "</font>%s ", buff);
-    
-    for(int i = strlen(buff); i < sizeof(buff); i++)
-        buff[i] = '\n';
-    
-    Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS));
-    pb.SetInt("msg_dst", 4);
-    pb.AddString("params", "#SFUI_ContractKillStart");
-    pb.AddString("params", buff);
-    pb.AddString("params", NULL_STRING);
-    pb.AddString("params", NULL_STRING);
-    pb.AddString("params", NULL_STRING);
-    pb.AddString("params", NULL_STRING);
-    
-    EndMessage();
+	char buff[MAX_HINT_SIZE];
+	VFormat(buff, sizeof(buff), format, 3);
+	Format(buff, sizeof(buff), "</font>%s ", buff);
+	
+	for(int i = strlen(buff); i < sizeof(buff); i++)
+	{
+		buff[i] = '\n';
+	}
+	
+	Protobuf pb = view_as<Protobuf>(StartMessageOne("TextMsg", client, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS));
+	pb.SetInt("msg_dst", 4);
+	pb.AddString("params", "#SFUI_ContractKillStart");
+	pb.AddString("params", buff);
+	pb.AddString("params", NULL_STRING);
+	pb.AddString("params", NULL_STRING);
+	pb.AddString("params", NULL_STRING);
+	pb.AddString("params", NULL_STRING);
+	
+	EndMessage();
 }

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -648,7 +648,7 @@ Action ShowHUDMenu(int client, int item)
 	menu.AddItem(sInfo, sHudItem);
 
 	FormatEx(sInfo, 16, "@%d", HUD2_TIMEDIFFERENCE);
-	FormatEx(sHudItem, 64, "%T", "HudTimeDiffText", client);
+	FormatEx(sHudItem, 64, "%T", "HudTimeDifference", client);
 	menu.AddItem(sInfo, sHudItem);
 
 	FormatEx(sInfo, 16, "@%d", HUD2_SPEED);

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -103,6 +103,8 @@ bool gB_SaveStates[MAXPLAYERS+1];
 char gS_SaveStateTargetname[MAXPLAYERS+1][32];
 ArrayList gA_SaveFrames[MAXPLAYERS+1];
 ArrayList gA_PersistentData = null;
+int gI_SavePreFrames[MAXPLAYERS+1];
+int gI_TimerFrames[MAXPLAYERS+1];
 
 // cookies
 Handle gH_HideCookie = null;
@@ -1156,7 +1158,7 @@ void PersistData(int client)
 	{
 		aData.aFrames = Shavit_GetReplayData(client);
 		aData.iPreFrames = Shavit_GetPlayerPreFrame(client);
-		aData.iTimerPreFrames = Shavit_GetPlayerTimerframe(client);
+		aData.iTimerPreFrames = Shavit_GetPlayerTimerFrame(client);
 	}
 
 	aData.fDisconnectTime = GetEngineTime();
@@ -1278,7 +1280,7 @@ public Action Timer_LoadPersistentData(Handle Timer, any data)
 	{
 		Shavit_SetReplayData(client, aData.aFrames);
 		Shavit_SetPlayerPreFrame(client, aData.iPreFrames);
-		Shavit_SetPlayerTimerPreFrame(client, aData.iTimerPreFrames);
+		Shavit_SetPlayerTimerFrame(client, aData.iTimerPreFrames);
 	}
 
 	if(aData.bPractice)
@@ -2371,7 +2373,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 		{
 			cpcache.aFrames = Shavit_GetReplayData(target);
 			cpcache.iPreFrames = Shavit_GetPlayerPreFrame(target);
-			cpcache.iTimerPreFrames = Shavit_GetPlayerTimerframe(target);
+			cpcache.iTimerPreFrames = Shavit_GetPlayerTimerFrame(target);
 		}
 
 		cpcache.bSegmented = true;
@@ -2585,7 +2587,7 @@ void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 		{
 			Shavit_SetReplayData(client, cpcache.aFrames);
 			Shavit_SetPlayerPreFrame(client, cpcache.iPreFrames);
-			Shavit_SetPlayerTimerPreFrame(client, cpcache.iTimerPreFrames);
+			Shavit_SetPlayerTimerFrame(client, cpcache.iTimerPreFrames);
 		}
 	}
 	
@@ -3420,6 +3422,8 @@ void LoadState(int client)
 	if(gB_Replay && gA_SaveFrames[client] != null)
 	{
 		Shavit_SetReplayData(client, gA_SaveFrames[client]);
+		Shavit_SetPlayerPreFrame(client, gI_SavePreFrames[client]);
+		Shavit_SetPlayerTimerFrame(client, gI_TimerFrames[client]);
 	}
 
 	delete gA_SaveFrames[client];
@@ -3445,6 +3449,8 @@ void SaveState(int client)
 	{
 		delete gA_SaveFrames[client];
 		gA_SaveFrames[client] = Shavit_GetReplayData(client);
+		gI_SavePreFrames[client] = Shavit_GetPlayerPreFrame(client);
+		gI_TimerFrames[client] = Shavit_GetPlayerTimerFrame(client);
 	}
 
 	gB_SaveStates[client] = true;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -3486,6 +3486,11 @@ int GetMaxCPs(int client)
 
 public any Native_GetCheckpoint(Handle plugin, int numParams)
 {
+	if(GetNativeCell(4) != sizeof(cp_cache_t))
+	{
+		return ThrowNativeError(200, "cp_cache_t does not match latest(got %i expected %i). Please update your includes and recompile your plugins",
+			GetNativeCell(4), sizeof(cp_cache_t));
+	}
 	int client = GetNativeCell(1);
 	int index = GetNativeCell(2);
 
@@ -3501,6 +3506,11 @@ public any Native_GetCheckpoint(Handle plugin, int numParams)
 
 public any Native_SetCheckpoint(Handle plugin, int numParams)
 {
+	if(GetNativeCell(4) != sizeof(cp_cache_t))
+	{
+		return ThrowNativeError(200, "cp_cache_t does not match latest(got %i expected %i). Please update your includes and recompile your plugins",
+			GetNativeCell(4), sizeof(cp_cache_t));
+	}
 	int client = GetNativeCell(1);
 	int position = GetNativeCell(2);
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -211,8 +211,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_SetReplayData", Native_SetReplayData);
 	CreateNative("Shavit_GetPlayerPreFrame", Native_GetPreFrame);
 	CreateNative("Shavit_SetPlayerPreFrame", Native_SetPreFrame);
-	CreateNative("Shavit_SetPlayerTimerPreFrame", Native_SetTimerPreFrame);
-	CreateNative("Shavit_GetPlayerTimerframe", Native_GetTimerFrame);
+	CreateNative("Shavit_SetPlayerTimerFrame", Native_SetTimerFrame);
+	CreateNative("Shavit_GetPlayerTimerFrame", Native_GetTimerFrame);
 	CreateNative("Shavit_GetClosestReplayTime", Native_GetClosestReplayTime);
 
 	// registers library, check "bool LibraryExists(const char[] name)" in order to use with other plugins
@@ -782,7 +782,7 @@ public int Native_SetPreFrame(Handle handler, int numParams)
 	gI_PlayerPrerunFrames[client] = preframes;
 }
 
-public int Native_SetTimerPreFrame(Handle handler, int numParams)
+public int Native_SetTimerFrame(Handle handler, int numParams)
 {
 	int client = GetNativeCell(1);
 	int timerframes = GetNativeCell(2);
@@ -1271,7 +1271,16 @@ bool SaveReplay(int style, int track, float time, int steamid, char[] name, int 
 	any aWriteData[CELLS_PER_FRAME * FRAMES_PER_WRITE];
 	int iFramesWritten = 0;
 
-	gA_Frames[style][track].Clear();
+	// How did I trigger this?
+	if(gA_Frames[style][track] == null)
+	{
+		gA_Frames[style][track] = new ArrayList(CELLS_PER_FRAME);
+	}
+	else
+	{
+		gA_Frames[style][track].Clear();
+	}
+
 
 	for(int i = preframes; i < iSize; i++)
 	{

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -205,6 +205,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_GetReplayTime", Native_GetReplayTime);
 	CreateNative("Shavit_HijackAngles", Native_HijackAngles);
 	CreateNative("Shavit_IsReplayDataLoaded", Native_IsReplayDataLoaded);
+	CreateNative("Shavit_StartReplay", Native_StartReplay);
 	CreateNative("Shavit_ReloadReplay", Native_ReloadReplay);
 	CreateNative("Shavit_ReloadReplays", Native_ReloadReplays);
 	CreateNative("Shavit_Replay_DeleteMap", Native_Replay_DeleteMap);
@@ -514,6 +515,39 @@ public int Native_IsReplayDataLoaded(Handle handler, int numParams)
 	}
 
 	return view_as<int>(ReplayEnabled(style) && gA_FrameCache[style][Track_Main].iFrameCount > 0);
+}
+
+public int Native_StartReplay(Handle handler, int numParams)
+{
+	int style = GetNativeCell(1);
+	int track = GetNativeCell(2);
+	float delay = GetNativeCell(3);
+	int client = GetNativeCell(4);
+
+	if(gA_FrameCache[style][track].iFrameCount == 0)
+	{
+		return false;
+	}
+
+	gI_ReplayTick[style] = 0;
+	gI_TimerTick[style] = 0;
+	gA_CentralCache.iStyle = style;
+	gA_CentralCache.iTrack = track;
+	gA_CentralCache.iPlaybackSerial = GetClientSerial(client);
+	gF_LastInteraction[client] = GetEngineTime();
+	gI_ReplayBotClient[style] = gA_CentralCache.iClient;
+	gRS_ReplayStatus[style] = gA_CentralCache.iReplayStatus = Replay_Start;
+	TeleportToStart(gA_CentralCache.iClient, style, track);
+	gB_ForciblyStopped = false;
+
+	float time = GetReplayLength(gA_CentralCache.iStyle, track);
+
+	UpdateReplayInfo(gA_CentralCache.iClient, style, time, track);
+
+	delete gH_ReplayTimers[style];
+	gH_ReplayTimers[style] = CreateTimer((delay / 2.0), Timer_StartReplay, style, TIMER_FLAG_NO_MAPCHANGE);
+
+	return true;
 }
 
 public int Native_ReloadReplay(Handle handler, int numParams)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -147,6 +147,7 @@ Convar gCV_UseCustomSprite = null;
 Convar gCV_Height = null;
 Convar gCV_Offset = null;
 Convar gCV_EnforceTracks = null;
+Convar gCV_BoxOffset = null;
 
 // handles
 Handle gH_DrawEverything = null;
@@ -248,7 +249,8 @@ public void OnPluginStart()
 	gCV_UseCustomSprite = new Convar("shavit_zones_usecustomsprite", "1", "Use custom sprite for zone drawing?\nSee `configs/shavit-zones.cfg`.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_Height = new Convar("shavit_zones_height", "128.0", "Height to use for the start zone.", 0, true, 0.0, false);
 	gCV_Offset = new Convar("shavit_zones_offset", "0.5", "When calculating a zone's *VISUAL* box, by how many units, should we scale it to the center?\n0.0 - no downscaling. Values above 0 will scale it inward and negative numbers will scale it outwards.\nAdjust this value if the zones clip into walls.");
-	gCV_EnforceTracks = new Convar("shavit_zones_enforcetracks", "1", "Enforce zone tracks upon entry?\n0 - allow every zone except for start/end to affect users on every zone.\n1- require the user's track to match the zone's track.", 0, true, 0.0, true, 1.0);
+	gCV_EnforceTracks = new Convar("shavit_zones_enforcetracks", "1", "Enforce zone tracks upon entry?\n0 - allow every zone except for start/end to affect users on every zone.\n1 - require the user's track to match the zone's track.", 0, true, 0.0, true, 1.0);
+	gCV_BoxOffset = new Convar("shavit_zones_box_offset", "16", "Offset zone trigger boxes by this many unit\n0 - matches players bounding box\n16 - matches players center");
 
 	gCV_Interval.AddChangeHook(OnConVarChanged);
 	gCV_UseCustomSprite.AddChangeHook(OnConVarChanged);
@@ -2887,14 +2889,14 @@ public void CreateZoneEntities()
 		float height = ((IsSource2013(gEV_Type))? 62.0:72.0) / 2;
 
 		float min[3];
-		min[0] = -distance_x + 16.0;
-		min[1] = -distance_y + 16.0;
+		min[0] = -distance_x + gCV_BoxOffset.FloatValue;
+		min[1] = -distance_y + gCV_BoxOffset.FloatValue;
 		min[2] = -distance_z + height;
 		SetEntPropVector(entity, Prop_Send, "m_vecMins", min);
 
 		float max[3];
-		max[0] = distance_x - 16.0;
-		max[1] = distance_y - 16.0;
+		max[0] = distance_x - gCV_BoxOffset.FloatValue;
+		max[1] = distance_y - gCV_BoxOffset.FloatValue;
 		max[2] = distance_z - height;
 		SetEntPropVector(entity, Prop_Send, "m_vecMaxs", max);
 

--- a/addons/sourcemod/translations/shavit-core.phrases.txt
+++ b/addons/sourcemod/translations/shavit-core.phrases.txt
@@ -121,4 +121,9 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"You {1}can't{2} teleport as an end zone for the map is not defined."
 	}
+	"DebugOffsets"
+	{
+		"#format"	"{1:f}"
+		"en"		"Your tick offset was {1}."
+	}
 }

--- a/addons/sourcemod/translations/shavit-hud.phrases.txt
+++ b/addons/sourcemod/translations/shavit-hud.phrases.txt
@@ -43,10 +43,6 @@
 	{
 		"en"		"Time"
 	}
-	"HudTimeDiffText"
-	{
-		"en"		"Time difference"
-	}
 	"HudBestText"
 	{
 		"en"		"Best"


### PR DESCRIPTION
Two new cvars:
- shavit_core_useoffsets (0/1) 
- shavit_core_debugoffsets (1/0)

Tick calculation is now done in IGameMovement::ProcessMovement
Added tick fractioning system from Momentum Mod.
Added StartReplay native to allow support for per-player replays. 

Tested and working on both csgo and css.