### PR TITLE
grab Z from replay origin for dynamic time diff

### DIFF
--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2818,7 +2818,7 @@ float GetClosestReplayTime(int client, int style, int track)
 
 	for(int frame = iStartFrame; frame < iEndFrame; frame++)
 	{
-		gA_Frames[style][track].GetArray(frame, fReplayPos, 2);
+		gA_Frames[style][track].GetArray(frame, fReplayPos, 3);
 
 		float dist = GetVectorDistance(fClientPos, fReplayPos, true);
 		if(dist < fMinDist)


### PR DESCRIPTION
This is a part of the fix for #953 