### PR TITLE
Fixed bad replay timer playback.

### DIFF
--- a/addons/sourcemod/scripting/shavit-replay.sp
+++ b/addons/sourcemod/scripting/shavit-replay.sp
@@ -250,8 +250,7 @@ public void OnPluginStart()
 
 	// game specific
 	gEV_Type = GetEngineVersion();
-	gF_Tickrate = (1.0 / GetTickInterval());
-
+	
 	FindConVar((gEV_Type != Engine_TF2)? "bot_quota":"tf_bot_quota").Flags &= ~FCVAR_NOTIFY;
 	FindConVar("bot_stop").Flags &= ~FCVAR_CHEAT;
 
@@ -1534,6 +1533,8 @@ void UpdateReplayInfo(int client, int style, float time, int track)
 	{
 		return;
 	}
+	
+	gF_Tickrate = (1.0 / GetTickInterval());
 
 	SetEntProp(client, Prop_Data, "m_CollisionGroup", 2);
 	SetEntityMoveType(client, MOVETYPE_NOCLIP);


### PR DESCRIPTION
If any plugin changes the tickrate of the server (i.e Tickrate Control by Rostu), the playback of the replay's timer might be at the wrong speed. To fix this we just make sure gF_Tickrate is up to date when starting the replay.