### PR TITLE
Don't include preframe count for dynamic time diff

### DIFF
--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2786,7 +2786,7 @@ float GetClosestReplayTime(int client, int style, int track)
 	int iLength = gA_Frames[style][track].Length;
 	int iPreframes = gA_FrameCache[style][track].iPreFrames;
 	int iSearch = RoundToFloor(gCV_DynamicTimeSearch.FloatValue * (1.0 / GetTickInterval()));
-	int iPlayerFrames = gA_PlayerFrames[client].Length;
+	int iPlayerFrames = gA_PlayerFrames[client].Length - gI_PlayerPrerunFrames[client];
 
 	int iStartFrame = iPlayerFrames - iSearch;
 	if(iStartFrame < 0)


### PR DESCRIPTION
https://github.com/shavitush/bhoptimer/issues/953#issuecomment-674516766
"Also, when you go back to startzone (not with !r) your dynamic time is not back to 0 when you have more than 10 seconds on the timer (you can have even 30 on it, walk back to startzone, walk out and it will show -10 sec on dynamic timer right away)."

Someone else test this patch too @Nairdaa 