### PR TITLE
Normalize and store PB stage times

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
+++ b/addons/sourcemod/scripting/include/shavit/sql-create-tables-and-migrations.sp
@@ -126,6 +126,14 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 		sOptionalINNODB = "ENGINE=INNODB";
 	}
 
+	// Enable foreign key constraints for SQLite (e.g. CASCADE DELETE)
+	// No-op within a transaction, so has to be its own query
+	if (driver == Driver_sqlite)
+	{
+		FormatEx(sQuery, sizeof(sQuery), "PRAGMA foreign_keys = ON");
+		QueryLog(gH_SQL, SQL_PragmaFKSqlite_Callback, sQuery, 0, DBPrio_High);
+	}
+
 	//
 	//// shavit-core
 	//
@@ -264,6 +272,14 @@ public void SQL_CreateTables(Database hSQL, const char[] prefix, int driver)
 	AddQueryLog(trans, sQuery);
 
 	hSQL.Execute(trans, Trans_CreateTables_Success, Trans_CreateTables_Error, 0, DBPrio_High);
+}
+
+public void SQL_PragmaFKSqlite_Callback(Database db, DBResultSet results, const char[] error, any data)
+{
+	if (results == null)
+	{
+		SetFailState("Timer failed to enable foreign key constraints (SQLite). Reason: %s", error);
+	}
 }
 
 public void Trans_CreateTables_Error(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -2563,10 +2563,11 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 	}
 
 	bool bEveryone = (iOverwrite > 0);
+	bool bIsWR = (iOverwrite > 0 && (time < gF_WRTime[style][track] || gF_WRTime[style][track] == 0.0));
 	char sMessage[255];
 	char sMessage2[255];
 
-	if(iOverwrite > 0 && (time < gF_WRTime[style][track] || gF_WRTime[style][track] == 0.0)) // WR?
+	if(bIsWR)
 	{
 		float fOldWR = gF_WRTime[style][track];
 		gF_WRTime[style][track] = time;
@@ -2600,36 +2601,6 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 		#if defined DEBUG
 		Shavit_PrintToChat(client, "old: %.01f new: %.01f", fOldWR, time);
 		#endif
-
-		Transaction trans = new Transaction();
-		char query[512];
-
-		FormatEx(query, sizeof(query),
-			"DELETE FROM `%sstagetimeswr` WHERE style = %d AND track = %d AND map = '%s';",
-			gS_MySQLPrefix, style, track, gS_Map
-		);
-
-		AddQueryLog(trans, query);
-
-		for (int i = 0; i < MAX_STAGES; i++)
-		{
-			float fTime = gA_StageTimes[client][i];
-			gA_StageWR[style][track][i] = fTime;
-
-			if (fTime == 0.0)
-			{
-				continue;
-			}
-
-			FormatEx(query, sizeof(query),
-				"INSERT INTO `%sstagetimeswr` (`style`, `track`, `map`, `auth`, `time`, `stage`) VALUES (%d, %d, '%s', %d, %f, %d);",
-				gS_MySQLPrefix, style, track, gS_Map, iSteamID, fTime, i
-			);
-
-			AddQueryLog(trans, query);
-		}
-
-		gH_SQL.Execute(trans, Trans_ReplaceStageTimes_Success, Trans_ReplaceStageTimes_Error, 0, DBPrio_High);
 	}
 
 	int iRank = GetRankForTime(style, time, track);
@@ -2669,7 +2640,35 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 	{
 		float fPoints = gB_Rankings ? Shavit_GuessPointsForTime(track, style, -1, time, gF_WRTime[style][track]) : 0.0;
 
+		Transaction trans = new Transaction();
 		char sQuery[1024];
+
+		FormatEx(sQuery, sizeof(sQuery), "CREATE TEMPORARY TABLE IF NOT EXISTS `Insert_Stages` (`playertimes_id` INT, `stage` TINYINT NOT NULL, `time` FLOAT NOT NULL);");
+		AddQueryLog(trans, sQuery);
+
+		FormatEx(sQuery, sizeof(sQuery), "DELETE FROM `Insert_Stages`;");
+		AddQueryLog(trans, sQuery);
+
+		for (int i = 0; i < MAX_STAGES; i++)
+		{
+			float fTime = gA_StageTimes[client][i];
+
+			if(bIsWR)
+			{
+				gA_StageWR[style][track][i] = fTime;
+			}
+
+			if (fTime == 0.0)
+			{
+				continue;
+			}
+
+			FormatEx(sQuery, sizeof(sQuery),
+				"INSERT INTO `Insert_Stages` (`stage`, `time`) VALUES (%d, %f);",
+				i, fTime
+			);
+			AddQueryLog(trans, sQuery);
+		}
 
 		if(iOverwrite == 1) // insert
 		{
@@ -2679,6 +2678,18 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 			FormatEx(sQuery, sizeof(sQuery),
 				"INSERT INTO %splayertimes (auth, map, time, jumps, date, style, strafes, sync, points, track, perfs) VALUES (%d, '%s', %.9f, %d, %d, %d, %d, %.2f, %f, %d, %.2f);",
 				gS_MySQLPrefix, iSteamID, gS_Map, time, jumps, timestamp, style, strafes, sync, fPoints, track, perfs);
+			AddQueryLog(trans, sQuery);
+
+			// Will affect 0 rows on linear/unstaged maps
+			// TODO: Needs PostgreSQL support
+			FormatEx(sQuery, sizeof(sQuery), "UPDATE `Insert_Stages` SET `playertimes_id` = %s;", gI_Driver == Driver_mysql ? "LAST_INSERT_ID()" : "last_insert_rowid()");
+			AddQueryLog(trans, sQuery);
+
+			FormatEx(sQuery, sizeof(sQuery),
+				"INSERT INTO `%sstagetimes` (playertimes_id, stage, time) SELECT playertimes_id, stage, time FROM `Insert_Stages`;",
+				gS_MySQLPrefix
+			);
+			AddQueryLog(trans, sQuery);
 		}
 		else // update
 		{
@@ -2688,9 +2699,26 @@ public void Shavit_OnFinish(int client, int style, float time, int jumps, int st
 			FormatEx(sQuery, sizeof(sQuery),
 				"UPDATE %splayertimes SET time = %.9f, jumps = %d, date = %d, strafes = %d, sync = %.02f, points = %f, perfs = %.2f, completions = completions + 1 WHERE map = '%s' AND auth = %d AND style = %d AND track = %d;",
 				gS_MySQLPrefix, time, jumps, timestamp, strafes, sync, fPoints, perfs, gS_Map, iSteamID, style, track);
+			AddQueryLog(trans, sQuery);
+
+			// Will affect 0 rows on linear/unstaged maps
+			FormatEx(sQuery, sizeof(sQuery), "UPDATE `Insert_Stages` SET `playertimes_id` = (SELECT id FROM `%splayertimes` WHERE map = '%s' AND auth = %d AND style = %d AND track = %d);",
+			gS_MySQLPrefix, gS_Map, iSteamID, style, track);
+			AddQueryLog(trans, sQuery);
+
+			// Delete all stage times first (safer than an UPDATE in unexpected cases where the new completion has fewer/no stage times, e.g. bad zoning)
+			FormatEx(sQuery, sizeof(sQuery), "DELETE FROM `%sstagetimes` WHERE playertimes_id IN (SELECT id FROM `%splayertimes` WHERE map = '%s' AND auth = %d AND style = %d AND track = %d);",
+			gS_MySQLPrefix, gS_MySQLPrefix, gS_Map, iSteamID, style, track);
+			AddQueryLog(trans, sQuery);
+
+			FormatEx(sQuery, sizeof(sQuery),
+				"INSERT INTO `%sstagetimes` (playertimes_id, stage, time) SELECT playertimes_id, stage, time FROM `Insert_Stages`;",
+				gS_MySQLPrefix
+			);
+			AddQueryLog(trans, sQuery);
 		}
 
-		QueryLog(gH_SQL, SQL_OnFinish_Callback, sQuery, GetClientSerial(client), DBPrio_High);
+		gH_SQL.Execute(trans, Trans_OnFinishTimes_Success, Trans_OnFinishTimes_Error, GetClientSerial(client), DBPrio_High);
 
 		Call_StartForward(gH_OnFinish_Post);
 		Call_PushCell(client);
@@ -2806,15 +2834,8 @@ public void SQL_OnIncrementCompletions_Callback(Database db, DBResultSet results
 	}
 }
 
-public void SQL_OnFinish_Callback(Database db, DBResultSet results, const char[] error, any data)
+public void Trans_OnFinishTimes_Success(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
 {
-	if(results == null)
-	{
-		LogError("Timer (WR OnFinish) SQL query failed. Reason: %s", error);
-
-		return;
-	}
-
 	int client = GetClientFromSerial(data);
 
 	if(client == 0)
@@ -2825,14 +2846,9 @@ public void SQL_OnFinish_Callback(Database db, DBResultSet results, const char[]
 	UpdateWRCache(client);
 }
 
-public void Trans_ReplaceStageTimes_Success(Database db, any data, int numQueries, DBResultSet[] results, any[] queryData)
+public void Trans_OnFinishTimes_Error(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
 {
-	return;
-}
-
-public void Trans_ReplaceStageTimes_Error(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
-{
-	LogError("Timer (ReplaceStageTimes) SQL query failed %d/%d. Reason: %s", failIndex, numQueries, error);
+	LogError("Timer (WR OnFinish) SQL query failed %d/%d. Reason: %s", failIndex, numQueries, error);
 }
 
 void UpdateLeaderboards()

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -575,9 +575,10 @@ void UpdateWRCache(int client = -1)
 	char sQuery[512];
 
 	FormatEx(sQuery, sizeof(sQuery),
-		"SELECT style, track, auth, stage, time FROM `%sstagetimeswr` WHERE map = '%s';",
-		gS_MySQLPrefix, gS_Map);
-
+			"SELECT WR.style, WR.track, ST.stage, ST.time \
+			FROM `%sstagetimes` AS `ST`	INNER JOIN `%swrs` AS `WR` ON WR.id = ST.playertimes_id \
+			WHERE WR.map = '%s';",
+			gS_MySQLPrefix, gS_MySQLPrefix, gS_Map);
 	QueryLog(gH_SQL, SQL_UpdateWRStageTimes_Callback, sQuery);
 }
 
@@ -604,9 +605,9 @@ public void SQL_UpdateWRStageTimes_Callback(Database db, DBResultSet results, co
 	{
 		int style = results.FetchInt(0);
 		int track = results.FetchInt(1);
-		int stage = results.FetchInt(3);
+		int stage = results.FetchInt(2);
 
-		gA_StageWR[style][track][stage] = results.FetchFloat(4);
+		gA_StageWR[style][track][stage] = results.FetchFloat(3);
 	}
 }
 

--- a/addons/sourcemod/scripting/shavit-wr.sp
+++ b/addons/sourcemod/scripting/shavit-wr.sp
@@ -2926,6 +2926,13 @@ public Action Shavit_OnStageMessage(int client, int stageNumber, char[] message,
 
 	gA_StageTimes[client][stageNumber] = stageTime;
 
+	// Don't show ANY stage message if 0.0
+	// (e.g. if stage zone intersects with start zone)
+	if (stageTime == 0.0)
+	{
+		return Plugin_Handled;
+	}
+
 	if (stageTimeWR == 0.0)
 	{
 		return Plugin_Continue;

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -5266,7 +5266,7 @@ public void StartTouchPost(int entity, int other)
 				FormatSeconds(Shavit_GetClientTime(other), sTime, 32, true);
 
 				char sMessage[255];
-				FormatEx(sMessage, 255, "%T", "ZoneStageEnter", other, gS_ChatStrings.sText, gS_ChatStrings.sVariable2, num, gS_ChatStrings.sText, gS_ChatStrings.sVariable2, sTime, gS_ChatStrings.sText);
+				FormatEx(sMessage, 255, "%T", "ZoneStageEnter", other, gS_ChatStrings.sText, gS_ChatStrings.sVariable, num, gS_ChatStrings.sText, gS_ChatStrings.sVariable, sTime, gS_ChatStrings.sText);
 
 				Action aResult = Plugin_Continue;
 				Call_StartForward(gH_Forwards_StageMessage);

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -5426,10 +5426,12 @@ public void TouchPost(int entity, int other)
 			if (Shavit_GetTimerStatus(other) == Timer_Stopped || Shavit_GetClientTrack(other) != Track_Main)
 			{
 				Shavit_StartTimer(other, track);
+				gI_LastStage[other] = 0;
 			}
 			else if (track == Track_Main)
 			{
 				Shavit_StartTimer(other, Track_Main);
+				gI_LastStage[other] = 0;
 			}
 		}
 		case Zone_Respawn:

--- a/addons/sourcemod/translations/shavit-zones.phrases.txt
+++ b/addons/sourcemod/translations/shavit-zones.phrases.txt
@@ -454,7 +454,7 @@
 	"ZoneStageEnter"
 	{
 		"#format"	"{1:s},{2:s},{3:d},{4:s},{5:s},{6:s}{7:s}"
-		"en"		"{1}Stage {2}{3}{4} @ {5}{6}{7} "
+		"en"		"{1}You have reached stage {2}{3}{4} with a time of {5}{6}{7}."
 	}
 	"Zone_Start"
 	{


### PR DESCRIPTION
Key changes:

- Each stage time now has a foreign key referencing an existing playertime ID, so redundant columns that were a part of stagetimeswr such as auth, map and style are now derived from the parent playertimes entry.

- Deleting a playertime now deletes the associated stage times through CASCADE referential action. Previously, when a WR playertime was deleted it created orphaned child records in stagetimeswr because there was no application logic to delete the stagetimeswr rows.

- Stage times are now stored for all PBs, not just a WR. Will allow for PB stage splits to be shown during a run – e.g. something like this:
![image](https://user-images.githubusercontent.com/26863777/206901702-655647c4-aa0a-40a5-8d59-5e945ee7f9b2.png)


A few minor fixes/changes too:
- gI_LastStage now resets to 0 when you enter/re-enter the main start zone/bonus start zone if currently on a bonus track. Previously only the restart command reset gI_LastStage.

- Updated ZoneStageEnter translation (when there are no WR stage times) to match the WRStageTime message translation.

- Having a stage time of 0.0 no longer shows a ZoneStageEnter/WRStageTime message. This would happen if you have a stage 1 zone intersecting with the start zone.

This PR doesn’t address the implementation of !wrcp, which would need to be a separate table because individual stage time records won’t necessarily be tied to an existing playertime.

The actual migration uses a new `stagetimes` table with `playertimes_id {PK, FK}`, `stage {PK}` and `time` columns. Technically the stage number column is redundant, and a `mapzones` `id` could be referenced to get the stage number from the `data` column. I opened #1177 to accommodate an implementation that does this, and don’t mind updating the schema/logic if you think it’s a good idea. Would have the benefit of stage times always being associated with the correct stage if a stage zone’s stage number is updated, as well as stage times being deleted at the same time the referenced zone is deleted.

Tested the updated queries in shavit-wr with SQLite and MySQL and both should be working fine. There’s definitely room for cleaner MySQL-specific queries though, as I was focused more on SQLite compatibility. Needs support for Postgres.

Should note that any orphaned records in stagetimeswr are deleted during the migration so you may want to encourage database backups before installation just in case people are relying on WR stage splits that do not belong to an existing playertime.