### PR TITLE
Add Shavit_StopReplay & Shavit_GetClientReplayBot natives

### DIFF
--- a/addons/sourcemod/scripting/include/shavit/replay-playback.inc
+++ b/addons/sourcemod/scripting/include/shavit/replay-playback.inc
@@ -333,7 +333,7 @@ native void Shavit_SetReplayCacheName(int bot, char[] name);
  * @param client                    Client requesting the stop, or 0 to bypass the permission check.
  * @return                          True if the replay bot has been stopped, false otherwise.
  */
-native void Shavit_StopReplay(int bot, int client = 0);
+native bool Shavit_StopReplay(int bot, int client = 0);
 
 /**
  * Starts a replay given a style and track.

--- a/addons/sourcemod/scripting/include/shavit/replay-playback.inc
+++ b/addons/sourcemod/scripting/include/shavit/replay-playback.inc
@@ -319,6 +319,15 @@ native bool Shavit_IsReplayEntity(int ent);
 native void Shavit_SetReplayCacheName(int bot, char[] name);
 
 /**
+ * Stops the playback of a replay bot.
+ *
+ * @param bot                       The replay bot entity.
+ * @param client                    Client requesting the stop, or 0 to bypass the permission check.
+ * @return                          True if the replay bot has been stopped, false otherwise.
+ */
+native void Shavit_StopReplay(int bot, int client = 0);
+
+/**
  * Starts a replay given a style and track.
  *
  * @param style                     Bhop style.
@@ -487,6 +496,7 @@ public void __pl_shavit_replay_playback_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_ReloadReplay");
 	MarkNativeAsOptional("Shavit_ReloadReplays");
 	MarkNativeAsOptional("Shavit_Replay_DeleteMap");
+	MarkNativeAsOptional("Shavit_StopReplay");
 	MarkNativeAsOptional("Shavit_StartReplay");
 	MarkNativeAsOptional("Shavit_GetClosestReplayTime");
 	MarkNativeAsOptional("Shavit_GetClosestReplayVelocityDifference");

--- a/addons/sourcemod/scripting/include/shavit/replay-playback.inc
+++ b/addons/sourcemod/scripting/include/shavit/replay-playback.inc
@@ -305,9 +305,17 @@ native bool Shavit_IsReplayDataLoaded(int style, int track);
 /**
  * Checks if the given entity is a replay bot (fakeclient) or replay prop.
  *
- * @param                           The entity index to check.
+ * @param ent                       The entity index to check.
  */
 native bool Shavit_IsReplayEntity(int ent);
+
+/**
+ * Retrieves the replay bot (or prop) entity currently tied to a client.
+ *
+ * @param client                    Client index.
+ * @return                          Replay bot entity, 0 if no replay bot is active.
+ */
+native int Shavit_GetClientReplayBot(int client);
 
 /**
  * Sets the sReplayName value in the bot's frame_cache_t.
@@ -501,6 +509,7 @@ public void __pl_shavit_replay_playback_SetNTVOptional()
 	MarkNativeAsOptional("Shavit_GetClosestReplayTime");
 	MarkNativeAsOptional("Shavit_GetClosestReplayVelocityDifference");
 	MarkNativeAsOptional("Shavit_IsReplayEntity");
+	MarkNativeAsOptional("Shavit_GetClientReplayBot");
 	MarkNativeAsOptional("Shavit_GetReplayButtons");
 	MarkNativeAsOptional("Shavit_GetReplayBotCache");
 	MarkNativeAsOptional("Shavit_GetReplayEntityFlags");

--- a/addons/sourcemod/scripting/shavit-replay-playback.sp
+++ b/addons/sourcemod/scripting/shavit-replay-playback.sp
@@ -302,6 +302,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_IsReplayDataLoaded", Native_IsReplayDataLoaded);
 	CreateNative("Shavit_IsReplayEntity", Native_IsReplayEntity);
 	CreateNative("Shavit_StartReplay", Native_StartReplay);
+	CreateNative("Shavit_StopReplay", Native_StopReplay);
 	CreateNative("Shavit_ReloadReplay", Native_ReloadReplay);
 	CreateNative("Shavit_ReloadReplays", Native_ReloadReplays);
 	CreateNative("Shavit_Replay_DeleteMap", Native_Replay_DeleteMap);
@@ -1109,6 +1110,25 @@ int CreateReplayEntity(int track, int style, float delay, int client, int bot, i
 	}
 
 	return bot;
+}
+
+public int Native_StopReplay(Handle handler, int numParams)
+{
+	int bot = GetNativeCell(1);
+	int client = GetNativeCell(2);
+	int index = GetBotInfoIndex(bot);
+
+	if (index >= 1 && (!client || (IsValidClient(client) && CanControlReplay(client, gA_BotInfo[index]))))
+	{
+		// It should be fine allowing to stop a replay even if it is already in the Replay_Stop state
+		if (gA_BotInfo[index].iStatus != Replay_Idle)
+		{
+			FinishReplay(gA_BotInfo[index]);
+			return true;
+		}
+	}
+
+	return false;
 }
 
 public int Native_StartReplay(Handle handler, int numParams)

--- a/addons/sourcemod/scripting/shavit-replay-playback.sp
+++ b/addons/sourcemod/scripting/shavit-replay-playback.sp
@@ -316,6 +316,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("Shavit_SetReplayCacheName", Native_SetReplayCacheName);
 	CreateNative("Shavit_GetReplayFolderPath", Native_GetReplayFolderPath);
 	CreateNative("Shavit_GetReplayPlaybackSpeed", Native_GetReplayPlaybackSpeed);
+	CreateNative("Shavit_GetClientReplayBot", Native_GetClientReplayBot);
 
 	if (!FileExists("cfg/sourcemod/plugin.shavit-replay-playback.cfg") && FileExists("cfg/sourcemod/plugin.shavit-replay.cfg"))
 	{
@@ -1510,6 +1511,12 @@ public int Native_GetLoopingBotByName(Handle plugin, int numParams)
 public any Native_GetReplayPlaybackSpeed(Handle plugin, int numParams)
 {
 	return gA_BotInfo[GetBotInfoIndex(GetNativeCell(1))].fPlaybackSpeed;
+}
+
+public any Native_GetClientReplayBot(Handle plugin, int numParams)
+{
+	int ent = gA_BotInfo[GetNativeCell(1)].iEnt;
+	return (ent > 0) ? ent : 0; // Normalize this to 0
 }
 
 public int Native_SetReplayCacheName(Handle plugin, int numParams)


### PR DESCRIPTION
There was previously no clean way to stop a replay bot:
- For `Replay_Central` bots, there was no way to stop one at all. Forcibly kicking it would leave it missing for up to several seconds until the cron timer respawns it.
- For `Replay_Dynamic` bots, the only option was `KickClientEx` to kick the bot in the same frame.
- For `Replay_Prop` bots, the only option was RemoveEdict, which destroys the prop and bypasses `Shavit_OnReplayEnd`. `OnEntityDestroyed`, which handles `Replay_Prop`s that mysteriously die, only kicks them (`KickReplay`) rather than finishing them (`FinishReplay`)
```
/**
 * Stops the playback of a replay bot.
 *
 * @param bot                       The replay bot entity.
 * @param client                    Client requesting the stop, or 0 to bypass the permission check.
 * @return                          True if the replay bot has been stopped, false otherwise.
 */
native bool Shavit_StopReplay(int bot, int client = 0);
```

- Either a simple check if a client has a active replay bot or a way to get further information of the active replay via the replay bot entity.
```
/**
 * Retrieves the replay bot (or prop) entity currently tied to a client.
 *
 * @param client                    Client index.
 * @return                          Replay bot entity, 0 if no replay bot is active.
 */
native int Shavit_GetClientReplayBot(int client);
```