### PR TITLE
 Add migration to update or add auth FK constraint in playertimes

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -59,6 +59,7 @@ static Database gH_SQL;
 static int gI_Driver;
 static char gS_SQLPrefix[32];
 
+char SQLitePTQuery[1024]; // used in Migration_AddPlayertimesAuthFK if db created <= v3.3.2
 int gI_MigrationsRequired;
 int gI_MigrationsFinished;
 
@@ -168,6 +169,7 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 		FormatEx(sQuery, sizeof(sQuery),
 			"CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INTEGER PRIMARY KEY, `style` TINYINT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, `time` FLOAT NOT NULL, `auth` INT NOT NULL, `map` VARCHAR(255) NOT NULL, `points` FLOAT NOT NULL DEFAULT 0, `jumps` INT, `date` INT, `strafes` INT, `sync` FLOAT, `perfs` FLOAT DEFAULT 0, `completions` SMALLINT DEFAULT 1, CONSTRAINT `%spt_auth` FOREIGN KEY (`auth`) REFERENCES `%susers` (`auth`) ON UPDATE RESTRICT ON DELETE RESTRICT);",
 			gS_SQLPrefix, gS_SQLPrefix, gS_SQLPrefix);
+		strcopy(SQLitePTQuery, sizeof(SQLitePTQuery), sQuery);
 	}
 
 	AddQueryLog(trans, sQuery);

--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -1,6 +1,6 @@
 /*
  * shavit's Timer - SQL table creation and migrations
- * by: shavit, rtldg
+ * by: shavit, rtldg, jedso
  *
  * This file is part of shavit's Timer (https://github.com/shavitush/bhoptimer)
  *

--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -159,15 +159,15 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 	if (driver == Driver_mysql)
 	{
 		FormatEx(sQuery, sizeof(sQuery),
-			"CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `style` TINYINT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, `time` FLOAT NOT NULL, `auth` INT NOT NULL, `map` VARCHAR(255) NOT NULL, `points` FLOAT NOT NULL DEFAULT 0, `jumps` INT, `date` INT, `strafes` INT, `sync` FLOAT, `perfs` FLOAT DEFAULT 0, `completions` SMALLINT DEFAULT 1, PRIMARY KEY (`id`), INDEX `map` (`map`, `style`, `track`, `time`), INDEX `auth` (`auth`, `date`, `points`), INDEX `time` (`time`), INDEX `map2` (`map`)) ENGINE=INNODB;",
-			gS_SQLPrefix);
+			"CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INT NOT NULL AUTO_INCREMENT, `style` TINYINT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, `time` FLOAT NOT NULL, `auth` INT NOT NULL, `map` VARCHAR(255) NOT NULL, `points` FLOAT NOT NULL DEFAULT 0, `jumps` INT, `date` INT, `strafes` INT, `sync` FLOAT, `perfs` FLOAT DEFAULT 0, `completions` SMALLINT DEFAULT 1, PRIMARY KEY (`id`), INDEX `map` (`map`, `style`, `track`, `time`), INDEX `auth` (`auth`, `date`, `points`), INDEX `time` (`time`), INDEX `map2` (`map`), CONSTRAINT `%spt_auth` FOREIGN KEY (`auth`) REFERENCES `%susers` (`auth`) ON UPDATE RESTRICT ON DELETE RESTRICT) ENGINE=INNODB;",
+			gS_SQLPrefix, gS_SQLPrefix, gS_SQLPrefix);
 	}
 	else
 	{
 		// id  style  track  time  auth  map  points  exact_time_int
 		FormatEx(sQuery, sizeof(sQuery),
-			"CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INTEGER PRIMARY KEY, `style` TINYINT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, `time` FLOAT NOT NULL, `auth` INT NOT NULL, `map` VARCHAR(255) NOT NULL, `points` FLOAT NOT NULL DEFAULT 0, `jumps` INT, `date` INT, `strafes` INT, `sync` FLOAT, `perfs` FLOAT DEFAULT 0, `completions` SMALLINT DEFAULT 1);",
-			gS_SQLPrefix);
+			"CREATE TABLE IF NOT EXISTS `%splayertimes` (`id` INTEGER PRIMARY KEY, `style` TINYINT NOT NULL DEFAULT 0, `track` TINYINT NOT NULL DEFAULT 0, `time` FLOAT NOT NULL, `auth` INT NOT NULL, `map` VARCHAR(255) NOT NULL, `points` FLOAT NOT NULL DEFAULT 0, `jumps` INT, `date` INT, `strafes` INT, `sync` FLOAT, `perfs` FLOAT DEFAULT 0, `completions` SMALLINT DEFAULT 1, CONSTRAINT `%spt_auth` FOREIGN KEY (`auth`) REFERENCES `%susers` (`auth`) ON UPDATE RESTRICT ON DELETE RESTRICT);",
+			gS_SQLPrefix, gS_SQLPrefix, gS_SQLPrefix);
 	}
 
 	AddQueryLog(trans, sQuery);


### PR DESCRIPTION
Fixes #1175. I decided to go with `ON UPDATE RESTRICT ON DELETE RESTRICT` referential actions instead of the CASCADE actions used by the constraint in DBs created <= v3.0.8. RESTRICT would have stopped the REPLACE SQLite query from working/cascading to delete all of the user's playertimes. It does mean that all child playertimes have to be deleted before the user table row can be, but this is already how DeleteRestOfUser works so should be fine.

MySQL supports `ALTER TABLE ... ADD CONSTRAINT ... FOREIGN KEY`. Unfortunately, [SQLite does not](https://stackoverflow.com/a/1884841), which means creating a temporary table to store existing playertimes data, dropping playertimes and re-creating playertimes with the correct FK constraint.

For SQLite I initially tried `PRAGMA foreign_key_list(playertimes)` to test for the existence of FKs on playertimes, but the code was starting to get ugly so I switched to using sqlite_master and checking the SQL used to create the table. This meant using StrContains to check for <= v3.0.8 and >= v3.1.0 DBs which isn't exactly elegant (but it works).

I tested this PR with a MySQL DB created at v3.0.8, v3.3.2 and a fresh DB with latest commits. Same for SQLite (with playertimes having >50k rows). Some more testing would definitely be good but should be working as-is.

Only concern I had was that this migration starts immediately after the first 9000 rows of Migration_DeprecateExactTimeInt, and for SQLite this means dropping playertimes and replacing the table without the exact_time_int column. Should be fine though since the id, exact_time_int combinations are still stored in DBResultSet results. If SQL_Migration_DeprecateExactTimeInt_Query fails for whatever reason though, it could mean loss of exact_time_int and the ability to redo Migration_DeprecateExactTimeInt. Probably should encourage SQLite users to backup before this migration.