### PR TITLE
Allow updating replay bot name without being a WR

### DIFF
--- a/addons/sourcemod/scripting/shavit-replay-playback.sp
+++ b/addons/sourcemod/scripting/shavit-replay-playback.sp
@@ -2132,7 +2132,16 @@ void FormatStyle(const char[] source, int style, bool central, int track, char d
 	else
 	{
 		FormatSeconds(GetReplayLength(style, track, aCache), sTime, 16);
-		GetReplayName(style, track, sName, sizeof(sName));
+
+		if(aCache.bNewFormat)
+		{
+			strcopy(sName, sizeof(sName), aCache.sReplayName);
+		}
+		else
+		{
+			GetReplayName(style, track, sName, sizeof(sName));
+		}
+
 		ReplaceString(temp, sizeof(temp), "{style}", gS_StyleStrings[style].sStyleName);
 		ReplaceString(temp, sizeof(temp), "{styletag}", gS_StyleStrings[style].sClanTag);
 	}


### PR DESCRIPTION
This allows editing the replay bot's name through the frame_cache_t of the replay data, which is useful for personal replays. Without this change, the replay bot's name after calling Shavit_StartReplayFromFrameCache would be the current WR's player name.