### PR TITLE
Make stage restart command take player to beginning when in end zone

### DIFF
--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -2491,7 +2491,7 @@ public Action Command_StageRestart(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if (last <= 0)
+	if (last <= 0 || InsideZone(client, Zone_End, track))
 	{
 		Shavit_RestartTimer(client, track);
 	}


### PR DESCRIPTION
This is a fix to the stage restart command I added a while ago for surf.