### PR TITLE
Fix infinite loop in RemoveFromString()

### DIFF
--- a/addons/sourcemod/scripting/shavit-chat.sp
+++ b/addons/sourcemod/scripting/shavit-chat.sp
@@ -1580,10 +1580,18 @@ public void SQL_GetChat_Callback(Database db, DBResultSet results, const char[] 
 
 void RemoveFromString(char[] buf, char[] thing, int extra)
 {
-	int index;
+	int index, len = strlen(buf);
 	extra += strlen(thing);
+	
 	while ((index = StrContains(buf, thing, true)) != -1)
 	{
+		// Search sequence is in the end of the string, so just cut it and exit
+		if(index + extra >= len)
+		{
+			buf[index] = '\0';
+			break;
+		}
+		
 		while (buf[index] != 0)
 		{
 			buf[index] = buf[index+extra];


### PR DESCRIPTION
Currently it is possible to hit an infinite loop if the sm_ccname has non correct length sequence at the end (eg. ``^FFF``, where it would expect ``^FFFFFF``), this pr adds the necessary checks to verify that end of the string was set correctly.

Also ``when u pr make sure to notice "nairda found a new feature in the timer to crash any server with cc access"`` (c) Nairda.