### PR TITLE
add 'bypass' param for Shavit_SaveCheckpointCache

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/checkpoints.inc
+++ b/addons/sourcemod/scripting/include/shavit/checkpoints.inc
@@ -283,10 +283,11 @@ native bool Shavit_LoadCheckpointCache(int client, any[] cache, int index, int s
  * @param cache                     Output cp_cache_t
  * @param index                     -1 if you want the cp_cache_t to be saved as "persistent data". 0 if not. greater-than-zero if you what you're doing and intentionally want to spoof the cp_cache_t creation as a checkpoint index for some reason... I recommend looking at shavit-checkpoints.sp to see how "index" and "isPersistentData" are used to see what kind of difference there is.
  * @param size                      sizeof(cp_cache_t) to mostly ensure the calling plugin has a matching cp_cache_t.
+ * @param bypass                    Do not trigger Shavit_OnCheckpointCacheSaved().
  *
  * @noreturn
  */
-native void Shavit_SaveCheckpointCache(int saver, int target, any[] cache, int index, int size = sizeof(cp_cache_t));
+native void Shavit_SaveCheckpointCache(int saver, int target, any[] cache, int index, int size = sizeof(cp_cache_t), bool bypass = false);
 
 public SharedPlugin __pl_shavit_checkpoints =
 {

--- a/addons/sourcemod/scripting/shavit-checkpoints.sp
+++ b/addons/sourcemod/scripting/shavit-checkpoints.sp
@@ -1399,7 +1399,7 @@ bool SaveCheckpoint(int client)
 	return true;
 }
 
-void SaveCheckpointCache(int saver, int target, cp_cache_t cpcache, int index, Handle plugin)
+void SaveCheckpointCache(int saver, int target, cp_cache_t cpcache, int index, Handle plugin, bool bypass = false)
 {
 	GetClientAbsOrigin(target, cpcache.fPosition);
 	GetClientEyeAngles(target, cpcache.fAngles);
@@ -1567,12 +1567,15 @@ void SaveCheckpointCache(int saver, int target, cp_cache_t cpcache, int index, H
 		cpcache.customdata = cd;
 	}
 
-	Call_StartForward(gH_Forwards_OnCheckpointCacheSaved);
-	Call_PushCell(saver);
-	Call_PushArray(cpcache, sizeof(cpcache));
-	Call_PushCell(index);
-	Call_PushCell(target);
-	Call_Finish();
+	if (!bypass)
+	{
+		Call_StartForward(gH_Forwards_OnCheckpointCacheSaved);
+		Call_PushCell(saver);
+		Call_PushArray(cpcache, sizeof(cpcache));
+		Call_PushCell(index);
+		Call_PushCell(target);
+		Call_Finish();
+	}
 }
 
 void TeleportToCheckpoint(int client, int index, bool suppressMessage)
@@ -2035,6 +2038,7 @@ public any Native_SaveCheckpointCache(Handle plugin, int numParams)
 	int target = GetNativeCell(2);
 	cp_cache_t cache;
 	int index = GetNativeCell(4);
-	SaveCheckpointCache(saver, target, cache, index, plugin);
+	bool bypass = GetNativeCell(5);
+	SaveCheckpointCache(saver, target, cache, index, plugin, bypass);
 	return SetNativeArray(3, cache, sizeof(cp_cache_t));
 }


### PR DESCRIPTION
To prevent conflicts if we use both functions in one plugin.