### PR TITLE
fix using -1 for shavit_misc_persistdata

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -762,6 +762,9 @@ public MRESReturn CCSPlayer__GetPlayerMaxSpeed(int pThis, Handle hReturn)
 
 public Action Timer_Cron(Handle Timer)
 {
+	if (gCV_PersistData.FloatValue == -1.0)
+		return Plugin_Continue;
+
 	int iLength = gA_PersistentData.Length;
 	float fTime = GetEngineTime();
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -762,8 +762,10 @@ public MRESReturn CCSPlayer__GetPlayerMaxSpeed(int pThis, Handle hReturn)
 
 public Action Timer_Cron(Handle Timer)
 {
-	if (gCV_PersistData.FloatValue == -1.0)
+	if(gCV_PersistData.FloatValue < 0.0)
+	{
 		return Plugin_Continue;
+	}
 
 	int iLength = gA_PersistentData.Length;
 	float fTime = GetEngineTime();


### PR DESCRIPTION
The convar says `-1 - Until map change` which doesn't work. Persistent data is deleted by the timer every 10 seconds due to `fTime - aData.fDisconnectTime >= gCV_PersistData.FloatValue` always being true when shavit_misc_persistdata is -1