### PR TITLE
[TF2] Add correct bounding box values for shavit_zones_box_offset

### DIFF
--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -333,9 +333,14 @@ public void OnPluginStart()
 	gCV_Height = new Convar("shavit_zones_height", "128.0", "Height to use for the start zone.", 0, true, 0.0, false);
 	gCV_Offset = new Convar("shavit_zones_offset", "1.0", "When calculating a zone's *VISUAL* box, by how many units, should we scale it to the center?\n0.0 - no downscaling. Values above 0 will scale it inward and negative numbers will scale it outwards.\nAdjust this value if the zones clip into walls.");
 	gCV_EnforceTracks = new Convar("shavit_zones_enforcetracks", "1", "Enforce zone tracks upon entry?\n0 - allow every zone except for start/end to affect users on every zone.\n1 - require the user's track to match the zone's track.", 0, true, 0.0, true, 1.0);
-	gCV_BoxOffset = new Convar("shavit_zones_box_offset", "16", "Offset zone trigger boxes by this many unit\n0 - matches players bounding box\n16 - matches players center");
 	gCV_ExtraSpawnHeight = new Convar("shavit_zones_extra_spawn_height", "0.0", "YOU DONT NEED TO TOUCH THIS USUALLY. FIX YOUR ACTUAL ZONES.\nUsed to fix some shit prebuilt zones that are in the ground like bhop_strafecontrol");
 	gCV_PrebuiltVisualOffset = new Convar("shavit_zones_prebuilt_visual_offset", "0", "YOU DONT NEED TO TOUCH THIS USUALLY.\nUsed to fix the VISUAL beam offset for prebuilt zones on a map.\nExample maps you'd want to use 16 on: bhop_tranquility and bhop_amaranthglow");
+
+	// Bounding box dimensions are different for TF2 [48x48x82] compared to CS:S [32x32x62] and CS:GO [32x32x72]
+	char sBoxOffset[3], sBoxOffsetDesc[128];
+	FormatEx(sBoxOffset, sizeof(sBoxOffset), gEV_Type == Engine_TF2 ? "24" : "16");
+	FormatEx(sBoxOffsetDesc, sizeof(sBoxOffsetDesc), "Offset zone trigger boxes by this many unit\n0 - matches players bounding box\n%s - matches players center", sBoxOffset);
+	gCV_BoxOffset = new Convar("shavit_zones_box_offset", sBoxOffset, sBoxOffsetDesc);
 
 	gCV_ForceTargetnameReset = new Convar("shavit_zones_forcetargetnamereset", "0", "Reset the player's targetname upon timer start?\nRecommended to leave disabled. Enable via per-map configs when necessary.\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_ResetTargetnameMain = new Convar("shavit_zones_resettargetname_main", "", "What targetname to use when resetting the player.\nWould be applied once player teleports to the start zone or on every start if shavit_zones_forcetargetnamereset cvar is set to 1.\nYou don't need to touch this");

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -5122,7 +5122,7 @@ void SetZoneMinsMaxs(int zone)
 
 	for (int i = 0; i < 3; i++)
 	{
-		float offset = offsets[i>>1];
+		float offset = offsets[i/2];
 #if 1
 		maxs[i] = Abs(gA_ZoneCache[zone].fCorner1[i] - gA_ZoneCache[zone].fCorner2[i]) / 2.0;
 		if (maxs[i] > offset) maxs[i] -= offset;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -5105,8 +5105,23 @@ void SetZoneMinsMaxs(int zone)
 	float distance_x = Abs(gA_ZoneCache[zone].fCorner1[0] - gA_ZoneCache[zone].fCorner2[0]) / 2;
 	float distance_y = Abs(gA_ZoneCache[zone].fCorner1[1] - gA_ZoneCache[zone].fCorner2[1]) / 2;
 	float distance_z = Abs(gA_ZoneCache[zone].fCorner1[2] - gA_ZoneCache[zone].fCorner2[2]) / 2;
+	float height;
 
-	float height = ((IsSource2013(gEV_Type))? 62.0:72.0) / 2;
+	switch (gEV_Type)
+	{
+		case Engine_CSS:
+		{
+			height = 62.0 / 2;
+		}
+		case Engine_CSGO:
+		{
+			height = 72.0 / 2;
+		}
+		case Engine_TF2:
+		{
+			height = 82.0 / 2;
+		}
+	}
 
 	float mins[3];
 	mins[0] = -distance_x;


### PR DESCRIPTION
TF2's bounding box is `48x48x82` compared to CS:S `32x32x62` and CS:GO `32x32x72`. As such, the default value of gCV_BoxOffset (bbox width / 2) is slightly off the player's center for TF2.

In SetZoneMinsMaxs, the `height` variable is half the bbox height but does not use the correct value for TF2 either (uses CS:S 62.0 instead of 82.0). This PR adds the correct bbox values for TF2.

As an aside, I did wonder if having `height` be constantly set to half the bbox height is really the desired behavior. E.g. if `shavit_zones_box_offset = 0`, why should distance_z be offset by half the bbox height yet have no offset for distance_x/y?

https://github.com/shavitush/bhoptimer/blob/a6da4358de06937b095dcafd79050e4ea937844a/addons/sourcemod/scripting/shavit-zones.sp#L5104-L5114