### PR TITLE
Fix targetname and classname locking

### DIFF
--- a/addons/sourcemod/configs/shavit-mapfixes.cfg
+++ b/addons/sourcemod/configs/shavit-mapfixes.cfg
@@ -1,34 +1,5 @@
 "Map fixes"
 {
-	"bhop_apathy"
-	{
-		"shavit_misc_forcetargetnamereset" "1"
-		"shavit_misc_resettargetname_main" "apathy"
-	}
-	"bhop_amaranthglow"
-	{
-		"shavit_zones_prebuilt_visual_offset" "16"
-	}
-	"bhop_crash_egypt"
-	{
-		"shavit_misc_forcetargetnamereset" "1"
-		"shavit_misc_resettargetname_main" "player"
-	}
-	"bhop_drop"
-	{
-		"shavit_misc_forcetargetnamereset" "1"
-		"shavit_misc_resettargetname_main" "activator_boost"
-	}
-	"bhop_japan"
-	{
-		"shavit_misc_forcetargetnamereset" "1"
-		"shavit_misc_resetclassname_main" "beginner"
-	}
-	"bhop_shutdown"
-	{
-		"shavit_misc_forcetargetnamereset" "1"
-		"shavit_misc_resettargetname_main" "asdf"
-	}
 	"bhop_strafecontrol"
 	{
 		"shavit_zones_extra_spawn_height" "1.0"
@@ -37,8 +8,49 @@
 	{
 		"shavit_zones_prebuilt_visual_offset" "16"
 	}
+	"bhop_amaranthglow"
+	{
+		"shavit_zones_prebuilt_visual_offset" "16"
+	}
+
+	"bhop_apathy"
+	{
+		"shavit_zones_resettargetname_main" "apathy"
+	}
+	"bhop_crash_egypt"
+	{
+		"shavit_zones_resettargetname_main" "player"
+	}
+	"bhop_japan"
+	{
+		"shavit_zones_resetclassname_main" "beginner"
+	}
+	"bhop_space"
+	{
+		"shavit_zones_resetclassname_main" "sadface"
+	}
+	"bhop_shutdown"
+	{
+		"shavit_zones_resettargetname_main" "asdf"
+	}
+	"bhop_interloper"
+	{
+		"shavit_zones_resettargetname_main" "lol"
+	}
+	
 	"bhop_solitude"
 	{
-		"shavit_misc_forcetargetnamereset" "1"
+		"shavit_zones_forcetargetnamereset" "1"
+	}
+	"bhop_drop"
+	{
+		"shavit_zones_forcetargetnamereset" "1"
+		"shavit_zones_resettargetname_main" "activator_boost"
+	}
+	"kz_bhop_kairo"
+	{
+		"shavit_zones_forcetargetnamereset" "1"
+		"shavit_zones_resettargetname_main" "tped"
+		"shavit_zones_resetclassname_main" "cp0filter"
 	}
 }

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -101,11 +101,6 @@ Convar gCV_AdvertisementInterval = null;
 Convar gCV_RemoveRagdolls = null;
 Convar gCV_ClanTag = null;
 Convar gCV_DropAll = null;
-Convar gCV_ForceTargetnameReset = null;
-Convar gCV_ResetTargetnameMain = null;
-Convar gCV_ResetTargetnameBonus = null;
-Convar gCV_ResetClassnameMain = null;
-Convar gCV_ResetClassnameBonus = null;
 Convar gCV_JointeamHook = null;
 Convar gCV_SpectatorList = null;
 Convar gCV_HideChatCommands = null;
@@ -276,11 +271,6 @@ public void OnPluginStart()
 	gCV_RemoveRagdolls = new Convar("shavit_misc_removeragdolls", "1", "Remove ragdolls after death?\n0 - Disabled\n1 - Only remove replay bot ragdolls.\n2 - Remove all ragdolls.", 0, true, 0.0, true, 2.0);
 	gCV_ClanTag = new Convar("shavit_misc_clantag", "{tr}{styletag} :: {time}", "Custom clantag for players.\n0 - Disabled\n{styletag} - style tag.\n{style} - style name.\n{time} - formatted time.\n{tr} - first letter of track.\n{rank} - player rank.\n{cr} - player's chatrank from shavit-chat, trimmed, with no colors", 0);
 	gCV_DropAll = new Convar("shavit_misc_dropall", "1", "Allow all weapons to be dropped?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_ForceTargetnameReset = new Convar("shavit_misc_forcetargetnamereset", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
-	gCV_ResetTargetnameMain = new Convar("shavit_misc_resettargetname_main", "", "What targetname to use when resetting the player. You don't need to touch this");
-	gCV_ResetTargetnameBonus = new Convar("shavit_misc_resettargetname_bonus", "", "What targetname to use when resetting the player (on bonus tracks). You don't need to touch this");
-	gCV_ResetClassnameMain = new Convar("shavit_misc_resetclassname_main", "", "What classname to use when resetting the player. You don't need to touch this");
-	gCV_ResetClassnameBonus = new Convar("shavit_misc_resetclassname_bonus", "", "What classname to use when resetting the player (on bonus tracks). You don't need to touch this");
 	gCV_JointeamHook = new Convar("shavit_misc_jointeamhook", "1", "Hook `jointeam`?\n0 - Disabled\n1 - Enabled, players can instantly change teams.", 0, true, 0.0, true, 1.0);
 	gCV_SpectatorList = new Convar("shavit_misc_speclist", "1", "Who to show in !specs?\n0 - everyone\n1 - all admins (admin_speclisthide override to bypass)\n2 - players you can target", 0, true, 0.0, true, 2.0);
 	gCV_HideChatCommands = new Convar("shavit_misc_hidechatcmds", "1", "Hide commands from chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -2142,32 +2132,6 @@ public Action Shavit_OnStart(int client)
 	if (gB_Eventqueuefix)
 	{
 		SetClientEventsPaused(client, false);
-	}
-
-	if(gCV_ForceTargetnameReset.BoolValue)
-	{
-		char targetname[64];
-		char classname[64];
-		
-		if (Shavit_GetClientTrack(client) == Track_Main)
-		{
-			gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
-		}
-		else
-		{
-			gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
-			gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
-		}
-
-		DispatchKeyValue(client, "targetname", targetname);
-
-		if (!classname[0])
-		{
-			classname = "player";
-		}
-
-		SetEntPropString(client, Prop_Data, "m_iClassname", classname);
 	}
 
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -4501,9 +4501,9 @@ public void TouchPost(int entity, int other)
 				// and be fired after which is the expected and desired effect.
 				// This also kills all ongoing events that were active on the client prior to the teleportation to start and also resets targetname and classname
 				// before the OnStartTouch from triggers in start zone are run, thus preventing the maps to be abusable if they don't have any reset triggers in place
-				if (curr_tick != tick_served[other])
+				if (gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4)
 				{
-					if (gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4)
+					if (curr_tick != tick_served[other])
 					{
 						ResetClientTargetNameAndClassName(other, gA_ZoneCache[gI_EntityZone[entity]].iZoneTrack);
 
@@ -4511,10 +4511,12 @@ public void TouchPost(int entity, int other)
 						ClearClientEvents(other);
 
 						tick_served[other] = curr_tick;
-
-						return;
 					}
 
+					return;
+				}
+				else if (curr_tick != tick_served[other])
+				{
 					tick_served[other] = 0;
 				}
 			}

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -139,6 +139,12 @@ Convar gCV_BoxOffset = null;
 Convar gCV_ExtraSpawnHeight = null;
 Convar gCV_PrebuiltVisualOffset = null;
 
+Convar gCV_ForceTargetnameReset = null;
+Convar gCV_ResetTargetnameMain = null;
+Convar gCV_ResetTargetnameBonus = null;
+Convar gCV_ResetClassnameMain = null;
+Convar gCV_ResetClassnameBonus = null;
+
 // handles
 Handle gH_DrawVisible = null;
 Handle gH_DrawAllZones = null;
@@ -312,6 +318,12 @@ public void OnPluginStart()
 	gCV_BoxOffset = new Convar("shavit_zones_box_offset", "16", "Offset zone trigger boxes by this many unit\n0 - matches players bounding box\n16 - matches players center");
 	gCV_ExtraSpawnHeight = new Convar("shavit_zones_extra_spawn_height", "0.0", "YOU DONT NEED TO TOUCH THIS USUALLY. FIX YOUR ACTUAL ZONES.\nUsed to fix some shit prebuilt zones that are in the ground like bhop_strafecontrol");
 	gCV_PrebuiltVisualOffset = new Convar("shavit_zones_prebuilt_visual_offset", "0", "YOU DONT NEED TO TOUCH THIS USUALLY.\nUsed to fix the VISUAL beam offset for prebuilt zones on a map.\nExample maps you'd want to use 16 on: bhop_tranquility and bhop_amaranthglow");
+
+	gCV_ForceTargetnameReset = new Convar("shavit_zones_forcetargetnamereset", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
+	gCV_ResetTargetnameMain = new Convar("shavit_zones_resettargetname_main", "", "What targetname to use when resetting the player.\nWould be applied once player teleports to the start zone or on every start if shavit_zones_forcetargetnamereset cvar is set to 1.\nYou don't need to touch this");
+	gCV_ResetTargetnameBonus = new Convar("shavit_zones_resettargetname_bonus", "", "What targetname to use when resetting the player (on bonus tracks).\nWould be applied once player teleports to the start zone or on every start if shavit_zones_forcetargetnamereset cvar is set to 1.\nYou don't need to touch this");
+	gCV_ResetClassnameMain = new Convar("shavit_zones_resetclassname_main", "", "What classname to use when resetting the player.\nWould be applied once player teleports to the start zone or on every start if shavit_zones_forcetargetnamereset cvar is set to 1.\nYou don't need to touch this");
+	gCV_ResetClassnameBonus = new Convar("shavit_zones_resetclassname_bonus", "", "What classname to use when resetting the player (on bonus tracks).\nWould be applied once player teleports to the start zone or on every start if shavit_zones_forcetargetnamereset cvar is set to 1.\nYou don't need to touch this");
 
 	gCV_Interval.AddChangeHook(OnConVarChanged);
 	gCV_UseCustomSprite.AddChangeHook(OnConVarChanged);
@@ -4007,6 +4019,40 @@ public void Shavit_OnDatabaseLoaded()
 	}
 }
 
+void ResetClientTargetNameAndClassName(int client, int track)
+{
+	char targetname[64];
+	char classname[64];
+
+	if (track == Track_Main)
+	{
+		gCV_ResetTargetnameMain.GetString(targetname, sizeof(targetname));
+		gCV_ResetClassnameMain.GetString(classname, sizeof(classname));
+	}
+	else
+	{
+		gCV_ResetTargetnameBonus.GetString(targetname, sizeof(targetname));
+		gCV_ResetClassnameBonus.GetString(classname, sizeof(classname));
+	}
+
+	DispatchKeyValue(client, "targetname", targetname);
+
+	if (!classname[0])
+	{
+		classname = "player";
+	}
+
+	SetEntPropString(client, Prop_Data, "m_iClassname", classname);
+}
+
+public Action Shavit_OnStart(int client, int track)
+{
+	if(gCV_ForceTargetnameReset.BoolValue)
+	{
+		ResetClientTargetNameAndClassName(client, track);
+	}
+}
+
 public void Shavit_OnRestart(int client, int track)
 {
 	gI_LastStage[client] = 0;
@@ -4053,6 +4099,7 @@ public void Shavit_OnRestart(int client, int track)
 
 			if (!gB_HasSetStart[client][track] || gB_StartAnglesOnly[client][track])
 			{
+				ResetClientTargetNameAndClassName(client, track);
 				// normally StartTimer will happen on zone-touch BUT we have this here for zones that are in the air
 				Shavit_StartTimer(client, track);
 			}
@@ -4458,6 +4505,8 @@ public void TouchPost(int entity, int other)
 				{
 					if (gI_LatestTeleportTick[other] <= curr_tick <= gI_LatestTeleportTick[other] + 4)
 					{
+						ResetClientTargetNameAndClassName(other, gA_ZoneCache[gI_EntityZone[entity]].iZoneTrack);
+
 						PhysicsRemoveTouchedList(other);
 						ClearClientEvents(other);
 


### PR DESCRIPTION
This pr prevents issues that were talked about in https://github.com/shavitush/bhoptimer/pull/1134 pr, basically teleporting mid way bhop triggers or any other same trigger setups might cause issues and lock wrong targetname on the player (For example 2 events fired with delay 0.9 and 1.0 where 1st one sets your targetname to ``bhop`` for example and other one clears it out, teleporting to start zone in between 0.9 and 1.0 would lock your targetname to being ``bhop`` as the still ongoing event with 1.0 delay would be erased). This pr solves this issue by manually resetting targetname and classname in situations when player is teleported to start zone, or when Shavit_OnRestart() is called (only when no start position is used) and all that is done before any events from start triggers are fired, thus meaning all targetnames and classnames that should be applied by start triggers, would be still applied. I've already talked how I see this being an option and decided not to do that before, now it's kind of required as I've oversaw the possibility of targetname locking in this pr https://github.com/shavitush/bhoptimer/pull/1123 .

Walked through the mapfixes list and all maps are working fine, so some more testing would be appreciated in case there are maps that would be highly affected by this.