### PR TITLE
Godmode fix for DMG_CRUSH and point_hurt

### DIFF
--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -261,7 +261,7 @@ public void OnPluginStart()
 	RegConsoleCmd("sm_adverts", Command_PrintAdverts, "Prints all the adverts to your chat");
 
 	// cvars and stuff
-	gCV_GodMode = new Convar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.", 0, true, 0.0, true, 3.0);
+	gCV_GodMode = new Convar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.\n4 - Prevent fall/world/entity damage (all except damage from other players).", 0, true, 0.0, true, 4.0);
 	gCV_PreSpeed = new Convar("shavit_misc_prespeed", "2", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.\n5 - Limit horizontal speed to prestrafe but allow prespeeding.", 0, true, 0.0, true, 5.0);
 	gCV_HideTeamChanges = new Convar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = new Convar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -1490,11 +1490,33 @@ public Action OnTakeDamage(int victim, int& attacker, int& inflictor, float& dam
 
 	switch(gCV_GodMode.IntValue)
 	{
-		case 0:
+		default: // 0 or invalid value: don't block damage
 		{
 			bBlockDamage = false;
 		}
-		case 1:
+		case 1: // block world/fall damage
+		{
+			// 0 - world/fall damage
+			if (attacker == 0)
+			{
+				bBlockDamage = true;
+			}
+		}
+		case 2: // block player-dealt damage
+		{
+			char sClassname[12];
+			if (IsValidClient(attacker) &&
+				( !IsValidEntity(inflictor) || !GetEntityClassname(inflictor, sClassname, sizeof(sClassname)) || !StrEqual(sClassname, "point_hurt") ) // This line ignores damage dealt by point_hurt (see https://developer.valvesoftware.com/wiki/Point_hurt)
+			   )
+			{
+				bBlockDamage = true;
+			}
+		}
+		case 3: // full godmode, blocks all damage
+		{
+			bBlockDamage = true;
+		}
+		case 4: // block world/fall/entity damage (all damage except damage from other players)
 		{
 			// 0 - world/fall damage
 			if (attacker == 0 || attacker > MaxClients) // (attacker > MaxClients) for DMG_CRUSH, by moving/falling objects for example (with cs_enable_player_physics_box 1)
@@ -1509,20 +1531,6 @@ public Action OnTakeDamage(int victim, int& attacker, int& inflictor, float& dam
 					bBlockDamage = true;
 				}
 			}
-		}
-		case 2:
-		{
-			char sClassname[12];
-			if (IsValidClient(attacker) &&
-				( !IsValidEntity(inflictor) || !GetEntityClassname(inflictor, sClassname, sizeof(sClassname)) || !StrEqual(sClassname, "point_hurt") ) // This line ignores damage dealt by point_hurt (see https://developer.valvesoftware.com/wiki/Point_hurt)
-			   )
-			{
-				bBlockDamage = true;
-			}
-		}
-		default:
-		{
-			bBlockDamage = true;
 		}
 	}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1490,7 +1490,7 @@ public Action OnTakeDamage(int victim, int& attacker, int& inflictor, float& dam
 
 	switch(gCV_GodMode.IntValue)
 	{
-		default: // 0 or invalid value: don't block damage
+		case 0: // don't block damage
 		{
 			bBlockDamage = false;
 		}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1484,7 +1484,7 @@ void ClearViewPunch(int victim)
 	}
 }
 
-public Action OnTakeDamage(int victim, int& attacker)
+public Action OnTakeDamage(int victim, int& attacker, int& inflictor, float& damage, int& damagetype, int& weapon, float damageForce[3], float damagePosition[3])
 {
 	bool bBlockDamage;
 
@@ -1497,14 +1497,25 @@ public Action OnTakeDamage(int victim, int& attacker)
 		case 1:
 		{
 			// 0 - world/fall damage
-			if(attacker == 0)
+			if (attacker == 0 || attacker > MaxClients) // (attacker > MaxClients) for DMG_CRUSH, by moving/falling objects for example (with cs_enable_player_physics_box 1)
 			{
 				bBlockDamage = true;
+			}
+			else if (inflictor != attacker && IsValidEntity(inflictor)) // handles damage dealt by point_hurt (see https://developer.valvesoftware.com/wiki/Point_hurt)
+			{
+				char sClassname[12];
+				if (GetEntityClassname(inflictor, sClassname, sizeof(sClassname)) && StrEqual(sClassname, "point_hurt"))
+				{
+					bBlockDamage = true;
+				}
 			}
 		}
 		case 2:
 		{
-			if(IsValidClient(attacker))
+			char sClassname[12];
+			if (IsValidClient(attacker) &&
+				( !IsValidEntity(inflictor) || !GetEntityClassname(inflictor, sClassname, sizeof(sClassname)) || !StrEqual(sClassname, "point_hurt") ) // This line ignores damage dealt by point_hurt (see https://developer.valvesoftware.com/wiki/Point_hurt)
+			   )
 			{
 				bBlockDamage = true;
 			}


### PR DESCRIPTION
Fixes DMG_CRUSH (by moving/falling objects for example (with cs_enable_player_physics_box 1))

Handles correctly damage dealt by point_hurt entities (see https://developer.valvesoftware.com/wiki/Point_hurt)

~~**IMPORTANT:** `shavit_misc_godmode 1` will now block damage dealt by ALL entities that aren't players, instead of only 0 (world).
If you don't want to make it like that, please tell me.~~
-- Added `shavit_misc_godmode 4` for that