### PR TITLE
Feat/autorestart

### DIFF
--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1543,8 +1543,8 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 		if ((gI_HUDSettings[client] & HUD_ZONEHUD) > 0)
 		{
 			FormatEx(sLine, sizeof(sLine),
-				"<span color='#%06X'>%T</span>",
-				((gI_Gradient.r << 16) + (gI_Gradient.g << 8) + (gI_Gradient.b)),
+				"<span color='#1EE9E3'>%T</span>",
+				// ((gI_Gradient.r << 16) + (gI_Gradient.g << 8) + (gI_Gradient.b)),
 				(data.iZoneHUD == ZoneHUD_Start) ? "HudInStartZoneCSGO" : "HudInEndZoneCSGO",
 				client,
 				data.iSpeed

--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -1543,8 +1543,8 @@ int AddHUDToBuffer_CSGO(int client, huddata_t data, char[] buffer, int maxlen)
 		if ((gI_HUDSettings[client] & HUD_ZONEHUD) > 0)
 		{
 			FormatEx(sLine, sizeof(sLine),
-				"<span color='#1EE9E3'>%T</span>",
-				// ((gI_Gradient.r << 16) + (gI_Gradient.g << 8) + (gI_Gradient.b)),
+				"<span color='#%06X'>%T</span>",
+				((gI_Gradient.r << 16) + (gI_Gradient.g << 8) + (gI_Gradient.b)),
 				(data.iZoneHUD == ZoneHUD_Start) ? "HudInStartZoneCSGO" : "HudInEndZoneCSGO",
 				client,
 				data.iSpeed

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -75,7 +75,7 @@ int gI_LastNoclipTick[MAXPLAYERS+1];
 int gI_LastStopInfo[MAXPLAYERS+1];
 
 // cookies
-Handle gH_HideCookie = null
+Handle gH_HideCookie = null;
 Handle gH_AutoRestartCookie = null;
 Cookie gH_BlockAdvertsCookie = null;
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -61,6 +61,7 @@ char gS_RadioCommands[][] = { "coverme", "takepoint", "holdpos", "regroup", "fol
 	"getout", "negative", "enemydown", "compliment", "thanks", "cheer", "go_a", "go_b", "sorry", "needrop", "playerradio", "playerchatwheel", "player_ping", "chatwheel_ping" };
 
 bool gB_Hide[MAXPLAYERS+1];
+bool gB_AutoRestart[MAXPLAYERS+1];
 bool gB_Late = false;
 int gI_GroundEntity[MAXPLAYERS+1];
 int gI_LastShot[MAXPLAYERS+1];
@@ -74,7 +75,7 @@ int gI_LastNoclipTick[MAXPLAYERS+1];
 int gI_LastStopInfo[MAXPLAYERS+1];
 
 // cookies
-Handle gH_HideCookie = null;
+Handle gH_HideCookie = null, gH_AutoResCookie = null;
 Cookie gH_BlockAdvertsCookie = null;
 
 // cvars
@@ -204,6 +205,11 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_practice", Command_Noclip, "Toggles noclip. (sm_nc alias)");
 	RegConsoleCmd("sm_nc", Command_Noclip, "Toggles noclip.");
 	RegConsoleCmd("sm_noclipme", Command_Noclip, "Toggles noclip. (sm_nc alias)");
+	
+	// qol
+	RegConsoleCmd("sm_autorestart", Command_AutoRestart, "Toggles auto-restart.");
+	gH_AutoResCookie = RegClientCookie("shavit_autorestart", "Auto-restart settings", CookieAccess_Protected);
+
 	AddCommandListener(CommandListener_Noclip, "+noclip");
 	AddCommandListener(CommandListener_Noclip, "-noclip");
 	// Hijack sourcemod's sm_noclip from funcommands to work when no args are specified.
@@ -426,20 +432,23 @@ public void OnClientCookiesCached(int client)
 		return;
 	}
 
+	gB_Hide[client] = ProcessCookie(client, gH_HideCookie);
+	gB_AutoRestart[client] = ProcessCookie(client, gH_AutoResCookie);
+
+	gI_Style[client] = Shavit_GetBhopStyle(client);
+}
+
+bool ProcessCookie(int client, Handle cookie)
+{
 	char sSetting[8];
-	GetClientCookie(client, gH_HideCookie, sSetting, 8);
+	GetClientCookie(client, cookie, sSetting, sizeof(sSetting));
 
 	if(strlen(sSetting) == 0)
 	{
-		SetClientCookie(client, gH_HideCookie, "0");
-		gB_Hide[client] = false;
+		SetClientCookie(client, cookie, "0");
+		return false;
 	}
-	else
-	{
-		gB_Hide[client] = view_as<bool>(StringToInt(sSetting));
-	}
-
-	gI_Style[client] = Shavit_GetBhopStyle(client);
+	return view_as<bool>(StringToInt(sSetting));
 }
 
 public void Shavit_OnStyleConfigLoaded(int styles)
@@ -1299,6 +1308,18 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			}
 		}
 	}
+
+	if(gB_AutoRestart[client])
+	{
+		float bestTime = Shavit_GetClientPB(client, style, track), current = Shavit_GetClientTime(client);
+		if(bestTime != 0 && current > bestTime)
+		{
+			Shavit_RestartTimer(client, track);
+			Shavit_PrintToChat(client, "%T", "AutoRestartTriggered1", client, gS_ChatStrings.sVariable, gS_ChatStrings.sText);
+			Shavit_PrintToChat(client, "%T", "AutoRestartTriggered2", client, gS_ChatStrings.sVariable, gS_ChatStrings.sText);
+		}
+	}
+
 
 	int iGroundEntity = GetEntPropEnt(client, Prop_Send, "m_hGroundEntity");
 
@@ -2706,6 +2727,15 @@ public Action Command_Drop(int client, const char[] command, int argc)
 	}
 
 	return Plugin_Stop;
+}
+
+public Action Command_AutoRestart(int client, int args)
+{
+	gB_AutoRestart[client] = !gB_AutoRestart[client];
+	SetClientCookie(client, gH_AutoResCookie, gB_AutoRestart[client] ? "1" : "0");
+
+	Shavit_PrintToChat(client, "%T", gB_AutoRestart[client] ? "AutoRestartEnabled" : "AutoRestartDisabled", client, gB_AutoRestart[client] ?  gS_ChatStrings.sVariable : gS_ChatStrings.sWarning, gS_ChatStrings.sText);
+	return Plugin_Handled;
 }
 
 public int Native_IsClientUsingHide(Handle plugin, int numParams)

--- a/addons/sourcemod/translations/shavit-misc.phrases.txt
+++ b/addons/sourcemod/translations/shavit-misc.phrases.txt
@@ -48,6 +48,26 @@
 		"#format"	"{1:s},{2:s}"
 		"en"		"You are now {1}not hiding{2} players."
 	}
+	"AutoRestartEnabled"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"You will now {1}automatically restart{2} if you are slower than your PB."
+	}
+	"AutoRestartDisabled"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"You will no longer {1}automatically restart{2}."
+	}
+	"AutoRestartTriggered1"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"You were {1}automatically restarted{2} due to being slower than your PB."
+	}
+	"AutoRestartTriggered2"
+	{
+		"#format"	"{1:s},{2:s}"
+		"en"		"Use {1}!autorestart{2} to disable this."
+	}
 	"LackingAccess"
 	{
 		"#format"	"{1:s},{2:s}"


### PR DESCRIPTION
Similar to SurfTimer's auto reset, this MR adds the `sm_autorestart` command to the BHop timer.
Players that have this enabled will automatically be reset if their current run time exceeds their PB.