### PR TITLE
shavit-stats.sp - fix error due to IsPlayerAlive() being called on disconnected client

### DIFF
--- a/addons/sourcemod/scripting/shavit-stats.sp
+++ b/addons/sourcemod/scripting/shavit-stats.sp
@@ -436,7 +436,7 @@ void SavePlaytime222(int client, float now, Transaction&trans, int style, int iS
 		if (gI_CurrentStyle[client] == style && gF_PlaytimeStyleStart[client] != 0.0)
 		{
 			diff += now - gF_PlaytimeStyleStart[client];
-			gF_PlaytimeStyleStart[client] = IsClientInGame(client) ? IsPlayerAlive(client) ? now : 0.0;
+			gF_PlaytimeStyleStart[client] = IsClientInGame(client) ? IsPlayerAlive(client) ? now : 0.0 : 0.0;
 		}
 
 		gF_PlaytimeStyleSum[client][style] = 0.0;

--- a/addons/sourcemod/scripting/shavit-stats.sp
+++ b/addons/sourcemod/scripting/shavit-stats.sp
@@ -436,7 +436,7 @@ void SavePlaytime222(int client, float now, Transaction&trans, int style, int iS
 		if (gI_CurrentStyle[client] == style && gF_PlaytimeStyleStart[client] != 0.0)
 		{
 			diff += now - gF_PlaytimeStyleStart[client];
-			gF_PlaytimeStyleStart[client] = IsPlayerAlive(client) ? now : 0.0;
+			gF_PlaytimeStyleStart[client] = IsClientInGame(client) ? IsPlayerAlive(client) ? now : 0.0;
 		}
 
 		gF_PlaytimeStyleSum[client][style] = 0.0;


### PR DESCRIPTION
L 06/25/2025 - 15:22:48: [SM] Exception reported: Client 2 is not in game
L 06/25/2025 - 15:22:48: [SM] Blaming: shavit/shavit-stats.smx
L 06/25/2025 - 15:22:48: [SM] Call stack trace:
L 06/25/2025 - 15:22:48: [SM]   [0] IsPlayerAlive
L 06/25/2025 - 15:22:48: [SM]   [1] Line 439, shavit-stats.sp::SavePlaytime222
L 06/25/2025 - 15:22:48: [SM]   [2] Line 498, shavit-stats.sp::SavePlaytime
L 06/25/2025 - 15:22:48: [SM]   [3] Line 351, shavit-stats.sp::OnClientDisconnect