### PR TITLE
Multiple bonuses

### DIFF
--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -455,9 +455,9 @@ stock bool GuessBestMapName(ArrayList maps, const char[] input, char[] output, i
 stock void GetTrackName(int client, int track, char[] output, int size)
 {
 	if (track == Track_Main)
-		FormatEx(output, size, "%T", "Track_Main", track, client);
+		FormatEx(output, size, "%T", "Track_Main", client, track);
 	else if (track >= Track_Bonus)
-		FormatEx(output, size, "%T", "Track_Bonus", track, client);
+		FormatEx(output, size, "%T", "Track_Bonus", client, track);
 	else //if (track < Track_Main)
 		FormatEx(output, size, "%T", "Track_Unknown", client);
 }

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -455,9 +455,9 @@ stock bool GuessBestMapName(ArrayList maps, const char[] input, char[] output, i
 stock void GetTrackName(int client, int track, char[] output, int size)
 {
 	if (track == Track_Main)
-		FormatEx(output, size, "%T", "Track_Main", sTrack, client);
+		FormatEx(output, size, "%T", "Track_Main", track, client);
 	else if (track >= Track_Bonus)
-		FormatEx(output, size, "%T", "Track_Bonus", sTrack, client);
+		FormatEx(output, size, "%T", "Track_Bonus", track, client);
 	else //if (track < Track_Main)
 		FormatEx(output, size, "%T", "Track_Unknown", client);
 }

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -113,6 +113,7 @@ enum
 {
 	Track_Main,
 	Track_Bonus,
+	Track_Bonus_Last = 8,
 	TRACKS_SIZE
 };
 

--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -451,6 +451,16 @@ stock bool GuessBestMapName(ArrayList maps, const char[] input, char[] output, i
 	return false;
 }
 
+stock void GetTrackName(int client, int track, char[] output, int size)
+{
+	if (track == Track_Main)
+		FormatEx(output, size, "%T", "Track_Main", sTrack, client);
+	else if (track >= Track_Bonus)
+		FormatEx(output, size, "%T", "Track_Bonus", sTrack, client);
+	else //if (track < Track_Main)
+		FormatEx(output, size, "%T", "Track_Unknown", client);
+}
+
 /**
  * Called before shavit-core processes the client's usercmd.
  * Before this is called, safety checks (fake/dead clients) happen.

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -574,7 +574,7 @@ public Action Command_StartTimer(int client, int args)
 			track = StringToInt(arg);
 		}
 
-		if (track < Track_Bonus)
+		if (track < Track_Bonus || track > Track_Bonus_Last)
 		{
 			track = Track_Bonus;
 		}
@@ -634,7 +634,7 @@ public Action Command_TeleportEnd(int client, int args)
 			track = StringToInt(arg);
 		}
 
-		if (track < Track_Bonus)
+		if (track < Track_Bonus || track > Track_Bonus_Last)
 		{
 			track = Track_Bonus;
 		}

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -563,7 +563,21 @@ public Action Command_StartTimer(int client, int args)
 
 	if(StrContains(sCommand, "sm_b", false) == 0)
 	{
-		track = Track_Bonus;
+		if (args < 1)
+		{
+			track = Shavit_GetClientTrack(client);
+		}
+		else
+		{
+			char arg[6];
+			GetCmdArg(1, arg, sizeof(arg));
+			track = StringToInt(arg);
+		}
+
+		if (track < Track_Bonus)
+		{
+			track = Track_Bonus;
+		}
 	}
 
 	if(gCV_AllowTimerWithoutZone.BoolValue || (gB_Zones && (Shavit_ZoneExists(Zone_Start, track) || gB_KZMap)))
@@ -609,7 +623,21 @@ public Action Command_TeleportEnd(int client, int args)
 
 	if(StrContains(sCommand, "sm_b", false) == 0)
 	{
-		track = Track_Bonus;
+		if (args < 1)
+		{
+			track = Shavit_GetClientTrack(client);
+		}
+		else
+		{
+			char arg[6];
+			GetCmdArg(1, arg, sizeof(arg));
+			track = StringToInt(arg);
+		}
+
+		if (track < Track_Bonus)
+		{
+			track = Track_Bonus;
+		}
 	}
 
 	if(gB_Zones && (Shavit_ZoneExists(Zone_End, track) || gB_KZMap))
@@ -1120,7 +1148,7 @@ public Action Command_Style(int client, int args)
 				char sWR[8];
 				strcopy(sWR, 8, "WR");
 
-				if(gA_Timers[client].iTrack == Track_Bonus)
+				if(gA_Timers[client].iTrack >= Track_Bonus)
 				{
 					strcopy(sWR, 8, "BWR");
 				}
@@ -3514,18 +3542,4 @@ void UpdateStyleSettings(int client)
 	UpdateAiraccelerate(client, view_as<float>(gA_StyleSettings[gA_Timers[client].iStyle].fAiraccelerate));
 
 	SetEntityGravity(client, view_as<float>(gA_StyleSettings[gA_Timers[client].iStyle].fGravityMultiplier));
-}
-
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
 }

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1923,20 +1923,6 @@ public int Native_GetHUDSettings(Handle handler, int numParams)
 	return gI_HUDSettings[client];
 }
 
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
-}
-
 void PrintCSGOHUDText(int client, const char[] format, any ...)
 {
 	char buff[MAX_HINT_SIZE];

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -961,11 +961,15 @@ void UpdateClanTag(int client)
 	}
 
 	int track = Shavit_GetClientTrack(client);
-	char sTrack[3];
+	char sTrack[4];
 
 	if(track != Track_Main)
 	{
-		GetTrackName(client, track, sTrack, 3);
+		sTrack[0] = 'B';
+		if (track > Track_Bonus)
+		{
+			FormatEx(sTrack, sizeof(sTrack), "B%d", track);
+		}
 	}
 
 	char sRank[8];
@@ -2852,20 +2856,6 @@ public Action Shavit_OnStart(int client)
 	}
 
 	return Plugin_Continue;
-}
-
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
 }
 
 public void Shavit_OnWorldRecord(int client, int style, float time, int jumps, int strafes, float sync, int track)

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -86,8 +86,6 @@ Handle gH_Forwards_OnRankAssigned = null;
 chatstrings_t gS_ChatStrings;
 int gI_Styles = 0;
 stylesettings_t gA_StyleSettings[STYLE_LIMIT];
-char gS_StyleNames[STYLE_LIMIT][64];
-char gS_TrackNames[TRACKS_SIZE][32];
 
 public Plugin myinfo =
 {
@@ -159,11 +157,6 @@ public void OnPluginStart()
 		Shavit_OnChatConfigLoaded();
 	}
 
-	for(int i = 0; i < TRACKS_SIZE; i++)
-	{
-		GetTrackName(LANG_SERVER, i, gS_TrackNames[i], 32);
-	}
-
 	SQL_DBConnect();
 }
 
@@ -187,7 +180,6 @@ public void Shavit_OnStyleConfigLoaded(int styles)
 	for(int i = 0; i < gI_Styles; i++)
 	{
 		Shavit_GetStyleSettings(i, gA_StyleSettings[i]);
-		Shavit_GetStyleStrings(i, sStyleName, gS_StyleNames[i], 64);
 	}
 }
 
@@ -870,20 +862,6 @@ public void SQL_UpdateTop100_Callback(Database db, DBResultSet results, const ch
 	}
 
 	gH_Top100Menu.ExitButton = true;
-}
-
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
 }
 
 public int Native_GetMapTier(Handle handler, int numParams)

--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -637,7 +637,7 @@ void RecalculateAll(const char[] map)
 	LogError("DEBUG: 5 (RecalculateAll)");
 	#endif
 
-	for(int i = 0; i < TRACKS_SIZE; i++)
+	for(int i = 0; i < 3; i++)
 	{
 		for(int j = 0; j < gI_Styles; j++)
 		{
@@ -646,7 +646,7 @@ void RecalculateAll(const char[] map)
 				continue;
 			}
 
-			RecalculateMap(map, i, j);
+			RecalculateMap(map, i, j, (i > Track_Bonus));
 		}
 	}
 }
@@ -656,15 +656,23 @@ public void Shavit_OnFinish_Post(int client, int style, float time, int jumps, i
 	RecalculateMap(gS_Map, track, style);
 }
 
-void RecalculateMap(const char[] map, const int track, const int style)
+void RecalculateMap(const char[] map, const int track, const int style, bool restOfTheBonuses=false)
 {
 	#if defined DEBUG
 	PrintToServer("Recalculating points. (%s, %d, %d)", map, track, style);
 	#endif
 
 	char sQuery[256];
-	FormatEx(sQuery, 256, "UPDATE %splayertimes SET points = GetRecordPoints(%d, %d, time, '%s', %.1f, %.3f) WHERE style = %d AND track = %d AND map = '%s';",
+	if (restOfTheBonuses)
+	{
+		FormatEx(sQuery, 256, "UPDATE %splayertimes SET points = GetRecordPoints(%d, track, time, '%s', %.1f, %.3f) WHERE style = %d AND track > 1 AND map = '%s';",
+		gS_MySQLPrefix, style, map, gCV_PointsPerTier.FloatValue, gA_StyleSettings[style].fRankingMultiplier, style, map);
+	}
+	else
+	{
+		FormatEx(sQuery, 256, "UPDATE %splayertimes SET points = GetRecordPoints(%d, %d, time, '%s', %.1f, %.3f) WHERE style = %d AND track = %d AND map = '%s';",
 		gS_MySQLPrefix, style, track, map, gCV_PointsPerTier.FloatValue, gA_StyleSettings[style].fRankingMultiplier, style, track, map);
+	}
 
 	gH_SQL.Query(SQL_Recalculate_Callback, sQuery, 0, DBPrio_High);
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2781,20 +2781,6 @@ int GetSpectatorTarget(int client)
 	return target;
 }
 
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
-}
-
 float GetReplayLength(int style, int track)
 {
 	if(gA_FrameCache[style][track].iFrameCount == 0)

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -717,7 +717,7 @@ public any Native_GetReplayTime(Handle handler, int numParams)
 	int style = GetNativeCell(1);
 	int track = GetNativeCell(2);
 
-	if(style < 0 || track < 0)
+	if(style < 0 || track < 0 || track >= TRACKS_SIZE)
 	{
 		return ThrowNativeError(200, "Style/Track out of range");
 	}

--- a/addons/sourcemod/scripting/shavit-stats.sp
+++ b/addons/sourcemod/scripting/shavit-stats.sp
@@ -935,17 +935,3 @@ public int Native_GetWRCount(Handle handler, int numParams)
 {
 	return gI_WRAmount[GetNativeCell(1)];
 }
-
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
-}

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1338,6 +1338,18 @@ public Action Command_WorldRecord(int client, int args)
 	if(StrContains(sCommand, "sm_b", false) == 0)
 	{
 		track = Track_Bonus;
+
+		if (args > 1)
+		{
+			char arg[6];
+			GetCmdArg(1, arg, sizeof(arg));
+			track = StringToInt(arg);
+
+			if (track < Track_Bonus)
+			{
+				track = Track_Bonus;
+			}
+		}
 	}
 
 	return ShowWRStyleMenu(client, track);
@@ -2264,18 +2276,4 @@ int GetRankForTime(int style, float time, int track)
 	}
 
 	return (iRecords + 1);
-}
-
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
 }

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -144,9 +144,9 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_wr", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_wr [map]");
 	RegConsoleCmd("sm_worldrecord", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_worldrecord [map]");
 
-	RegConsoleCmd("sm_bwr", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bwr [map]");
-	RegConsoleCmd("sm_bworldrecord", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bworldrecord [map]");
-	RegConsoleCmd("sm_bonusworldrecord", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bonusworldrecord [map]");
+	RegConsoleCmd("sm_bwr", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bwr [map] [bonus number]");
+	RegConsoleCmd("sm_bworldrecord", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bworldrecord [map] [bonus number]");
+	RegConsoleCmd("sm_bonusworldrecord", Command_WorldRecord, "View the leaderboard of a map. Usage: sm_bonusworldrecord [map] [bonus number]");
 
 	RegConsoleCmd("sm_recent", Command_RecentRecords, "View the recent #1 times set.");
 	RegConsoleCmd("sm_recentrecords", Command_RecentRecords, "View the recent #1 times set.");

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1329,6 +1329,7 @@ public Action Command_WorldRecord(int client, int args)
 			GetCmdArg((args > 1) ? 2 : 1, arg, sizeof(arg));
 			track = StringToInt(arg);
 
+			// if the track doesn't fit in the bonus track range then assume it's a map name
 			if (args > 1 || (track < Track_Bonus || track > Track_Bonus_Last))
 			{
 				havemap = true;
@@ -1339,6 +1340,11 @@ public Action Command_WorldRecord(int client, int args)
 		{
 			track = Track_Bonus;
 		}
+	}
+
+	else
+	{
+		havemap = (args >= 1);
 	}
 
 	if(!havemap)

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1315,40 +1315,44 @@ public Action Command_WorldRecord(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(args == 0)
+	char sCommand[16];
+	GetCmdArg(0, sCommand, 16);
+
+	int track = Track_Main;
+	bool havemap = false;
+
+	if(StrContains(sCommand, "sm_b", false) == 0)
+	{
+		if (args >= 1)
+		{
+			char arg[6];
+			GetCmdArg((args > 1) ? 2 : 1, arg, sizeof(arg));
+			track = StringToInt(arg);
+
+			if (args > 1 || (track < Track_Bonus || track > Track_Bonus_Last))
+			{
+				havemap = true;
+			}
+		}
+
+		if (track < Track_Bonus || track > Track_Bonus_Last)
+		{
+			track = Track_Bonus;
+		}
+	}
+
+	if(!havemap)
 	{
 		strcopy(gA_WRCache[client].sClientMap, 128, gS_Map);
 	}
 
 	else
 	{
-		GetCmdArgString(gA_WRCache[client].sClientMap, 128);
+		GetCmdArg(1, gA_WRCache[client].sClientMap, 128);
 		if (!GuessBestMapName(gA_ValidMaps, gA_WRCache[client].sClientMap, gA_WRCache[client].sClientMap, 128))
 		{
 			Shavit_PrintToChat(client, "%t", "Map was not found", gA_WRCache[client].sClientMap);
 			return Plugin_Handled;
-		}
-	}
-
-	char sCommand[16];
-	GetCmdArg(0, sCommand, 16);
-
-	int track = Track_Main;
-
-	if(StrContains(sCommand, "sm_b", false) == 0)
-	{
-		track = Track_Bonus;
-
-		if (args > 1)
-		{
-			char arg[6];
-			GetCmdArg(1, arg, sizeof(arg));
-			track = StringToInt(arg);
-
-			if (track < Track_Bonus || track > Track_Bonus_Last)
-			{
-				track = Track_Bonus;
-			}
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1345,7 +1345,7 @@ public Action Command_WorldRecord(int client, int args)
 			GetCmdArg(1, arg, sizeof(arg));
 			track = StringToInt(arg);
 
-			if (track < Track_Bonus)
+			if (track < Track_Bonus || track > Track_Bonus_Last)
 			{
 				track = Track_Bonus;
 			}

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -801,6 +801,11 @@ public void Frame_HookTrigger(any data)
 		return;
 	}
 
+	if (StrContains(sName, "checkpoint") != -1)
+	{
+		return; // TODO
+	}
+
 	int zone = -1;
 	int track = Track_Main;
 

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -816,7 +816,16 @@ public void Frame_HookTrigger(any data)
 
 	if(StrContains(sName, "bonus") != -1)
 	{
-		track = Track_Bonus;
+		// Parse out the X in mod_zone_bonus_X_start and mod_zone_bonus_X_end
+		char sections[8][8];
+		ExplodeString(sName, "_", sections, 8, 8, false);
+		track = StringToInt(sections[3]); // 0 on failure to parse. 0 is less than Track_Bonus
+
+		if (track < Track_Bonus || track > Track_Bonus_Last)
+		{
+			// Just ignore because there's either too many bonuses or X can be 0 and nobody told me
+			return;
+		}
 	}
 
 	if(zone != -1)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2196,20 +2196,6 @@ public Action OnClientSayCommand(int client, const char[] command, const char[] 
 	return Plugin_Continue;
 }
 
-void GetTrackName(int client, int track, char[] output, int size)
-{
-	if(track < 0 || track >= TRACKS_SIZE)
-	{
-		FormatEx(output, size, "%T", "Track_Unknown", client);
-
-		return;
-	}
-
-	static char sTrack[16];
-	FormatEx(sTrack, 16, "Track_%d", track);
-	FormatEx(output, size, "%T", sTrack, client);
-}
-
 void UpdateTeleportZone(int client)
 {
 	float vTeleport[3];

--- a/addons/sourcemod/translations/shavit-common.phrases.txt
+++ b/addons/sourcemod/translations/shavit-common.phrases.txt
@@ -9,13 +9,14 @@
 	{
 		"en"		"UNKNOWN TRACK"
 	}
-	"Track_0"
+	"Track_Main"
 	{
 		"en"		"Main"
 	}
-	"Track_1"
+	"Track_Bonus"
 	{
-		"en"		"Bonus"
+		"#format"	"{1:d}"
+		"en"		"Bonus #{1}"
 	}
 	// ---------- Commands ---------- //
 	"NoCommandAccess"


### PR DESCRIPTION
i want feature parity with surf timers like ksf's so i did this
up to 8 bonuses should work now since I expanded the TRACKS_SIZE (i have no idea what the max number of bonuses a map has so I just made it 8)
_also i'm very lazy, carnifex_
todo:
- a menu added for !bwr that allows you to select which bonus number to view times from
- ~~add the number to BWR text [hereish](https://github.com/shavitush/bhoptimer/pull/982/files#diff-a6d6c2b4761eea8f68202daa7a99cb0b1fcd07186b000ca75e9db88a587769c5R1151)~~ nevermind. not needed
- ~~fix slow zone loading on map change... went from 7~ seconds to 30~ seconds on my server...~~ fixed
  - caused by recalcing a shit ton of zones/styles on map start [here](https://github.com/shavitush/bhoptimer/blob/ac889722d5a648c586ebc6c0476a11347b21eb53/addons/sourcemod/scripting/shavit-rankings.sp#L648)
- figure out why EndTouchPost can have `-1` as the track...
```
L 11/23/2020 - 23:12:57: [SM] Exception reported: Array index out-of-bounds (index -1, limit 13)
L 11/23/2020 - 23:12:57: [SM] Blaming: shavit-zones.smx
L 11/23/2020 - 23:12:57: [SM] Call stack trace:
L 11/23/2020 - 23:12:57: [SM]   [1] Line 3058, shavit-zones.sp::EndTouchPost
```
```
int track = gA_ZoneCache[entityzone].iZoneTrack;

gB_InsideZone[other][type][track] = false;
gB_InsideZoneID[other][entityzone] = false;
```