### PR TITLE
minor shavit-chatsettings fix

### DIFF
--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -259,23 +259,27 @@ bool LoadChatSettings()
 	}
 
 	gSM_Messages.Clear();
+	bool failed;
 
 	if(gEV_Type == Engine_CSS)
 	{
-		kv.JumpToKey("CS:S");
+		failed = !kv.JumpToKey("CS:S");
 	}
 
 	else if(gEV_Type == Engine_CSGO)
 	{
-		kv.JumpToKey("CS:GO");
+		failed = !kv.JumpToKey("CS:GO");
 	}
 
 	if(gEV_Type == Engine_TF2)
 	{
-		kv.JumpToKey("TF2");
+		failed = !kv.JumpToKey("TF2");
 	}
 
-	kv.GotoFirstSubKey(false);
+	if(failed || !kv.GotoFirstSubKey(false))
+	{
+		SetFailState("Invalid \"configs/shavit-chatsettings.cfg\" file, or the game section is missing");
+	}
 
 	do
 	{

--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -100,8 +100,7 @@ bool gB_Protobuf = false;
 bool gB_NewMessage[MAXPLAYERS+1];
 StringMap gSM_Messages = null;
 
-char gS_ControlCharacters[][] = { "\n", "\t", "\r",
-	"\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\x09",
+char gS_ControlCharacters[][] = {"\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\x09",
 	"\x0A", "\x0B", "\x0C", "\x0D", "\x0E", "\x0F", "\x10" };
 
 public Plugin myinfo =
@@ -180,7 +179,7 @@ bool LoadChatConfig()
 
 	KeyValues kv = new KeyValues("shavit-chat");
 	
-	if(!kv.ImportFromFile(sPath) || !kv.GotoFirstSubKey())
+	if(!kv.ImportFromFile(sPath))
 	{
 		delete kv;
 


### PR DESCRIPTION
"this breaks the parsing and it always parses CS:S section"
made a PR on behalf of GAMMACASE


also by the way removed the useless " \t \n \r " cus it's already in there defined as hex, pointless to have it defined twice