### PR TITLE
Startzone speed limit flexibility

### DIFF
--- a/addons/sourcemod/configs/shavit-styles.cfg
+++ b/addons/sourcemod/configs/shavit-styles.cfg
@@ -35,6 +35,7 @@
 		// Physics
 		"airaccelerate"		"1000.0" // sv_airaccelerate value for the style.
 		"runspeed"			"260.00" // Running speed. Requires DHooks, shavit-misc and shavit_misc_staticprestrafe set to 1.
+		"maxprestrafe"      "0.0" // IDK what description to put for this....
 		"gravity"			"1.0" // Gravity setting, 1.0 for default. Standard for low gravity styles is 0.6.
 		"speed"				"1.0" // Speed multiplier, 1.0 for default. Standard for slowmo styles is 0.5. This a multiplier for m_flLaggedMovementValue.
 		"timescale"			"1.0" // Timing will scale with this setting. This is a multiplier for m_flLaggedMovementValue but also affects the timer increase speed.

--- a/addons/sourcemod/configs/shavit-styles.cfg
+++ b/addons/sourcemod/configs/shavit-styles.cfg
@@ -35,7 +35,7 @@
 		// Physics
 		"airaccelerate"		"1000.0" // sv_airaccelerate value for the style.
 		"runspeed"			"260.00" // Running speed. Requires DHooks, shavit-misc and shavit_misc_staticprestrafe set to 1.
-		"maxprestrafe"      "0.0" // IDK what description to put for this....
+		"maxprestrafe"      "0.0" // The max prestrafe that still allows your timer to start/restart. You generally do *not* need or want to change this unless for surf things (combined with style-setting "prespeed_type" "6" or cvar "shavit_misc_prespeed 6"). Default is 0.0 (disabled).
 		"gravity"			"1.0" // Gravity setting, 1.0 for default. Standard for low gravity styles is 0.6.
 		"speed"				"1.0" // Speed multiplier, 1.0 for default. Standard for slowmo styles is 0.5. This a multiplier for m_flLaggedMovementValue.
 		"timescale"			"1.0" // Timing will scale with this setting. This is a multiplier for m_flLaggedMovementValue but also affects the timer increase speed.

--- a/addons/sourcemod/scripting/include/shavit/style-settings.sp
+++ b/addons/sourcemod/scripting/include/shavit/style-settings.sp
@@ -164,6 +164,7 @@ public SMCResult OnStyleEnterSection(SMCParser smc, const char[] name, bool opt_
 
 	SetStyleSettingFloat(gI_CurrentParserIndex, "airaccelerate", 1000.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "runspeed", 260.00);
+	SetStyleSettingFloat(gI_CurrentParserIndex, "maxprestrafe", 0.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "gravity", 1.0);
 	SetStyleSettingFloat(gI_CurrentParserIndex, "speed", 1.0);
 	SetStyleSettingInt  (gI_CurrentParserIndex, "halftime", 0);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -173,6 +173,7 @@ char gS_Verification[MAXPLAYERS+1][8];
 bool gB_CookiesRetrieved[MAXPLAYERS+1];
 float gF_ZoneAiraccelerate[MAXPLAYERS+1];
 float gF_ZoneSpeedLimit[MAXPLAYERS+1];
+float gF_ZoneStartSpeedLimit[MAXPLAYERS+1];
 int gI_LastPrintedSteamID[MAXPLAYERS+1];
 
 // kz support
@@ -2511,7 +2512,18 @@ bool CanStartTimer(int client, int track, bool skipGroundCheck)
 		return true;
 
 	float cfgMax = GetStyleSettingFloat(style, "maxprestrafe");
-	float prestrafe = cfgMax > 0.0 ? cfgMax : StyleMaxPrestrafe(style);
+	float zoneMax = gF_ZoneStartSpeedLimit[client];
+	// float prestrafe = cfgMax > 0.0 ? cfgMax : StyleMaxPrestrafe(style);
+	float prestrafe;
+	if (zoneMax > 0.0) {
+		prestrafe = zoneMax;
+	}
+	else if (cfgMax > 0.0) {
+		prestrafe = cfgMax;
+	} else {
+		prestrafe = StyleMaxPrestrafe(style);
+	}
+
 	if (curVel > prestrafe)
 		return false;
 
@@ -2899,7 +2911,10 @@ void SQL_DBConnect()
 
 public void Shavit_OnEnterZone(int client, int type, int track, int id, int entity, int data)
 {
-	if (type == Zone_Airaccelerate && track == gA_Timers[client].iTimerTrack)
+	if (type == Zone_Start && track == gA_Timers[client].iTimerTrack) {
+		gF_ZoneStartSpeedLimit[client] = float(data);
+	}
+	else if (type == Zone_Airaccelerate && track == gA_Timers[client].iTimerTrack)
 	{
 		gF_ZoneAiraccelerate[client] = float(data);
 	}
@@ -2921,7 +2936,7 @@ public void Shavit_OnLeaveZone(int client, int type, int track, int id, int enti
 	//       Probably so very niche that it doesn't matter.
 	if (track != gA_Timers[client].iTimerTrack)
 		return;
-	if (type != Zone_Airaccelerate && type != Zone_CustomSpeedLimit)
+	if (type != Zone_Airaccelerate && type != Zone_CustomSpeedLimit && type != Zone_Start)
 		return;
 
 	UpdateStyleSettings(client);

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -2510,7 +2510,8 @@ bool CanStartTimer(int client, int track, bool skipGroundCheck)
 	if (curVel <= 50.0)
 		return true;
 
-	float prestrafe = StyleMaxPrestrafe(style);
+	float cfgMax = GetStyleSettingFloat(style, "maxprestrafe");
+	float prestrafe = cfgMax > 0.0 ? cfgMax : StyleMaxPrestrafe(style);
 	if (curVel > prestrafe)
 		return false;
 

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -2521,14 +2521,18 @@ bool CanStartTimer(int client, int track, bool skipGroundCheck)
 
 	float cfgMax = GetStyleSettingFloat(style, "maxprestrafe");
 	float zoneMax = gF_ZoneStartSpeedLimit[client];
-	// float prestrafe = cfgMax > 0.0 ? cfgMax : StyleMaxPrestrafe(style);
 	float prestrafe;
-	if (zoneMax > 0.0) {
+
+	if (zoneMax > 0.0)
+	{
 		prestrafe = zoneMax;
 	}
-	else if (cfgMax > 0.0) {
+	else if (cfgMax > 0.0)
+	{
 		prestrafe = cfgMax;
-	} else {
+	}
+	else
+	{
 		prestrafe = StyleMaxPrestrafe(style);
 	}
 
@@ -2919,7 +2923,8 @@ void SQL_DBConnect()
 
 public void Shavit_OnEnterZone(int client, int type, int track, int id, int entity, int data)
 {
-	if (type == Zone_Start && track == gA_Timers[client].iTimerTrack) {
+	if (type == Zone_Start && track == gA_Timers[client].iTimerTrack)
+	{
 		gF_ZoneStartSpeedLimit[client] = float(data);
 	}
 	else if (type == Zone_Airaccelerate && track == gA_Timers[client].iTimerTrack)

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -73,6 +73,7 @@ Function gH_AfterWarningMenu[MAXPLAYERS+1];
 int gI_LastWeaponTick[MAXPLAYERS+1];
 int gI_LastNoclipTick[MAXPLAYERS+1];
 int gI_LastStopInfo[MAXPLAYERS+1];
+int gI_LastGroundLandTick[MAXPLAYERS+1];
 
 // cookies
 Handle gH_HideCookie = null;
@@ -1345,8 +1346,19 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			prespeed_type = gCV_PreSpeed.IntValue;
 		}
 
+		int tickCount = GetSysTickCount();
 		int iPrevGroundEntity = (gI_GroundEntity[client] != -1) ? EntRefToEntIndex(gI_GroundEntity[client]) : -1;
-		if ((prespeed_type == 2 || prespeed_type == 3 || prespeed_type == 6) && iPrevGroundEntity == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
+
+		if (iPrevGroundEntity == -1 && iGroundEntity != -1) {
+			gI_LastGroundLandTick[client] = tickCount;
+		}
+
+		if ((prespeed_type == 2 || prespeed_type == 3) && iPrevGroundEntity == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
+		{
+			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
+		}
+
+		if (prespeed_type == 6 && iPrevGroundEntity == -1 && iGroundEntity != -1 && tickCount - gI_LastGroundLandTick[client] <= 1000)
 		{
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
 		}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -264,7 +264,7 @@ public void OnPluginStart()
 
 	// cvars and stuff
 	gCV_GodMode = new Convar("shavit_misc_godmode", "3", "Enable godmode for players?\n0 - Disabled\n1 - Only prevent fall/world damage.\n2 - Only prevent damage from other players.\n3 - Full godmode.\n4 - Prevent fall/world/entity damage (all except damage from other players).", 0, true, 0.0, true, 4.0);
-	gCV_PreSpeed = new Convar("shavit_misc_prespeed", "2", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.\n5 - Limit horizontal speed to prestrafe but allow prespeeding.", 0, true, 0.0, true, 5.0);
+	gCV_PreSpeed = new Convar("shavit_misc_prespeed", "2", "Stop prespeeding in the start zone?\n0 - Disabled, fully allow prespeeding.\n1 - Limit relatively to prestrafelimit.\n2 - Block bunnyhopping in startzone.\n3 - Limit to prestrafelimit and block bunnyhopping.\n4 - Limit to prestrafelimit but allow prespeeding. Combine with shavit_core_nozaxisspeed 1 for SourceCode timer's behavior.\n5 - Limit horizontal speed to prestrafe but allow prespeeding. \n6 - Limit horizontal speed to prestrafe and block bunnyhopping.", 0, true, 0.0, true, 5.0);
 	gCV_HideTeamChanges = new Convar("shavit_misc_hideteamchanges", "1", "Hide team changes in chat?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnTeam = new Convar("shavit_misc_respawnonteam", "1", "Respawn whenever a player joins a team?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
 	gCV_RespawnOnRestart = new Convar("shavit_misc_respawnonrestart", "1", "Respawn a dead player if they use the timer restart command?\n0 - Disabled\n1 - Enabled", 0, true, 0.0, true, 1.0);
@@ -1346,7 +1346,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 		}
 
 		int iPrevGroundEntity = (gI_GroundEntity[client] != -1) ? EntRefToEntIndex(gI_GroundEntity[client]) : -1;
-		if ((prespeed_type == 2 || prespeed_type == 3) && iPrevGroundEntity == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
+		if ((prespeed_type == 2 || prespeed_type == 3 || prespeed_type == 6) && iPrevGroundEntity == -1 && iGroundEntity != -1 && (buttons & IN_JUMP) > 0)
 		{
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
 		}
@@ -1387,7 +1387,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 			if(fScale < 1.0)
 			{
-				if (prespeed_type == 5)
+				if (prespeed_type == 5 || prespeed_type == 6)
 				{
 					float zSpeed = fSpeed[2];
 					fSpeed[2] = 0.0;
@@ -2335,7 +2335,7 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 
 			if(fScale < 1.0)
 			{
-				if (prespeed_type == 5)
+				if (prespeed_type == 5 || prespeed_type == 6)
 				{
 					float zSpeed = fSpeed[2];
 					fSpeed[2] = 0.0;

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1358,10 +1358,6 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
 		}
 
-		if (prespeed_type == 6 && iGroundEntity != -1 && tickCount - gI_LastGroundLandTick[client] <= 250 && (buttons & IN_JUMP) > 0)
-		{
-			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
-		}
 		else if (prespeed_type == 1 || prespeed_type >= 3)
 		{
 			float fSpeed[3];
@@ -1391,6 +1387,21 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
 			if (prespeed_type < 4 && fSpeed[2] > 0.0)
+			{
+				fLimit /= 3.0;
+			}
+
+			int iOldButtons = GetEntProp(client, Prop_Data, "m_nOldButtons");
+			// TODO: somehow incorporate the autobhop style thingy or figure out a better way to do all of this lmao
+			int iAutoBhop = Shavit_GetStyleSettingBool(Shavit_GetBhopStyle(client), "autobhop");
+			bool isJumping = (buttons & IN_JUMP) > 0;
+			if (!iAutoBhop)
+			{
+				isJumping &= (iOldButtons & IN_JUMP) == 0;
+			}
+			if (prespeed_type == 6 && iGroundEntity != -1 &&
+			    tickCount - gI_LastGroundLandTick[client] <= 150 &&
+				isJumping)
 			{
 				fLimit /= 3.0;
 			}

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1357,10 +1357,21 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
 			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
+
+			int zoneid;
+			Shavit_InsideZoneGetID(client, Zone_Start, track, zoneid);
+			float zoneLimit = float(Shavit_GetZoneData(zoneid));
+
 			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
-			if (cfgLimit > 0.0) {
+			if (zoneLimit > 0.0)
+			{
+				fLimit = zoneLimit;
+			}
+			else if (cfgLimit > 0.0)
+			{
 				fLimit = cfgLimit;
-			} else if (fLimit > maxPrestrafe) {
+			}
+			else if (fLimit > maxPrestrafe){
 				fLimit = maxPrestrafe;
 			}
 
@@ -2294,10 +2305,21 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
 			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
+
+			int zoneid;
+			Shavit_InsideZoneGetID(client, Zone_Start, track, zoneid);
+			float zoneLimit = float(Shavit_GetZoneData(zoneid));
+
 			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
-			if (cfgLimit > 0.0) {
+			if (zoneLimit > 0.0)
+			{
+				fLimit = zoneLimit;
+			}
+			else if (cfgLimit > 0.0)
+			{
 				fLimit = cfgLimit;
-			} else if (fLimit > maxPrestrafe) {
+			}
+			else if (fLimit > maxPrestrafe){
 				fLimit = maxPrestrafe;
 			}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1368,7 +1368,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
 			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
-			float zoneLimit = gF_ZoneStartSpeedLimit[client]
+			float zoneLimit = gF_ZoneStartSpeedLimit[client];
 			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
 
 			if (zoneLimit > 0.0)

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1358,7 +1358,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
 		}
 
-		if (prespeed_type == 6 && iPrevGroundEntity == -1 && iGroundEntity != -1 && tickCount - gI_LastGroundLandTick[client] <= 1000)
+		if (prespeed_type == 6 && iGroundEntity != -1 && tickCount - gI_LastGroundLandTick[client] <= 250 && (buttons & IN_JUMP) > 0)
 		{
 			DumbSetVelocity(client, view_as<float>({0.0, 0.0, 0.0}));
 		}
@@ -1466,6 +1466,7 @@ public void OnClientPutInServer(int client)
 
 	gI_LastWeaponTick[client] = 0;
 	gI_LastNoclipTick[client] = 0;
+	gI_LastGroundLandTick[client] = 0;
 
 	if(IsFakeClient(client))
 	{

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1371,7 +1371,8 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			{
 				fLimit = cfgLimit;
 			}
-			else if (fLimit > maxPrestrafe){
+			else if (fLimit > maxPrestrafe)
+			{
 				fLimit = maxPrestrafe;
 			}
 
@@ -2319,7 +2320,8 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 			{
 				fLimit = cfgLimit;
 			}
-			else if (fLimit > maxPrestrafe){
+			else if (fLimit > maxPrestrafe)
+			{
 				fLimit = maxPrestrafe;
 			}
 

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1356,6 +1356,13 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
+			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
+			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
+			if (cfgLimit > 0.0) {
+				fLimit = cfgLimit;
+			} else if (fLimit > maxPrestrafe) {
+				fLimit = maxPrestrafe;
+			}
 
 			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)
@@ -2286,8 +2293,13 @@ public Action Shavit_OnStartPre(int client, int track, bool& skipGroundTimer)
 			GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", fSpeed);
 
 			float fLimit = (Shavit_GetStyleSettingFloat(gI_Style[client], "runspeed") + gCV_PrestrafeLimit.FloatValue);
+			float cfgLimit = Shavit_GetStyleSettingFloat(gI_Style[client], "maxprestrafe");
 			float maxPrestrafe = StyleMaxPrestrafe(gI_Style[client]);
-			if (fLimit > maxPrestrafe) fLimit = maxPrestrafe;
+			if (cfgLimit > 0.0) {
+				fLimit = cfgLimit;
+			} else if (fLimit > maxPrestrafe) {
+				fLimit = maxPrestrafe;
+			}
 
 			// if trying to jump, add a very low limit to stop prespeeding in an elegant way
 			// otherwise, make sure nothing weird is happening (such as sliding at ridiculous speeds, at zone enter)

--- a/addons/sourcemod/scripting/shavit-misc.sp
+++ b/addons/sourcemod/scripting/shavit-misc.sp
@@ -1349,7 +1349,7 @@ public Action Shavit_OnUserCmdPre(int client, int &buttons, int &impulse, float 
 			prespeed_type = gCV_PreSpeed.IntValue;
 		}
 
-		int tickCount = GetSysTickCount();
+		int tickCount = GetGameTickCount();
 		int iPrevGroundEntity = (gI_GroundEntity[client] != -1) ? EntRefToEntIndex(gI_GroundEntity[client]) : -1;
 
 		if (iPrevGroundEntity == -1 && iGroundEntity != -1)

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -4402,7 +4402,8 @@ void CreateEditMenu(int client, bool autostage=false)
 	FormatEx(sMenuItem, 64, "%T", "ZoneForceRender", client, ((gA_EditCache[client].iFlags & ZF_ForceRender) > 0)? "＋":"－");
 	menu.AddItem("forcerender", sMenuItem);
 
-	if (gA_EditCache[client].iType == Zone_Start) {
+	if (gA_EditCache[client].iType == Zone_Start)
+	{
 		if (gA_EditCache[client].iData == 0)
 		{
 			FormatEx(sMenuItem, 64, "%T", "ZoneSetSpeedLimitDefault", client, gA_EditCache[client].iData);

--- a/addons/sourcemod/scripting/shavit-zones.sp
+++ b/addons/sourcemod/scripting/shavit-zones.sp
@@ -4361,7 +4361,19 @@ void CreateEditMenu(int client, bool autostage=false)
 	FormatEx(sMenuItem, 64, "%T", "ZoneForceRender", client, ((gA_EditCache[client].iFlags & ZF_ForceRender) > 0)? "＋":"－");
 	menu.AddItem("forcerender", sMenuItem);
 
-	if (gA_EditCache[client].iType == Zone_Stage)
+	if (gA_EditCache[client].iType == Zone_Start) {
+		if (gA_EditCache[client].iData == 0)
+		{
+			FormatEx(sMenuItem, 64, "%T", "ZoneSetSpeedLimitDefault", client, gA_EditCache[client].iData);
+		}
+		else
+		{
+			FormatEx(sMenuItem, 64, "%T", "ZoneSetSpeedLimit", client, gA_EditCache[client].iData);
+		}
+
+		menu.AddItem("datafromchat", sMenuItem);
+	}
+	else if (gA_EditCache[client].iType == Zone_Stage)
 	{
 		if (autostage)
 		{

--- a/addons/sourcemod/translations/shavit-zones.phrases.txt
+++ b/addons/sourcemod/translations/shavit-zones.phrases.txt
@@ -260,6 +260,11 @@
 		"#format"	"{1:d}"
 		"en"		"Custom speed limit: {1} (No Limit)"
 	}
+	"ZoneSetSpeedLimitDefault"
+	{
+		"#format"	"{1:d}"
+		"en"		"Custom speed limit: {1} (Default Speedcap)"
+	}
 	"ZoneSetStage"
 	{
 		"#format"	"{1:d}"


### PR DESCRIPTION
This PR changes a few things:
- The startzone code in shavit-misc duplicates some functionality for certain zone types, and one of those duplicates doesn't call StyleMaxPrestrafe even though the rest of the code is identical.
- There is now a style configuration flag that overrides fLimit, so modes that use it can enforce a different speedcap than the ~290 that it normally does
- This style configuration can be overridden by the contents of the data field of the startzone. If the startzone has 400 and the config file has 350, it will use 400.
- There is now a new prespeed type (6) that behaves like type 5 but also blocks prehopping. One thing I noticed is that the code to block bhops in mode 2, 3, and 6 only triggers on the first tick that the player hit the ground. You can still scroll and get to a higher speed, which is less of an issue on other styles that start the timer when you go above a certain speed.

Being able to change the zone speed limit like this allows for zones to behave more like surf. In bhop the average prestrafe requires you to jump at the exact last moment while still being on the ground. Surf prestrafes involve jumping up into the air and doing a strafe while falling down past the edge of the startzone. People have argued about whether this technique should be encouraged, but this type of zone is what I and many others are used to. ckSurf has a default of 350 xy speed.

Pitfalls:
- Coding style might not be up to snuff
- This doesn't do anything for stage zones. One thing that makes me feel better about this is that the way that stages are implemented in bhoptimer are really only meant to record splits. ALSO, I checked vibez and it also doesn't do any speed capping on stages so I'm not the only one who decided to not care.