### PR TITLE
Change the behaviour of shavit_misc_resettargetname

### DIFF
--- a/addons/sourcemod/configs/shavit-mapfixes.cfg
+++ b/addons/sourcemod/configs/shavit-mapfixes.cfg
@@ -1,8 +1,33 @@
 "Map fixes"
 {
+	"bhop_apathy"
+	{
+		"shavit_misc_resettargetname" "1"
+		"shavit_misc_resettargetname_main" "apathy"
+	}
 	"bhop_amaranthglow"
 	{
 		"shavit_zones_prebuilt_visual_offset" "16"
+	}
+	"bhop_crash_egypt"
+	{
+		"shavit_misc_resettargetname" "1"
+		"shavit_misc_resettargetname_main" "player"
+	}
+	"bhop_drop"
+	{
+		"shavit_misc_resettargetname" "1"
+		"shavit_misc_resettargetname_main" "activator_boost"
+	}
+	"bhop_japan"
+	{
+		"shavit_misc_resettargetname" "1"
+		"shavit_misc_resetclassname_main" "beginner"
+	}
+	"bhop_shutdown"
+	{
+		"shavit_misc_resettargetname" "1"
+		"shavit_misc_resettargetname_main" "asdf"
 	}
 	"bhop_strafecontrol"
 	{

--- a/addons/sourcemod/configs/shavit-mapfixes.cfg
+++ b/addons/sourcemod/configs/shavit-mapfixes.cfg
@@ -37,4 +37,8 @@
 	{
 		"shavit_zones_prebuilt_visual_offset" "16"
 	}
+	"bhop_solitude"
+	{
+		"shavit_misc_forcetargetnamereset" "1"
+	}
 }

--- a/addons/sourcemod/configs/shavit-mapfixes.cfg
+++ b/addons/sourcemod/configs/shavit-mapfixes.cfg
@@ -2,7 +2,7 @@
 {
 	"bhop_apathy"
 	{
-		"shavit_misc_resettargetname" "1"
+		"shavit_misc_forcetargetnamereset" "1"
 		"shavit_misc_resettargetname_main" "apathy"
 	}
 	"bhop_amaranthglow"
@@ -11,22 +11,22 @@
 	}
 	"bhop_crash_egypt"
 	{
-		"shavit_misc_resettargetname" "1"
+		"shavit_misc_forcetargetnamereset" "1"
 		"shavit_misc_resettargetname_main" "player"
 	}
 	"bhop_drop"
 	{
-		"shavit_misc_resettargetname" "1"
+		"shavit_misc_forcetargetnamereset" "1"
 		"shavit_misc_resettargetname_main" "activator_boost"
 	}
 	"bhop_japan"
 	{
-		"shavit_misc_resettargetname" "1"
+		"shavit_misc_forcetargetnamereset" "1"
 		"shavit_misc_resetclassname_main" "beginner"
 	}
 	"bhop_shutdown"
 	{
-		"shavit_misc_resettargetname" "1"
+		"shavit_misc_forcetargetnamereset" "1"
 		"shavit_misc_resettargetname_main" "asdf"
 	}
 	"bhop_strafecontrol"

--- a/addons/sourcemod/configs/shavit-mapfixes.cfg
+++ b/addons/sourcemod/configs/shavit-mapfixes.cfg
@@ -1,116 +1,15 @@
-
 "Map fixes"
 {
-	"bhop_appaisaniceman3"
-	{
-		"shavit_misc_resetclassname_main" "main"
-		"shavit_misc_resetclassname_bonus" "bonus_filter"
-	}
 	"bhop_amaranthglow"
 	{
 		"shavit_zones_prebuilt_visual_offset" "16"
-	}
-	"bhop_blackshit"
-	{
-		"shavit_misc_resettargetname_main" "fil_fw"
-	}
-	"bhop_crash_egypt"
-	{
-		"shavit_misc_resettargetname_main" "player"
-	}
-	"bhop_decbble"
-	{
-		"shavit_misc_resettargetname_main" "p1"
-	}
-	"bhop_downtown"
-	{
-		"shavit_misc_resettargetname_main" "fil_fw"
-	}
-	"bhop_drop"
-	{
-		"shavit_misc_resettargetname_main" "activator_boost"
-	}
-	"bhop_futile"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"bhop_futile_fix"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"bhop_horseshit_5"
-	{
-		"shavit_misc_resettargetname_main" "last"
-	}
-	"bhop_japan"
-	{
-		"shavit_misc_resetclassname_main" "beginner"
-	}
-	"bhop_kirous"
-	{
-		"shavit_misc_resettargetname_main" "state0"
-	}
-	"bhop_lowg"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"bhop_microwave"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"bhop_overthinker"
-	{
-		"shavit_misc_resettargetname_main" "noobinside"
-		"shavit_misc_resettargetname_bonus" "filter_bonus"
-		"shavit_misc_resetclassname_main" "cp1"
-		"shavit_misc_resetclassname_bonus" "cp1"
-	}
-	"bhop_overthinker_go"
-	{
-		"shavit_misc_resettargetname_main" "noobinside"
-		"shavit_misc_resettargetname_bonus" "filter_bonus"
-		"shavit_misc_resetclassname_main" "cp1"
-		"shavit_misc_resetclassname_bonus" "cp1"
-	}
-	"bhop_shutdown"
-	{
-		"shavit_misc_resettargetname_main" "asdf"
-	}
-	"bhop_space"
-	{
-		"shavit_misc_resettargetname" "0"
 	}
 	"bhop_strafecontrol"
 	{
 		"shavit_zones_extra_spawn_height" "1.0"
 	}
-	"bhop_symbiotic"
-	{
-		"shavit_misc_resettargetname_main" "filter_main"
-		"shavit_misc_resettargetname_bonus" "filter_bonus"
-	}
 	"bhop_tranquility"
 	{
 		"shavit_zones_prebuilt_visual_offset" "16"
-	}
-	"kz_bhop_izanami"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"kz_bhop_kairo"
-	{
-		"shavit_misc_resettargetname" "0"
-	}
-	"kz_bhop_sanctum"
-	{
-		"shavit_misc_resetclassname_main" "A1"
-	}
-	"kz_bhop_strafe_comjump2"
-	{
-		"shavit_misc_resettargetname_main" "pass1"
-	}
-	"kz_bhop_strafe_comjump2_v2"
-	{
-		"shavit_misc_resettargetname_main" "pass1"
 	}
 }

--- a/addons/sourcemod/gamedata/shavit.games.txt
+++ b/addons/sourcemod/gamedata/shavit.games.txt
@@ -101,6 +101,13 @@
 				"windows"   "\x55\x8B\xEC\x83\xEC\x08\x56\x8B\xF1\x8B\x86\xD0\x00\x00\x00"
 				"linux"     "\x55\x89\xE5\x57\x56\x53\x83\xEC\x2C\x8B\x5D\x08\xC7\x44\x24\x04\x01\x00\x00\x00\x89\x1C\x24"
 			}
+			// search string: "remove 0x%p: %s-%s (%d-%d) [%d in play, %d max]\n".
+			// function with one argument is PhysicsRemoveTouchedList
+			"PhysicsRemoveTouchedList"
+			{
+				"windows"   "\x55\x8B\xEC\x83\xEC\x0C\x57\x8B\xF9\x8B\x87\x2A\x2A\x2A\x2A\xD1\xE8\xA8\x01\x0F\x84"
+				"linux"     "\x55\x89\xE5\x57\x56\x53\x83\xEC\x5C\x8B\x55\x08\xC7\x44\x24\x2A\x2A\x2A\x2A\x2A\x89\x14\x24\xE8"
+			}
 		}
 	}
 
@@ -177,6 +184,13 @@
 				"windows"   "\x55\x8B\xEC\x56\x8B\xF1\xE8\x2A\x2A\x2A\x2A\x8B\x45\x2A\x83\xE8\x02"
 				"linux"     "@_ZN12CCSGameRules8TeamFullEi"
 			}
+			// search string: "remove 0x%p: %s-%s (%d-%d) [%d in play, %d max]\n".
+			// function with one argument is PhysicsRemoveTouchedList
+			"PhysicsRemoveTouchedList"
+			{
+				"windows"   "\x55\x8B\xEC\x83\xEC\x08\x57\x8B\x7D\x08\x8B\x87\x2A\x2A\x2A\x2A\xD1\xE8\xA8\x01\x0F\x84"
+				"linux"     "@_ZN11CBaseEntity24PhysicsRemoveTouchedListEPS_"
+			}
 		}
 	}
 
@@ -231,6 +245,13 @@
 			{
 				"windows"   "\x55\x8B\xEC\x56\x8B\x75\x2A\x85\xF6\x75\x2A\x33\xC0\x5E\x5D\xC3\x8B\x56"
 				"linux"     "@_ZN12CTFGameRules15CalcPlayerScoreEP12RoundStats_tP9CTFPlayer"
+			}
+			// search string: "remove 0x%p: %s-%s (%d-%d) [%d in play, %d max]\n".
+			// function with one argument is PhysicsRemoveTouchedList
+			"PhysicsRemoveTouchedList"
+			{
+				"windows"   "\x55\x8B\xEC\x83\xEC\x08\x57\x8B\x7D\x08\x8B\x87\x2A\x2A\x2A\x2A\xD1\xE8\xA8\x01\x0F\x84"
+				"linux"     "@_ZN11CBaseEntity24PhysicsRemoveTouchedListEPS_"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2168,6 +2168,32 @@ public Action Shavit_OnStartPre(int client)
 	if((gI_LatestTeleportTick[client] <= curr_tick <= gI_LatestTeleportTick[client] + 1) && 
 		!gB_WasInStartZoneBeforeTeleport[client] && curr_tick != tick_served[client])
 	{
+		if(gCV_ResetTargetname.BoolValue)
+		{
+			char targetname[64];
+			char classname[64];
+			
+			if (Shavit_GetClientTrack(client) == Track_Main)
+			{
+				gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
+				gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
+			}
+			else
+			{
+				gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
+				gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
+			}
+			
+			DispatchKeyValue(client, "targetname", targetname);
+			
+			if (!classname[0])
+			{
+				classname = "player";
+			}
+			
+			SetEntPropString(client, Prop_Data, "m_iClassname", classname);
+		}
+		
 		MaybeDoPhysicsUntouch(client);
 		ClearClientEvents(client);
 		
@@ -2188,32 +2214,6 @@ public Action Shavit_OnStart(int client)
 	if (gB_Eventqueuefix)
 	{
 		SetClientEventsPaused(client, false);
-	}
-	
-	if(gCV_ResetTargetname.BoolValue)
-	{
-		char targetname[64];
-		char classname[64];
-
-		if (Shavit_GetClientTrack(client) == Track_Main)
-		{
-			gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
-		}
-		else
-		{
-			gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
-		}
-
-		DispatchKeyValue(client, "targetname", targetname);
-
-		if (!classname[0])
-		{
-			classname = "player";
-		}
-
-		SetEntPropString(client, Prop_Data, "m_iClassname", classname);
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -105,11 +105,6 @@ Convar gCV_AdvertisementInterval = null;
 Convar gCV_RemoveRagdolls = null;
 Convar gCV_ClanTag = null;
 Convar gCV_DropAll = null;
-Convar gCV_ResetTargetname = null;
-Convar gCV_ResetTargetnameMain = null;
-Convar gCV_ResetTargetnameBonus = null;
-Convar gCV_ResetClassnameMain = null;
-Convar gCV_ResetClassnameBonus = null;
 Convar gCV_JointeamHook = null;
 Convar gCV_SpectatorList = null;
 Convar gCV_HideChatCommands = null;
@@ -279,11 +274,6 @@ public void OnPluginStart()
 	gCV_RemoveRagdolls = new Convar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = new Convar("shavit_misc_clantag", "{tr}{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style tag.\n{style} - style name.\n{time} - formatted time.\n{tr} - first letter of track.\n{rank} - player rank.\n{cr} - player's chatrank from shavit-chat, trimmed, with no colors", 0);
 	gCV_DropAll = new Convar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_ResetTargetname = new Convar("shavit_misc_resettargetname", "0", "Reset the player's targetname and eventqueue upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_ResetTargetnameMain = new Convar("shavit_misc_resettargetname_main", "", "What targetname to use when resetting the player. You don't need to touch this");
-	gCV_ResetTargetnameBonus = new Convar("shavit_misc_resettargetname_bonus", "", "What targetname to use when resetting the player (on bonus tracks). You don't need to touch this");
-	gCV_ResetClassnameMain = new Convar("shavit_misc_resetclassname_main", "", "What classname to use when resetting the player. You don't need to touch this");
-	gCV_ResetClassnameBonus = new Convar("shavit_misc_resetclassname_bonus", "", "What classname to use when resetting the player (on bonus tracks). You don't need to touch this");
 	gCV_JointeamHook = new Convar("shavit_misc_jointeamhook", "1", "Hook `jointeam`?\n0 - Disabled\n1 - Enabled, players can instantly change teams.", 0, true, 0.0, true, 1.0);
 	gCV_SpectatorList = new Convar("shavit_misc_speclist", "1", "Who to show in !specs?\n0 - everyone\n1 - all admins (admin_speclisthide override to bypass)\n2 - players you can target", 0, true, 0.0, true, 2.0);
 	gCV_HideChatCommands = new Convar("shavit_misc_hidechatcmds", "1", "Hide commands from chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -2155,17 +2145,32 @@ public Action Shavit_OnStartPre(int client)
 		return Plugin_Stop;
 	}
 	
+	static int tick_served[MAXPLAYERS + 1];
+	int curr_tick = GetGameTickCount();
+	
 	// GAMMACASE: This prevents further abuses related to external events being ran after you teleport from the trigger, with events setup, outside the start zone into the start zone.
 	// This accounts for the io events that might be set inside the start zone trigger in OnStartTouch and wont reset them!
 	// Logic behind this code is that all events in this chain are not instantly fired, so checking if there were teleport from the outside of a start zone in last 2 ticks
 	// and doing physics untouch now to trigger all OnEndTouch that should happen at the same tick but later and removing them allows further events from OnStartTouch be separated
 	// and be fired after which is the expected and desired effect.
-	// This also kills all ongoing events that were active on the client prior to the teleportation to start.
-	if((gI_LatestTeleportTick[client] == GetGameTickCount() || gI_LatestTeleportTick[client] + 1 == GetGameTickCount()) && !gB_WasInStartZoneBeforeTeleport[client])
+	// This also kills all ongoing events that were active on the client prior to the teleportation to start and also resets targetname and classname
+	// before the OnStartTouch from triggers in start zone are run, thus preventing the maps to be abusable if they don't have any reset triggers in place
+	if((gI_LatestTeleportTick[client] <= curr_tick <= gI_LatestTeleportTick[client] + 1) && 
+		!gB_WasInStartZoneBeforeTeleport[client] && curr_tick != tick_served[client])
 	{
+		SetEntPropString(client, Prop_Data, "m_iName", "");
+		SetEntPropString(client, Prop_Data, "m_iClassname", "player");
+		
 		MaybeDoPhysicsUntouch(client);
 		ClearClientEvents(client);
+		
+		tick_served[client] = curr_tick;
+		
 		return Plugin_Stop;
+	}
+	else if(curr_tick != tick_served[client])
+	{
+		tick_served[client] = 0;
 	}
 	
 	return Plugin_Continue;
@@ -2176,32 +2181,6 @@ public Action Shavit_OnStart(int client)
 	if (gB_Eventqueuefix)
 	{
 		SetClientEventsPaused(client, false);
-	}
-
-	if(gCV_ResetTargetname.BoolValue)
-	{
-		char targetname[64];
-		char classname[64];
-
-		if (Shavit_GetClientTrack(client) == Track_Main)
-		{
-			gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
-		}
-		else
-		{
-			gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
-		}
-
-		DispatchKeyValue(client, "targetname", targetname);
-
-		if (!classname[0])
-		{
-			classname = "player";
-		}
-
-		SetEntPropString(client, Prop_Data, "m_iClassname", classname);
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -105,7 +105,7 @@ Convar gCV_AdvertisementInterval = null;
 Convar gCV_RemoveRagdolls = null;
 Convar gCV_ClanTag = null;
 Convar gCV_DropAll = null;
-Convar gCV_ResetTargetname = null;
+Convar gCV_ForceTargetnameReset = null;
 Convar gCV_ResetTargetnameMain = null;
 Convar gCV_ResetTargetnameBonus = null;
 Convar gCV_ResetClassnameMain = null;
@@ -279,7 +279,7 @@ public void OnPluginStart()
 	gCV_RemoveRagdolls = new Convar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = new Convar("shavit_misc_clantag", "{tr}{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style tag.\n{style} - style name.\n{time} - formatted time.\n{tr} - first letter of track.\n{rank} - player rank.\n{cr} - player's chatrank from shavit-chat, trimmed, with no colors", 0);
 	gCV_DropAll = new Convar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_ResetTargetname = new Convar("shavit_misc_resettargetname", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_ForceTargetnameReset = new Convar("shavit_misc_forcetargetnamereset", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_ResetTargetnameMain = new Convar("shavit_misc_resettargetname_main", "", "What targetname to use when resetting the player. You don't need to touch this");
 	gCV_ResetTargetnameBonus = new Convar("shavit_misc_resettargetname_bonus", "", "What targetname to use when resetting the player (on bonus tracks). You don't need to touch this");
 	gCV_ResetClassnameMain = new Convar("shavit_misc_resetclassname_main", "", "What classname to use when resetting the player. You don't need to touch this");
@@ -2168,7 +2168,7 @@ public Action Shavit_OnStartPre(int client)
 	if((gI_LatestTeleportTick[client] <= curr_tick <= gI_LatestTeleportTick[client] + 1) && 
 		!gB_WasInStartZoneBeforeTeleport[client] && curr_tick != tick_served[client])
 	{
-		if(gCV_ResetTargetname.BoolValue)
+		if(gCV_ForceTargetnameReset.BoolValue)
 		{
 			char targetname[64];
 			char classname[64];

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -2099,7 +2099,7 @@ public Action Shavit_OnStartPre(int client)
 	{
 		return Plugin_Stop;
 	}
-	
+
 	return Plugin_Continue;
 }
 
@@ -2109,7 +2109,7 @@ public Action Shavit_OnStart(int client)
 	{
 		SetClientEventsPaused(client, false);
 	}
-	
+
 	if(gCV_ForceTargetnameReset.BoolValue)
 	{
 		char targetname[64];
@@ -2125,14 +2125,14 @@ public Action Shavit_OnStart(int client)
 			gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
 			gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
 		}
-		
+
 		DispatchKeyValue(client, "targetname", targetname);
-		
+
 		if (!classname[0])
 		{
 			classname = "player";
 		}
-		
+
 		SetEntPropString(client, Prop_Data, "m_iClassname", classname);
 	}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -105,6 +105,11 @@ Convar gCV_AdvertisementInterval = null;
 Convar gCV_RemoveRagdolls = null;
 Convar gCV_ClanTag = null;
 Convar gCV_DropAll = null;
+Convar gCV_ResetTargetname = null;
+Convar gCV_ResetTargetnameMain = null;
+Convar gCV_ResetTargetnameBonus = null;
+Convar gCV_ResetClassnameMain = null;
+Convar gCV_ResetClassnameBonus = null;
 Convar gCV_JointeamHook = null;
 Convar gCV_SpectatorList = null;
 Convar gCV_HideChatCommands = null;
@@ -274,6 +279,11 @@ public void OnPluginStart()
 	gCV_RemoveRagdolls = new Convar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = new Convar("shavit_misc_clantag", "{tr}{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style tag.\n{style} - style name.\n{time} - formatted time.\n{tr} - first letter of track.\n{rank} - player rank.\n{cr} - player's chatrank from shavit-chat, trimmed, with no colors", 0);
 	gCV_DropAll = new Convar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_ResetTargetname = new Convar("shavit_misc_resettargetname", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_ResetTargetnameMain = new Convar("shavit_misc_resettargetname_main", "", "What targetname to use when resetting the player. You don't need to touch this");
+	gCV_ResetTargetnameBonus = new Convar("shavit_misc_resettargetname_bonus", "", "What targetname to use when resetting the player (on bonus tracks). You don't need to touch this");
+	gCV_ResetClassnameMain = new Convar("shavit_misc_resetclassname_main", "", "What classname to use when resetting the player. You don't need to touch this");
+	gCV_ResetClassnameBonus = new Convar("shavit_misc_resetclassname_bonus", "", "What classname to use when resetting the player (on bonus tracks). You don't need to touch this");
 	gCV_JointeamHook = new Convar("shavit_misc_jointeamhook", "1", "Hook `jointeam`?\n0 - Disabled\n1 - Enabled, players can instantly change teams.", 0, true, 0.0, true, 1.0);
 	gCV_SpectatorList = new Convar("shavit_misc_speclist", "1", "Who to show in !specs?\n0 - everyone\n1 - all admins (admin_speclisthide override to bypass)\n2 - players you can target", 0, true, 0.0, true, 2.0);
 	gCV_HideChatCommands = new Convar("shavit_misc_hidechatcmds", "1", "Hide commands from chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -2158,9 +2168,6 @@ public Action Shavit_OnStartPre(int client)
 	if((gI_LatestTeleportTick[client] <= curr_tick <= gI_LatestTeleportTick[client] + 1) && 
 		!gB_WasInStartZoneBeforeTeleport[client] && curr_tick != tick_served[client])
 	{
-		SetEntPropString(client, Prop_Data, "m_iName", "");
-		SetEntPropString(client, Prop_Data, "m_iClassname", "player");
-		
 		MaybeDoPhysicsUntouch(client);
 		ClearClientEvents(client);
 		
@@ -2181,6 +2188,32 @@ public Action Shavit_OnStart(int client)
 	if (gB_Eventqueuefix)
 	{
 		SetClientEventsPaused(client, false);
+	}
+	
+	if(gCV_ResetTargetname.BoolValue)
+	{
+		char targetname[64];
+		char classname[64];
+
+		if (Shavit_GetClientTrack(client) == Track_Main)
+		{
+			gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
+			gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
+		}
+		else
+		{
+			gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
+			gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
+		}
+
+		DispatchKeyValue(client, "targetname", targetname);
+
+		if (!classname[0])
+		{
+			classname = "player";
+		}
+
+		SetEntPropString(client, Prop_Data, "m_iClassname", classname);
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -384,7 +384,7 @@ void LoadDHooks()
 	
 	LoadPhysicsUntouch(hGameData);
 	
-	if(gEV_Type == Engine_CSGO)
+	if (gEV_Type == Engine_CSGO)
 	{
 		StartPrepSDKCall(SDKCall_Entity);
 	}
@@ -393,19 +393,19 @@ void LoadDHooks()
 		StartPrepSDKCall(SDKCall_Static);
 	}
 	
-	if(!PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "PhysicsRemoveTouchedList"))
+	if (!PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "PhysicsRemoveTouchedList"))
 	{
 		SetFailState("Failed to find \"PhysicsRemoveTouchedList\" signature!");
 	}
 	
-	if(gEV_Type != Engine_CSGO)
+	if (gEV_Type != Engine_CSGO)
 	{
 		PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
 	}
 	
 	gH_PhysicsRemoveTouchedList = EndPrepSDKCall();
 	
-	if(!gH_PhysicsRemoveTouchedList)
+	if (!gH_PhysicsRemoveTouchedList)
 	{
 		SetFailState("Failed to create sdkcall to \"PhysicsRemoveTouchedList\"!");
 	}
@@ -459,7 +459,7 @@ public void OnLibraryAdded(const char[] name)
 	{
 		gB_ReplayRecorder = true;
 	}
-	else if(StrEqual(name, "eventqueuefix"))
+	else if (StrEqual(name, "eventqueuefix"))
 	{
 		gB_Eventqueuefix = true;
 	}
@@ -476,7 +476,7 @@ public void OnLibraryRemoved(const char[] name)
 	{
 		gB_ReplayRecorder = false;
 	}
-	else if(StrEqual(name, "eventqueuefix"))
+	else if (StrEqual(name, "eventqueuefix"))
 	{
 		gB_Eventqueuefix = false;
 	}
@@ -1000,7 +1000,7 @@ public void OnClientPutInServer(int client)
 {
 	gI_LatestTeleportTick[client] = 0;
 	
-	if(gH_TeleportDhook != null)
+	if (!IsFakeClient(client) && gH_TeleportDhook != null)
 	{
 		gH_TeleportDhook.HookEntity(Hook_Pre, client, DHooks_OnTeleport);
 	}
@@ -4287,12 +4287,12 @@ public void CreateZoneEntities(bool only_create_dead_entities)
 
 public MRESReturn DHooks_OnTeleport(int pThis, DHookParam hParams)
 {
-	if(!IsValidEntity(pThis) || !IsClientInGame(pThis) || IsFakeClient(pThis))
+	if (!IsValidEntity(pThis) || !IsClientInGame(pThis))
 	{
 		return MRES_Ignored;
 	}
 	
-	if(!hParams.IsNull(1))
+	if (!hParams.IsNull(1))
 	{
 		gI_LatestTeleportTick[pThis] = GetGameTickCount();
 	}
@@ -4449,17 +4449,18 @@ public void TouchPost(int entity, int other)
 				// and be fired after which is the expected and desired effect.
 				// This also kills all ongoing events that were active on the client prior to the teleportation to start and also resets targetname and classname
 				// before the OnStartTouch from triggers in start zone are run, thus preventing the maps to be abusable if they don't have any reset triggers in place
-				if((gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4) && curr_tick != tick_served[other])
+				if (curr_tick != tick_served[other])
 				{
-					PhysicsRemoveTouchedList(other);
-					ClearClientEvents(other);
-					
-					tick_served[other] = curr_tick;
-					
-					return;
-				}
-				else if(curr_tick != tick_served[other])
-				{
+					if (gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4)
+					{
+						PhysicsRemoveTouchedList(other);
+						ClearClientEvents(other);
+
+						tick_served[other] = curr_tick;
+
+						return;
+					}
+
 					tick_served[other] = 0;
 				}
 			}

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -27,6 +27,7 @@
 
 #include <shavit/core>
 #include <shavit/zones>
+#include <shavit/physicsuntouch>
 
 #undef REQUIRE_PLUGIN
 #include <adminmenu>
@@ -35,6 +36,7 @@
 #undef REQUIRE_EXTENSIONS
 #include <cstrike>
 #include <tf2>
+#include <eventqueuefix>
 
 #pragma semicolon 1
 #pragma newdecls required
@@ -90,6 +92,8 @@ float gF_Modifier[MAXPLAYERS+1];
 int gI_GridSnap[MAXPLAYERS+1];
 bool gB_SnapToWall[MAXPLAYERS+1];
 bool gB_CursorTracing[MAXPLAYERS+1];
+
+int gI_LatestTeleportTick[MAXPLAYERS+1];
 
 // player zone status
 bool gB_InsideZone[MAXPLAYERS+1][ZONETYPES_SIZE][TRACKS_SIZE];
@@ -153,6 +157,12 @@ Handle gH_Forwards_EnterZone = null;
 Handle gH_Forwards_LeaveZone = null;
 Handle gH_Forwards_StageMessage = null;
 
+// sdkcalls
+Handle gH_PhysicsRemoveTouchedList = null;
+
+// dhooks
+DynamicHook gH_TeleportDhook = null;
+
 // kz support
 float gF_ClimbButtonCache[MAXPLAYERS+1][TRACKS_SIZE][2][3]; // 0 - location, 1 - angles
 
@@ -162,6 +172,8 @@ bool gB_StartAnglesOnly[MAXPLAYERS+1][TRACKS_SIZE];
 float gF_StartPos[MAXPLAYERS+1][TRACKS_SIZE][3];
 float gF_StartAng[MAXPLAYERS+1][TRACKS_SIZE][3];
 
+// modules
+bool gB_Eventqueuefix = false;
 bool gB_ReplayRecorder = false;
 
 // custom zone stuff
@@ -307,7 +319,9 @@ public void OnPluginStart()
 	gCV_PrebuiltVisualOffset.AddChangeHook(OnConVarChanged);
 
 	Convar.AutoExecConfig();
-
+	
+	LoadDHooks();
+	
 	// misc cvars
 	sv_gravity = FindConVar("sv_gravity");
 
@@ -331,6 +345,7 @@ public void OnPluginStart()
 	}
 
 	gB_ReplayRecorder = LibraryExists("shavit-replay-recorder");
+	gB_Eventqueuefix = LibraryExists("eventqueuefix");
 
 	if (gB_Late)
 	{
@@ -342,6 +357,7 @@ public void OnPluginStart()
 			if (IsValidClient(i))
 			{
 				OnClientConnected(i);
+				OnClientPutInServer(i);
 
 				if (AreClientCookiesCached(i) && !IsFakeClient(i))
 				{
@@ -355,6 +371,70 @@ public void OnPluginStart()
 public void OnPluginEnd()
 {
 	UnloadZones(0);
+}
+
+void LoadDHooks()
+{
+	Handle hGameData = LoadGameConfigFile("shavit.games");
+	
+	if (hGameData == null)
+	{
+		SetFailState("Failed to load shavit gamedata");
+	}
+	
+	LoadPhysicsUntouch(hGameData);
+	
+	if(gEV_Type == Engine_CSGO)
+	{
+		StartPrepSDKCall(SDKCall_Entity);
+	}
+	else
+	{
+		StartPrepSDKCall(SDKCall_Static);
+	}
+	
+	if(!PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "PhysicsRemoveTouchedList"))
+	{
+		SetFailState("Failed to find \"PhysicsRemoveTouchedList\" signature!");
+	}
+	
+	if(gEV_Type != Engine_CSGO)
+	{
+		PrepSDKCall_AddParameter(SDKType_CBaseEntity, SDKPass_Pointer);
+	}
+	
+	gH_PhysicsRemoveTouchedList = EndPrepSDKCall();
+	
+	if(!gH_PhysicsRemoveTouchedList)
+	{
+		SetFailState("Failed to create sdkcall to \"PhysicsRemoveTouchedList\"!");
+	}
+	
+	delete hGameData;
+	
+	hGameData = LoadGameConfigFile("sdktools.games");
+	if (hGameData == null)
+	{
+		SetFailState("Failed to load sdktools gamedata");
+	}
+	
+	int iOffset = GameConfGetOffset(hGameData, "Teleport");
+	if (iOffset == -1)
+	{
+		SetFailState("Couldn't get the offset for \"Teleport\"!");
+	}
+	
+	gH_TeleportDhook = new DynamicHook(iOffset, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity);
+	
+	gH_TeleportDhook.AddParam(HookParamType_VectorPtr);
+	gH_TeleportDhook.AddParam(HookParamType_VectorPtr);
+	gH_TeleportDhook.AddParam(HookParamType_VectorPtr);
+	if (GetEngineVersion() == Engine_CSGO)
+	{
+		gH_TeleportDhook.AddParam(HookParamType_Bool);
+	}
+	
+	delete hGameData;
 }
 
 public void OnAllPluginsLoaded()
@@ -379,6 +459,10 @@ public void OnLibraryAdded(const char[] name)
 	{
 		gB_ReplayRecorder = true;
 	}
+	else if(StrEqual(name, "eventqueuefix"))
+	{
+		gB_Eventqueuefix = true;
+	}
 }
 
 public void OnLibraryRemoved(const char[] name)
@@ -391,6 +475,10 @@ public void OnLibraryRemoved(const char[] name)
 	else if (StrEqual(name, "shavit-replay-recorder"))
 	{
 		gB_ReplayRecorder = false;
+	}
+	else if(StrEqual(name, "eventqueuefix"))
+	{
+		gB_Eventqueuefix = false;
 	}
 }
 
@@ -906,6 +994,16 @@ public void OnMapEnd()
 	gB_InsertedPrebuiltZones = false;
 	delete gH_DrawVisible;
 	delete gH_DrawAllZones;
+}
+
+public void OnClientPutInServer(int client)
+{
+	gI_LatestTeleportTick[client] = 0;
+	
+	if(gH_TeleportDhook != null)
+	{
+		gH_TeleportDhook.HookEntity(Hook_Pre, client, DHooks_OnTeleport);
+	}
 }
 
 public void OnEntityCreated(int entity, const char[] classname)
@@ -4187,6 +4285,26 @@ public void CreateZoneEntities(bool only_create_dead_entities)
 	gB_ZoneCreationQueued = false;
 }
 
+public MRESReturn DHooks_OnTeleport(int pThis, DHookParam hParams)
+{
+	if(!IsValidEntity(pThis) || !IsClientInGame(pThis) || IsFakeClient(pThis))
+	{
+		return MRES_Ignored;
+	}
+	
+	if(!hParams.IsNull(1))
+	{
+		gI_LatestTeleportTick[pThis] = GetGameTickCount();
+	}
+	
+	return MRES_Ignored;
+}
+
+void PhysicsRemoveTouchedList(int client)
+{
+	SDKCall(gH_PhysicsRemoveTouchedList, client);
+}
+
 public void StartTouchPost(int entity, int other)
 {
 	if(other < 1 || other > MaxClients || gI_EntityZone[entity] == -1 || !gA_ZoneCache[gI_EntityZone[entity]].bZoneInitialized || IsFakeClient(other) ||
@@ -4319,6 +4437,33 @@ public void TouchPost(int entity, int other)
 	{
 		case Zone_Start:
 		{
+			if (gB_Eventqueuefix)
+			{
+				static int tick_served[MAXPLAYERS + 1];
+				int curr_tick = GetGameTickCount();
+				
+				// GAMMACASE: This prevents further abuses related to external events being ran after you teleport from the trigger, with events setup, outside the start zone into the start zone.
+				// This accounts for the io events that might be set inside the start zone trigger in OnStartTouch and wont reset them!
+				// Logic behind this code is that all events in this chain are not instantly fired, so checking if there were teleport from the outside of a start zone in last couple of ticks
+				// and doing PhysicsRemoveTouchedList() now to trigger all OnEndTouch that should happen at the same tick but later and removing them allows further events from OnStartTouch be separated
+				// and be fired after which is the expected and desired effect.
+				// This also kills all ongoing events that were active on the client prior to the teleportation to start and also resets targetname and classname
+				// before the OnStartTouch from triggers in start zone are run, thus preventing the maps to be abusable if they don't have any reset triggers in place
+				if((gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4) && curr_tick != tick_served[other])
+				{
+					PhysicsRemoveTouchedList(other);
+					ClearClientEvents(other);
+					
+					tick_served[other] = curr_tick;
+					
+					return;
+				}
+				else if(curr_tick != tick_served[other])
+				{
+					tick_served[other] = 0;
+				}
+			}
+			
 			if (GetEntPropEnt(other, Prop_Send, "m_hGroundEntity") == -1 && !Shavit_GetStyleSettingBool(Shavit_GetBhopStyle(other), "startinair"))
 			{
 				return;


### PR DESCRIPTION
This change sets ``shavit_misc_resettargetname`` to 0 being default. Also does changes how events are handled when player is teleported from outside the start zone. This implementation accounts for the OnStartTouch events that might be in the start zone triggers and wont clear these events out.

Main logic behind the implementation is that events are applied at the same tick after teleport from both the trigger that was teleported from (OnEndTouch) and to the destination trigger (OnStartTouch), but they are applied too late for the Shavit_OnStartPre() forward to catch them, thus to clearly erase all events from the OnEndTouch DoPhysicsUntouch() called (forcing events to be applied) and events are cleared right after (This is done for 2 ticks after the teleport was done outside the start zone, this value is fine tuned and was fine in my tests, although I'm not sure if client hacks could delay the packets and cause the difference between ticks here for more than 2, I wasn't successful at it with built in net_* commands or trying to lag the client via snd_restart). After the DoPhysicsUntouch() is called and all the events are cleared for the last time (after 2 ticks), the new OnStartTouch would be triggered for the start zone triggers which after they would apply the expected events.