### PR TITLE
added missing prefix

### DIFF
--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -813,7 +813,7 @@ public void OnMapStart()
 public void LoadStageZones()
 {
 	char sQuery[256];
-	FormatEx(sQuery, 256, "SELECT id, data, track FROM mapzones WHERE type = %i and map = '%s'", Zone_Stage, gS_Map);
+	FormatEx(sQuery, 256, "SELECT id, data, track FROM %smapzones WHERE type = %i and map = '%s'", gS_MySQLPrefix, Zone_Stage, gS_Map);
 	gH_SQL.Query(SQL_GetStageZone_Callback, sQuery,0, DBPrio_High);
 }
 


### PR DESCRIPTION
to prevent fails for people that are using a prefix 
[shavit-zones.smx] Timer (zones GetStageZone) SQL query failed. Reason: Table 'bhoptimer.mapzones' doesn't exist
Query callback. Number of returned results: 399, Maps added to g_aMapList:284, g_aAllMapsList.Length:287, g_mMapList:286