### PR TITLE
Remove practice mode check for target/classname reset

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2947,7 +2947,7 @@ public Action Shavit_OnStart(int client)
 		return Plugin_Stop;
 	}
 
-	if(gCV_ResetTargetname.BoolValue || Shavit_IsPracticeMode(client)) // practice mode can be abused to break map triggers
+	if(gCV_ResetTargetname.BoolValue)
 	{
 		DispatchKeyValue(client, "targetname", "");
 		SetEntPropString(client, Prop_Data, "m_iClassname", "player");


### PR DESCRIPTION
Having this check allows players to abuse the practice mode, to clear their targetname/classname on map start and abuse the map to do skips etc. (This is also what the comment was suggesting there I assume). Unsure why the check was there in the first place, but tested this for like a few month I believe and everything seems to be fine (on 2.6.0 version tho, but also tested locally on latest version too).