### PR TITLE
Replace tickcount-based perf detection

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/core.inc
+++ b/addons/sourcemod/scripting/include/shavit/core.inc
@@ -161,7 +161,8 @@ enum struct timer_snapshot_t
 	float fLastAngle;
 
 	// Internal int used for the iMeasuredJumps & iPerfectJumps stuff.
-	int iLandingTick;
+	// How many ticks the player has been on the ground since landing. 0 = in air.
+	int iGroundTicks;
 	// Internal value used for unfucking style/zone gravity when using ladders.
 	MoveType iLastMoveType;
 	// Internal value used for blocking +strafe (if block_pstrafe is enabled).

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -3718,7 +3718,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 			}
 		}
 	}
-	
+
 	if (bOnGround)
 	{
 		if (!gA_Timers[client].bOnGround)

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -3347,7 +3347,6 @@ void BuildSnapshot(int client, timer_snapshot_t snapshot)
 	snapshot = gA_Timers[client];
 	snapshot.fServerTime = GetEngineTime();
 	snapshot.fTimescale = (gA_Timers[client].fTimescale > 0.0) ? gA_Timers[client].fTimescale : 1.0;
-	//snapshot.iLandingTick = ?????; // TODO: Think about handling segmented scroll? /shrug
 }
 
 public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
@@ -3698,7 +3697,6 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 
 	if(bOnGround && !gA_Timers[client].bOnGround)
 	{
-		gA_Timers[client].iLandingTick = tickcount;
 		gI_FirstTouchedGroundForStartTimer[client] = tickcount;
 
 		if (gEV_Type != Engine_TF2 && GetStyleSettingBool(gA_Timers[client].bsStyle, "easybhop"))
@@ -3708,17 +3706,30 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	}
 	else if (!bOnGround && gA_Timers[client].bOnGround && gA_Timers[client].bJumped && !gA_Timers[client].bClientPaused)
 	{
-		int iDifference = (tickcount - gA_Timers[client].iLandingTick);
+		int iGroundTicks = gA_Timers[client].iGroundTicks;
 
-		if (iDifference < 10)
+		if(iGroundTicks < 10)
 		{
 			gA_Timers[client].iMeasuredJumps++;
 
-			if (iDifference == 1)
+			if(iGroundTicks == 1)
 			{
 				gA_Timers[client].iPerfectJumps++;
 			}
 		}
+	}
+	
+	// Maintain GroundTicks counter
+	if(bOnGround)
+	{
+		if (!gA_Timers[client].bOnGround)
+			gA_Timers[client].iGroundTicks = 1; // landing frame
+		else
+			gA_Timers[client].iGroundTicks++;
+	}
+	else
+	{
+		gA_Timers[client].iGroundTicks = 0;
 	}
 
 	// This can be bypassed by spamming +duck on CSS which causes `iGroundEntity` to be `-1` here...

--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -3708,19 +3708,18 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	{
 		int iGroundTicks = gA_Timers[client].iGroundTicks;
 
-		if(iGroundTicks < 10)
+		if (iGroundTicks < 10)
 		{
 			gA_Timers[client].iMeasuredJumps++;
 
-			if(iGroundTicks == 1)
+			if (iGroundTicks == 1)
 			{
 				gA_Timers[client].iPerfectJumps++;
 			}
 		}
 	}
 	
-	// Maintain GroundTicks counter
-	if(bOnGround)
+	if (bOnGround)
 	{
 		if (!gA_Timers[client].bOnGround)
 			gA_Timers[client].iGroundTicks = 1; // landing frame


### PR DESCRIPTION
Replaces iLandingTick (an absolute tickcount stored on landing) with
iGroundTicks, a counter that increments each tick spent on
the ground and resets to 0 in the air.

This allows snapshots to be saved/restored cleanly with perf detection,
fixing the existing TODO in BuildSnapshot. Gameplay behaviour is unchanged.