### PR TITLE
Fix unchecked dependency on shavit-rankings in shavit-chat

### DIFF
--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -1416,13 +1416,13 @@ void FormatChat(int client, char[] buffer, int size)
 
 		FormatEx(temp, 32, "%0.f", Shavit_GetPoints(client));
 		ReplaceString(buffer, size, "{pts}", temp);
+		
+		FormatEx(temp, 32, "%d", Shavit_GetWRHolderRank(client));
+		ReplaceString(buffer, size, "{wrrank}", temp);
+
+		FormatEx(temp, 32, "%d", Shavit_GetWRCount(client));
+		ReplaceString(buffer, size, "{wrs}", temp);
 	}
-
-	FormatEx(temp, 32, "%d", Shavit_GetWRHolderRank(client));
-	ReplaceString(buffer, size, "{wrrank}", temp);
-
-	FormatEx(temp, 32, "%d", Shavit_GetWRCount(client));
-	ReplaceString(buffer, size, "{wrs}", temp);
 
 	GetClientName(client, temp, 32);
 	ReplaceString(buffer, size, "{name}", temp);


### PR DESCRIPTION
If the shavit-rankings plugin isn't loaded, the calls to its natives will cause an exception and the client's messages will not be formatted correctly.