### PR TITLE
Fixed incorrect kv traversal for shavit-chatsettings.cfg

### DIFF
--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -179,7 +179,7 @@ bool LoadChatConfig()
 
 	KeyValues kv = new KeyValues("shavit-chat");
 	
-	if(!kv.ImportFromFile(sPath))
+	if(!kv.ImportFromFile(sPath) || !kv.GotoFirstSubKey())
 	{
 		delete kv;
 
@@ -251,7 +251,7 @@ bool LoadChatSettings()
 
 	KeyValues kv = new KeyValues("shavit-chat");
 	
-	if(!kv.ImportFromFile(sPath) || !kv.GotoFirstSubKey())
+	if(!kv.ImportFromFile(sPath))
 	{
 		delete kv;
 


### PR DESCRIPTION
Actual fix for the shavit-chatsettings.cfg, also fixed back what was incorrectly removed before.