### PR TITLE
Handle multi byte symbols in player names in !recent menu correctly

### DIFF
--- a/addons/sourcemod/scripting/include/shavit.inc
+++ b/addons/sourcemod/scripting/include/shavit.inc
@@ -610,6 +610,28 @@ stock float GetAngleDiff(float current, float previous)
 	return diff - 360.0 * RoundToFloor((diff + 180.0) / 360.0);
 }
 
+// https://forums.alliedmods.net/showthread.php?t=216841
+// Trims display string to specified max possible length, and prepends "..." if initial string exceeds that length
+stock void TrimDisplayString(const char[] str, char[] outstr, int outstrlen, int max_allowed_length)
+{
+	int count, finallen;
+	for(int i = 0; str[i]; i++)
+	{
+		count += ((str[i] & 0xc0) != 0x80) ? 1 : 0;
+		
+		if(count <= max_allowed_length)
+		{
+			outstr[i] = str[i];
+			finallen = i;
+		}
+	}
+	
+	outstr[finallen + 1] = '\0';
+	
+	if(count > max_allowed_length)
+		Format(outstr, outstrlen, "%s...", outstr);
+}
+
 /**
  * Called before shavit-core processes the client's usercmd.
  * Before this is called, safety checks (fake/dead clients) happen.

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1741,7 +1741,7 @@ void UpdateSpectatorList(int client, Panel panel, bool &draw)
 
 			GetClientName(iSpectatorClients[i], sName, sizeof(sName));
 			ReplaceString(sName, sizeof(sName), "#", "?");
-			TrimPlayerName(sName, sName, sizeof(sName));
+			TrimDisplayString(sName, sName, sizeof(sName), gCV_SpecNameSymbolLength.IntValue);
 
 			panel.DrawItem(sName, ITEMDRAW_RAWLINE);
 		}
@@ -1946,7 +1946,7 @@ void UpdateKeyHint(int client)
 
 						GetClientName(iSpectatorClients[i], sName, sizeof(sName));
 						ReplaceString(sName, sizeof(sName), "#", "?");
-						TrimPlayerName(sName, sName, sizeof(sName));
+						TrimDisplayString(sName, sName, sizeof(sName), gCV_SpecNameSymbolLength.IntValue);
 						Format(sMessage, 256, "%s\n%s", sMessage, sName);
 					}
 				}
@@ -2044,25 +2044,3 @@ void PrintCSGOHUDText(int client, const char[] str)
 	
 	EndMessage();
 }
-
-// https://forums.alliedmods.net/showthread.php?t=216841
-void TrimPlayerName(const char[] name, char[] outname, int len)
-{
-	int count, finallen;
-	for(int i = 0; name[i]; i++)
-	{
-		count += ((name[i] & 0xc0) != 0x80) ? 1 : 0;
-		
-		if(count <= gCV_SpecNameSymbolLength.IntValue)
-		{
-			outname[i] = name[i];
-			finallen = i;
-		}
-	}
-	
-	outname[finallen + 1] = '\0';
-	
-	if(count > gCV_SpecNameSymbolLength.IntValue)
-		Format(outname, len, "%s...", outname);
-}
-

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1883,12 +1883,8 @@ public void SQL_RR_Callback(Database db, DBResultSet results, const char[] error
 		results.FetchString(1, sMap, sizeof(sMap));
 
 		char sName[MAX_NAME_LENGTH];
-		results.FetchString(2, sName, 10);
-
-		if(strlen(sName) >= 9)
-		{
-			Format(sName, MAX_NAME_LENGTH, "%s...", sName);
-		}
+		results.FetchString(2, sName, sizeof(sName));
+		TrimPlayerName(sName, sName, sizeof(sName), 9);
 
 		char sTime[16];
 		float fTime = results.FetchFloat(3);
@@ -2649,4 +2645,25 @@ int GetRankForTime(int style, float time, int track)
 float ExactTimeMaybe(float time, int exact_time)
 {
 	return (exact_time != 0) ? view_as<float>(exact_time) : time;
+}
+
+// https://forums.alliedmods.net/showthread.php?t=216841
+void TrimPlayerName(const char[] name, char[] outname, int len, int total_allowed_length)
+{
+	int count, finallen;
+	for(int i = 0; name[i]; i++)
+	{
+		count += ((name[i] & 0xc0) != 0x80) ? 1 : 0;
+		
+		if(count <= total_allowed_length)
+		{
+			outname[i] = name[i];
+			finallen = i;
+		}
+	}
+	
+	outname[finallen + 1] = '\0';
+	
+	if(count > total_allowed_length)
+		Format(outname, len, "%s...", outname);
 }

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -1884,7 +1884,7 @@ public void SQL_RR_Callback(Database db, DBResultSet results, const char[] error
 
 		char sName[MAX_NAME_LENGTH];
 		results.FetchString(2, sName, sizeof(sName));
-		TrimPlayerName(sName, sName, sizeof(sName), 9);
+		TrimDisplayString(sName, sName, sizeof(sName), 9);
 
 		char sTime[16];
 		float fTime = results.FetchFloat(3);
@@ -2645,25 +2645,4 @@ int GetRankForTime(int style, float time, int track)
 float ExactTimeMaybe(float time, int exact_time)
 {
 	return (exact_time != 0) ? view_as<float>(exact_time) : time;
-}
-
-// https://forums.alliedmods.net/showthread.php?t=216841
-void TrimPlayerName(const char[] name, char[] outname, int len, int total_allowed_length)
-{
-	int count, finallen;
-	for(int i = 0; name[i]; i++)
-	{
-		count += ((name[i] & 0xc0) != 0x80) ? 1 : 0;
-		
-		if(count <= total_allowed_length)
-		{
-			outname[i] = name[i];
-			finallen = i;
-		}
-	}
-	
-	outname[finallen + 1] = '\0';
-	
-	if(count > total_allowed_length)
-		Format(outname, len, "%s...", outname);
 }


### PR DESCRIPTION
Currently there's a problem with multi byte characters being cut early in the !recent menu:
![image](https://user-images.githubusercontent.com/31375974/130394009-6a7e5549-d926-472e-98e6-a9245205c11c.png)

Here's after this pr:
![image](https://user-images.githubusercontent.com/31375974/130394026-e0f61a82-c673-4187-885b-eee90557d735.png)

This pr should handle all multi byte symbols correctly, also there's already a TrimPlayerName() implementation in shavit-hud, and I'm unsure if it's better to just move it to shavit.inc as a stock and use from there as it might come handy again somewhere else idk.