### PR TITLE
[TF2] Fix broken NoWeaponDrops (shavit-misc)

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -295,7 +295,7 @@ public void OnPluginStart()
 
 	mp_humanteam = FindConVar((gEV_Type == Engine_TF2) ? "mp_humans_must_join_team" : "mp_humanteam");
 	sv_disable_radar = FindConVar("sv_disable_radar");
-	if (gEV_Type == Engine_TF2) tf_dropped_weapon_lifetime = FindConVar("tf_dropped_weapon_lifetime");
+	tf_dropped_weapon_lifetime = FindConVar("tf_dropped_weapon_lifetime");
 
 	// crons
 	CreateTimer(10.0, Timer_Cron, 0, TIMER_REPEAT);
@@ -553,6 +553,11 @@ public void OnConfigsExecuted()
 	if (sv_disable_radar != null && gCV_HideRadar.BoolValue)
 	{
 		sv_disable_radar.BoolValue = true;
+	}
+
+	if (tf_dropped_weapon_lifetime != null && gCV_NoWeaponDrops.BoolValue)
+	{
+		tf_dropped_weapon_lifetime.IntValue = 0;
 	}
 
 	if(gCV_CreateSpawnPoints.IntValue > 0)


### PR DESCRIPTION
Fixes #1159 by using the built-in TF2 ConVar ` tf_dropped_weapon_lifetime` and killing all **tf_dropped_weapon** entities when shavit_misc_noweapondrops is changed to 1.

The TF2_KillDroppedWeapons function is necessary because existing dropped weapons continue to live out their lifetime even after `tf_dropped_weapon_lifetime` is changed to 0.