### PR TITLE
Time difference optimizations

### DIFF
--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1104,7 +1104,7 @@ int AddHUDToBuffer_Source2013(int client, huddata_t data, char[] buffer, int max
 
 			char sTimeDiff[32];
 			
-			if(gB_Replay && gCV_EnableDynamicTimeDifference.BoolValue && Shavit_GetReplayFrameCount(data.iStyle, data.iTrack) != 0 && (gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0)
+			if(gB_Replay && gCV_EnableDynamicTimeDifference.BoolValue && Shavit_GetReplayFrameCount(data.iStyle, data.iTrack) != 0 && (gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0 && data.fTime != 0.0)
 			{
 				float fClosestReplayTime = Shavit_GetClosestReplayTime(data.iTarget, data.iStyle, data.iTrack);
 
@@ -1321,7 +1321,7 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 			
 			char sTimeDiff[32];
 			
-			if(gB_Replay && gCV_EnableDynamicTimeDifference.BoolValue && Shavit_GetReplayFrameCount(data.iStyle, data.iTrack) != 0 && (gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0)
+			if(gB_Replay && gCV_EnableDynamicTimeDifference.BoolValue && Shavit_GetReplayFrameCount(data.iStyle, data.iTrack) != 0 && (gI_HUD2Settings[client] & HUD2_TIMEDIFFERENCE) == 0 && data.fTime != 0.0)
 			{
 				float fClosestReplayTime = Shavit_GetClosestReplayTime(data.iTarget, data.iStyle, data.iTrack);
 

--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -2888,7 +2888,8 @@ float GetClosestReplayTime(int client, int style, int track)
 	int iLength = has_cache ? gReplayCacheLength[style][track] : gA_Frames[style][track].Length;
 	int iPreframes = gA_FrameCache[style][track].iPreFrames;
 	int iSearch = RoundToFloor(gCV_DynamicTimeSearch.FloatValue * (1.0 / GetTickInterval()));
-	int iPlayerFrames = gA_PlayerFrames[client].Length - gI_PlayerPrerunFrames[client];
+	//int iPlayerFrames = gA_PlayerFrames[client].Length - gI_PlayerPrerunFrames[client];
+	int iPlayerFrames = RoundToNearest(Shavit_GetClientTime(client) / GetTickInterval());
 	int offset = RoundToNearest(float(iLength) * gCV_DynamicTimeOffsetPct.FloatValue);
 	
 	static int prevframe[MAXPLAYERS];


### PR DESCRIPTION
This pr is mainly aimed as a reference and I fully understand that this pr might not get accepted due to increase in compile times or some other factors (Yes the main cause of increased compile time is the insanely large local array that's used as a cache).
Optimizations that were done:
* Caching replay data into local array (``shavit_replay_timedifference_use_cache`` cvar to enable), thus removing ``Array.GetArray()`` calls from the main timediff loop;
* Saving previous found frame and working with it as a starting point, thus I also introduced ``shavit_replay_timedifference_offset_pct`` cvar that is aimed to search forward and behind by N% of the total replay frames and saving some loop time;
* ``TIMEDIFF_STEPSIZE`` define that's aimed to cut down replay into chunks as there's no need for insane precision (besides start maybe, thus ``shavit_replay_timedifference_precise_start`` is used here), and 0.1 is enough, thus cutting down replay frames by 12 (works alright in CSGO but might need to be lowered to work okay in CSS or other low tickrate games), shrinks it insanely and also saves a lot of loop time;
* ``shavit_replay_timedifference_dist_to_check`` that'll stop the loop when it reaches some really high value meaning that player is too far away and there's no need to search further (This might be redundant as I decided not to use it in the end).

Also this pr includes fixes to ``gI_PlayerPrerunFrames[]`` variable as it were broken before, and some other code fixups, like a while loop to clear garbage data in ``Shavit_OnStart()`` and some preframe saving fixes as well as timediff on practice.