### PR TITLE
Add SQLite migration to fix mapzones having NULL id for all rows

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -60,6 +60,7 @@ static int gI_Driver;
 static char gS_SQLPrefix[32];
 
 bool gB_MigrationsApplied[255];
+char SQLiteMapzonesQuery[1024]; // used in Migration_FixSQLiteMapzonesROWID if db created <= v3.3.2
 
 public void RunOnDatabaseLoadedForward()
 {
@@ -218,6 +219,7 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 			"CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INTEGER PRIMARY KEY, `map` VARCHAR(255) NOT NULL, `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, `flags` INT NOT NULL DEFAULT 0, `data` INT NOT NULL DEFAULT 0, `form` TINYINT, `target` VARCHAR(63));",
 			gS_SQLPrefix);
 		AddQueryLog(trans, sQuery);
+		strcopy(SQLiteMapzonesQuery, sizeof(SQLiteMapzonesQuery), sQuery);
 	}
 
 	FormatEx(sQuery, sizeof(sQuery),

--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -205,10 +205,20 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 	//// shavit-wr
 	//
 
-	FormatEx(sQuery, sizeof(sQuery),
-		"CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` VARCHAR(255) NOT NULL, `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, `flags` INT NOT NULL DEFAULT 0, `data` INT NOT NULL DEFAULT 0, `form` TINYINT, `target` VARCHAR(63), PRIMARY KEY (`id`)) %s;",
-		gS_SQLPrefix, sOptionalINNODB);
-	AddQueryLog(trans, sQuery);
+	if (driver == Driver_mysql)
+	{
+		FormatEx(sQuery, sizeof(sQuery),
+			"CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INT AUTO_INCREMENT, `map` VARCHAR(255) NOT NULL, `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, `flags` INT NOT NULL DEFAULT 0, `data` INT NOT NULL DEFAULT 0, `form` TINYINT, `target` VARCHAR(63), PRIMARY KEY (`id`)) %s;",
+			gS_SQLPrefix, sOptionalINNODB);
+		AddQueryLog(trans, sQuery);
+	}
+	else
+	{
+		FormatEx(sQuery, sizeof(sQuery),
+			"CREATE TABLE IF NOT EXISTS `%smapzones` (`id` INTEGER PRIMARY KEY, `map` VARCHAR(255) NOT NULL, `type` INT, `corner1_x` FLOAT, `corner1_y` FLOAT, `corner1_z` FLOAT, `corner2_x` FLOAT, `corner2_y` FLOAT, `corner2_z` FLOAT, `destination_x` FLOAT NOT NULL DEFAULT 0, `destination_y` FLOAT NOT NULL DEFAULT 0, `destination_z` FLOAT NOT NULL DEFAULT 0, `track` INT NOT NULL DEFAULT 0, `flags` INT NOT NULL DEFAULT 0, `data` INT NOT NULL DEFAULT 0, `form` TINYINT, `target` VARCHAR(63));",
+			gS_SQLPrefix);
+		AddQueryLog(trans, sQuery);
+	}
 
 	FormatEx(sQuery, sizeof(sQuery),
 		"CREATE TABLE IF NOT EXISTS `%sstartpositions` (`auth` INTEGER NOT NULL, `track` TINYINT NOT NULL, `map` VARCHAR(255) NOT NULL, `pos_x` FLOAT, `pos_y` FLOAT, `pos_z` FLOAT, `ang_x` FLOAT, `ang_y` FLOAT, `ang_z` FLOAT, `angles_only` BOOL, PRIMARY KEY (`auth`, `track`, `map`)) %s;",


### PR DESCRIPTION
[SQLite uses ROWID](https://sqlite.org/lang_createtable.html#rowid) to uniquely identify each row in a table, and a column with type INTEGER PRIMARY KEY becomes an alias for that ROWID value. The CREATE TABLE statement for mapzones since the beginning (1.1b) has been `id INT AUTO_INCREMENT`, but the column _has_ to be of INTEGER type for it to act as a ROWID alias (not INT). Because id is therefore acting as a ordinary integer table column, all id rows in mapzones have been NULL in SQLite DBs since the plugin was released.

This migration fixes that and gives each map zone a unique identifier for SQLite DBs.