### PR TITLE
Update shavit-hud.sp - fix client not in game error

### DIFF
--- a/addons/sourcemod/scripting/shavit-hud.sp
+++ b/addons/sourcemod/scripting/shavit-hud.sp
@@ -606,7 +606,11 @@ void Frame_UpdateTopLeftHUD(int serial)
 
 public Action Command_SpecNextPrev(int client, const char[] command, int args)
 {
-	RequestFrame(Frame_UpdateTopLeftHUD, GetClientSerial(client));
+	if (IsClientInGame(client))
+	{
+		RequestFrame(Frame_UpdateTopLeftHUD, GetClientSerial(client));
+	}
+
 	return Plugin_Continue;
 }
 


### PR DESCRIPTION
L 04/13/2026 - 15:44:35: [SM] Exception reported: Client 3 is not in game
L 04/13/2026 - 15:44:35: [SM] Blaming: shavit/shavit-hud.smx
L 04/13/2026 - 15:44:35: [SM] Call stack trace:
L 04/13/2026 - 15:44:35: [SM]   [0] IsClientObserver
L 04/13/2026 - 15:44:35: [SM]   [1] Line 491, ./include/shavit/core.inc::GetSpectatorTarget
L 04/13/2026 - 15:44:35: [SM]   [2] Line 2228, shavit-hud.sp::UpdateTopLeftHUD
L 04/13/2026 - 15:44:35: [SM]   [3] Line 603, shavit-hud.sp::Frame_UpdateTopLeftHUD
L 04/13/2026 - 15:46:14: Error log file session closed.