### PR TITLE
fix error that happens if you 'sm_tele 0' with no checkpoints

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2390,7 +2390,7 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 
 void TeleportToCheckpoint(int client, int index, bool suppressMessage)
 {
-	if(index < 0 || index > gCV_MaxCP.IntValue || (!gCV_Checkpoints.BoolValue && !CanSegment(client)))
+	if(index < 1 || index > gCV_MaxCP.IntValue || (!gCV_Checkpoints.BoolValue && !CanSegment(client)))
 	{
 		return;
 	}


### PR DESCRIPTION
An `index` of 0 becomes -1 here
https://github.com/shavitush/bhoptimer/blob/05614c1d514c053bf062bfb4cd1e7f997512c3e3/addons/sourcemod/scripting/shavit-misc.sp#L2413
```
L 10/15/2020 - 02:36:14: [SM] Exception reported: Invalid index -1 (count: 0)
L 10/15/2020 - 02:36:14: [SM] Blaming: shavit-misc.smx
L 10/15/2020 - 02:36:14: [SM] Call stack trace:
L 10/15/2020 - 02:36:14: [SM]   [0] ArrayList.GetArray
L 10/15/2020 - 02:36:14: [SM]   [1] Line 2409, shavit-misc.sp::TeleportToCheckpoint
L 10/15/2020 - 02:36:14: [SM]   [2] Line 1779, shavit-misc.sp::Command_Tele
```
(line numbers aren't the same due to other changes)