### PR TITLE
Calculate sync using last tick's input vel

### DIFF
--- a/addons/sourcemod/scripting/shavit-core.sp
+++ b/addons/sourcemod/scripting/shavit-core.sp
@@ -3845,7 +3845,7 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 			fTempAngle += 360.0;
 		}
 
-		TestAngles(client, (fTempAngle - fAngles[1]), fAngle, vel);
+		TestAngles(client, (fTempAngle - fAngles[1]), fAngle, gA_Timers[client].fLastInputVel);
 	}
 
 	if (gA_Timers[client].fCurrentTime != 0.0)
@@ -3863,7 +3863,7 @@ public void OnPlayerRunCmdPost(int client, int buttons, int impulse, const float
 	gA_Timers[client].fLastInputVel[1] = vel[1];
 }
 
-void TestAngles(int client, float dirangle, float yawdelta, const float vel[3])
+void TestAngles(int client, float dirangle, float yawdelta, const float vel[2])
 {
 	if(dirangle < 0.0)
 	{


### PR DESCRIPTION
Noticed a while ago that sync calculations were incorrect - currently the timer's checking whether your mouse is moving in the direction of the keys you're pressing. This isn't right, and can be seen from sync only being in the low 90s when perfectly strafing using something like https://github.com/enimmy/shavit-syncstyle.

> example (with that autosync plugin):

[old - 10mb.webm](https://github.com/user-attachments/assets/ab5b7c43-ee5b-4993-9750-61602208267f)

You'll also see this happen with cheated records:

<img width="483" height="296" alt="image" src="https://github.com/user-attachments/assets/7dd7755c-0058-42c9-8721-300644e2f716" />

To perfectly sync you want your movement key to change side 1 tick before your viewangles. The reason this is because you want to be strafing towards (overly simplified) your velocity direction, and your current keypresses update your velocity _after_ strafing happens inside AirAccelerate (pretty sure - going off memory here). That means when you switch strafe key your velocity switches side 1 tick "late".

This PR (currently) just switches TestAngles (where sync is calculated) to use last tick's input velocities rather than this tick's. I think there's a nicer, more generic solution than the if/else chain being used for sync calcs currently, but I'm not entirely sure what the best way of approaching it is currently. You'd probably want to rebuild some of CGameMovement::AirMove and do some stuff to check whether the mouse is moving in the correct direction (towards velocity I guess?). I had a little try getting something working but couldn't come up with anything that felt perfect.

> result (using the same autosync plugin but with sync changes from this PR):

[new - 10mb.webm](https://github.com/user-attachments/assets/6258b9a4-83e1-4153-a09c-8ee735746d76)