### PR TITLE
shavit-replay-playback.sp - close replay menu on spawn (if it's open)

### DIFF
--- a/addons/sourcemod/scripting/shavit-replay-playback.sp
+++ b/addons/sourcemod/scripting/shavit-replay-playback.sp
@@ -2763,6 +2763,12 @@ public void Player_Event(Event event, const char[] name, bool dontBroadcast)
 			KickReplay(gA_BotInfo[index]);
 		}
 	}
+	
+	if(IsPlayerAlive(client) && gB_InReplayMenu[client])
+	{
+		CancelClientMenu(client);
+		gB_InReplayMenu[client] = false;
+	}
 }
 
 public Action BotEvents(Event event, const char[] name, bool dontBroadcast)


### PR DESCRIPTION
QoL change. no reason to keep the replay menu open when spawning. works very well with the menu persistence changes