### PR TITLE
Fix incorrect memory allocation for segmented checkpoints

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2506,9 +2506,13 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 		}
 		
 		if(gI_CurrentCheckpoint[client] >= gA_Checkpoints[client].Length)
+		{
 			gA_Checkpoints[client].Push(0);
+		}
 		else
+		{
 			gA_Checkpoints[client].ShiftUp(gI_CurrentCheckpoint[client]);
+		}
 		
 		gA_Checkpoints[client].SetArray(gI_CurrentCheckpoint[client], cpcache);
 	}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2502,10 +2502,14 @@ bool SaveCheckpoint(int client, int index, bool overflow = false)
 		{
 			delete view_as<ArrayList>(gA_Checkpoints[client].Get(0, cp_cache_t::aFrames));
 			gA_Checkpoints[client].Erase(0);
-			gI_CurrentCheckpoint[client] = gA_Checkpoints[client].Length;
+			gI_CurrentCheckpoint[client] = iMaxCPs - 1;
 		}
-
-		gA_Checkpoints[client].Push(0);
+		
+		if(gI_CurrentCheckpoint[client] >= gA_Checkpoints[client].Length)
+			gA_Checkpoints[client].Push(0);
+		else
+			gA_Checkpoints[client].ShiftUp(gI_CurrentCheckpoint[client]);
+		
 		gA_Checkpoints[client].SetArray(gI_CurrentCheckpoint[client], cpcache);
 	}
 	else 


### PR DESCRIPTION
This fixes incorrect memory allocation that allows users to go beyond the ``shavit_misc_maxcp_seg`` limit and spam segmented checkpoints to cause server to crash due to memory limit.