### PR TITLE
Fix database verison parsing

### DIFF
--- a/addons/sourcemod/scripting/shavit-rankings.sp
+++ b/addons/sourcemod/scripting/shavit-rankings.sp
@@ -1304,25 +1304,32 @@ public void SQL_UpdateTop100_Callback(Database db, DBResultSet results, const ch
 
 bool DoWeHaveWindowFunctions(const char[] sVersion)
 {
-	float fVersion = StringToFloat(sVersion);
+	char buf[100][2];
+	ExplodeString(sVersion, ".", buf, 2, 100);
+	int iMajor = StringToInt(buf[0]);
+	int iMinor = StringToInt(buf[1]);
 
 	if (gI_Driver == Driver_sqlite)
 	{
-		return fVersion >= 3.25; // 2018~
+		// 2018~
+		return iMajor > 3 || (iMajor == 3 && iMinor >= 25); // 2018~
 	}
 	else if (gI_Driver == Driver_pgsql)
 	{
-		return fVersion >= 8.4; // 2009~
+		// 2009~
+		return iMajor > 8 || (iMajor == 8 && iMinor >= 4);
 	}
 	else if (gI_Driver == Driver_mysql)
 	{
 		if (StrContains(sVersion, "MariaDB") != -1)
 		{
-			return fVersion >= 10.2; // 2016~
+			 // 2016~
+			return iMajor > 10 || (iMajor == 10 && iMinor >= 2);
 		}
 		else // mysql then...
 		{
-			return fVersion >= 8.0; // 2018~
+			// 2018~
+			return iMajor > 8 || (iMajor == 8 && iMinor >= 0);
 		}
 	}
 


### PR DESCRIPTION
In the "DoWeHaveWindowFunctions" function, the timer checks the version numbers by converting it to a float. For some reason, this didn't work for me because sVersion was `10.11.6-MariaDB-0+deb12u1`, then StringToFloat converted that into 10.109999, which isn't greater than the required version of 10.2!

I changed this function to parse the major and minor version and do integer comparisons instead. I haven't tested it thoroughly but it seems to work.