### PR TITLE
Fix checkpoint-in-startzone exploit that bypasses practice-mode

### DIFF
--- a/addons/sourcemod/scripting/shavit-checkpoints.sp
+++ b/addons/sourcemod/scripting/shavit-checkpoints.sp
@@ -1905,12 +1905,15 @@ bool LoadCheckpointCache(int client, cp_cache_t cpcache, int index, bool force =
 		return true;
 	}
 
-	if (cpcache.aSnapshot.iFullTicks > 0 && (cpcache.aSnapshot.bPracticeMode || !(cpcache.bSegmented || isPersistentData) || GetSteamAccountID(client) != cpcache.iSteamID))
+	if (cpcache.aSnapshot.bPracticeMode || !(cpcache.bSegmented || isPersistentData) || GetSteamAccountID(client) != cpcache.iSteamID)
 	{
 		cpcache.aSnapshot.bPracticeMode = true;
 
 		// Do this here to trigger practice mode alert
-		Shavit_SetPracticeMode(client, true, true);
+		if (!Shavit_InsideZone(client, Zone_Start, -1))
+		{
+			Shavit_SetPracticeMode(client, true, true);
+		}
 	}
 
 	Shavit_LoadSnapshot(client, cpcache.aSnapshot, sizeof(timer_snapshot_t), force);

--- a/addons/sourcemod/scripting/shavit-checkpoints.sp
+++ b/addons/sourcemod/scripting/shavit-checkpoints.sp
@@ -1909,7 +1909,7 @@ bool LoadCheckpointCache(int client, cp_cache_t cpcache, int index, bool force =
 	{
 		cpcache.aSnapshot.bPracticeMode = true;
 
-		// Do this here to trigger practice mode alert
+		// Do this here to only trigger a practice mode alert if the client was outside the start zone (prevent alert spam in some cases)
 		if (!Shavit_InsideZone(client, Zone_Start, -1))
 		{
 			Shavit_SetPracticeMode(client, true, true);


### PR DESCRIPTION
fix major exploit where you do not get your practice mode set if you save a checkpoint in the start zone with velocity (noclip, prespeed, etc)

this is the proper "fix" to the "practice mode message spam" [nora tried to remedy](https://github.com/shavitush/bhoptimer/pull/1268) but introduced this bad bug.